### PR TITLE
Cli

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,3 +9,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/nellie/cli.py
+++ b/nellie/cli.py
@@ -1,0 +1,30 @@
+import argparse
+import os
+from nellie.run import run
+
+
+def process_files(files, ch, num_t, output_dir):
+    for file_num, tif_file in enumerate(files):
+        print(f'Processing file {file_num + 1} of {len(files)}, channel {ch + 1} of 1')
+        try:
+            _ = run(tif_file, remove_edges=False, ch=ch, num_t=num_t, output_dirpath=output_dir)
+        except:
+            print(f'Failed to run {tif_file}')
+            continue
+
+
+def process_directory(directory, substring, output_dir, ch, num_t):
+    all_files = sorted([os.path.join(directory, f) for f in os.listdir(directory) if substring in f and f.endswith('.tiff')])
+    process_files(all_files, ch, num_t, output_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Process TIF images within subdirectories containing a specific substring.')
+    parser.add_argument('--directory', required=True, help='Subdirectory with TIF files')
+    parser.add_argument('--substring', required=True, help='Substring to look for in filenames')
+    parser.add_argument('--output_directory', default=None, help='Output directory. Default is parent + nellie_output.')
+    parser.add_argument('--ch', type=int, default=0, help='Channel number to process')
+    parser.add_argument('--num_t', type=int, default=1, help='Number of time points')
+    args = parser.parse_args()
+
+    process_directory(args.directory, args.substring, args.output_directory, args.ch, args.num_t)

--- a/nellie/im_info/im_info.py
+++ b/nellie/im_info/im_info.py
@@ -135,8 +135,8 @@ class ImInfo:
 
         if 'ResolutionUnit' in tag_names:
             if metadata[tag_names['ResolutionUnit']].value == tifffile.TIFF.RESUNIT.CENTIMETER:
-                self.dim_sizes['X'] *= 1E-2 * 1E6
-                self.dim_sizes['Y'] *= 1E-2 * 1E6
+                self.dim_sizes['X'] *= 1E-4 * 1E6
+                self.dim_sizes['Y'] *= 1E-4 * 1E6
         if 'Z' in self.axes:
             if 'ZResolution' in tag_names:
                 self.dim_sizes['Z'] = 1 / metadata[tag_names['ZResolution']].value[0]
@@ -297,6 +297,7 @@ class ImInfo:
             return_memmap: bool = False, read_mode='r+'):
         axes = self.axes
         axes = axes.replace('C', '') if 'C' in axes else axes
+
         logger.debug(f'Saving axes as {axes}')
         data = self._ensure_t(data)
         if shape is None:
@@ -307,6 +308,8 @@ class ImInfo:
                 path_im, shape=shape, dtype=dtype, bigtiff=True, metadata={"axes": axes}
             )
         else:
+            if len(axes) != len(data.shape) and data.shape[0] == 1:
+                data = data[0]
             tifffile.imwrite(
                 path_im, data, bigtiff=True, metadata={"axes": axes}
             )

--- a/nellie/run.py
+++ b/nellie/run.py
@@ -6,10 +6,14 @@ from nellie.segmentation.mocap_marking import Markers
 from nellie.segmentation.networking import Network
 from nellie.tracking.hu_tracking import HuMomentTracking
 from nellie.tracking.voxel_reassignment import VoxelReassigner
+import os
 
 
-def run(im_path, num_t=None, remove_edges=True, ch=0):
-    im_info = ImInfo(im_path, ch=ch)
+def run(im_path, num_t=None, remove_edges=True, ch=0, output_dirpath=None):
+    im_info = ImInfo(im_path, ch=ch, output_dirpath=output_dirpath)
+    if os.path.exists(im_info.pipeline_paths['adjacency_maps']):
+        print(f'Already exists, skipping.')
+        return
 
     preprocessing = Filter(im_info, num_t, remove_edges=remove_edges)
     preprocessing.run()

--- a/nellie/run.py
+++ b/nellie/run.py
@@ -38,28 +38,28 @@ def run(im_path, num_t=None, remove_edges=True, ch=0):
 if __name__ == "__main__":
     # Single file run
     # im_path = r"/Users/austin/Downloads/test.tif"
-    # im_path = r"/Users/austin/GitHub/nellie-simulations/motion/fission_fusion/outputs/fusion-std_fusion-std_512-t_0p5.ome.tif"
-    # im_info = run(im_path, remove_edges=False, ch=0)
+    im_path = r"D:\test_files\cppx115\a1768945-d4fb-459d-98a2-d926ef18fc5a\images\r04c14\r04c14f03p01-ch04t01.tiff"
+    im_info = run(im_path, remove_edges=False, ch=0)
 
     # Directory bactch run
-    import os
-    top_dirs = [
-        r"C:\Users\austin\GitHub\nellie-supplemental\comparisons\simulations\multi_grid\outputs",
-        r"C:\Users\austin\GitHub\nellie-supplemental\comparisons\simulations\separation\outputs",
-        r"C:\Users\austin\GitHub\nellie-supplemental\comparisons\simulations\px_sizes\outputs",
-        ]
-    ch = 0
-    num_t = 1
-    # get all non-folder files
-    for top_dir in top_dirs:
-        all_files = os.listdir(top_dir)
-        all_files = [os.path.join(top_dir, file) for file in all_files if not os.path.isdir(os.path.join(top_dir, file))]
-        all_files = [file for file in all_files if file.endswith('.tif')]
-        for file_num, tif_file in enumerate(all_files):
-            # for ch in range(1):
-            print(f'Processing file {file_num + 1} of {len(all_files)}, channel {ch + 1} of 1')
-            im_info = ImInfo(tif_file, ch=ch)
-            if os.path.exists(im_info.pipeline_paths['im_skel_relabelled']):
-                print(f'Already exists, skipping.')
-                continue
-            im_info = run(tif_file, remove_edges=False, ch=ch, num_t=num_t)
+    # import os
+    # top_dirs = [
+    #     r"C:\Users\austin\GitHub\nellie-supplemental\comparisons\simulations\multi_grid\outputs",
+    #     r"C:\Users\austin\GitHub\nellie-supplemental\comparisons\simulations\separation\outputs",
+    #     r"C:\Users\austin\GitHub\nellie-supplemental\comparisons\simulations\px_sizes\outputs",
+    #     ]
+    # ch = 0
+    # num_t = 1
+    # # get all non-folder files
+    # for top_dir in top_dirs:
+    #     all_files = os.listdir(top_dir)
+    #     all_files = [os.path.join(top_dir, file) for file in all_files if not os.path.isdir(os.path.join(top_dir, file))]
+    #     all_files = [file for file in all_files if file.endswith('.tif')]
+    #     for file_num, tif_file in enumerate(all_files):
+    #         # for ch in range(1):
+    #         print(f'Processing file {file_num + 1} of {len(all_files)}, channel {ch + 1} of 1')
+    #         im_info = ImInfo(tif_file, ch=ch)
+    #         if os.path.exists(im_info.pipeline_paths['im_skel_relabelled']):
+    #             print(f'Already exists, skipping.')
+    #             continue
+    #         im_info = run(tif_file, remove_edges=False, ch=ch, num_t=num_t)

--- a/nellie/run.py
+++ b/nellie/run.py
@@ -9,7 +9,7 @@ from nellie.tracking.voxel_reassignment import VoxelReassigner
 import os
 
 
-def run(im_path, num_t=None, remove_edges=True, ch=0, output_dirpath=None):
+def run(im_path, num_t=None, remove_edges=True, ch=0, output_dirpath=None, otsu_thresh_intensity=False):
     im_info = ImInfo(im_path, ch=ch, output_dirpath=output_dirpath)
     if os.path.exists(im_info.pipeline_paths['adjacency_maps']):
         print(f'Already exists, skipping.')
@@ -18,7 +18,7 @@ def run(im_path, num_t=None, remove_edges=True, ch=0, output_dirpath=None):
     preprocessing = Filter(im_info, num_t, remove_edges=remove_edges)
     preprocessing.run()
 
-    segmenting = Label(im_info, num_t)
+    segmenting = Label(im_info, num_t, otsu_thresh_intensity=otsu_thresh_intensity)
     segmenting.run()
 
     networking = Network(im_info, num_t)

--- a/nellie/run.py
+++ b/nellie/run.py
@@ -6,14 +6,10 @@ from nellie.segmentation.mocap_marking import Markers
 from nellie.segmentation.networking import Network
 from nellie.tracking.hu_tracking import HuMomentTracking
 from nellie.tracking.voxel_reassignment import VoxelReassigner
-import os
 
 
 def run(im_path, num_t=None, remove_edges=True, ch=0, output_dirpath=None, otsu_thresh_intensity=False):
     im_info = ImInfo(im_path, ch=ch, output_dirpath=output_dirpath)
-    if os.path.exists(im_info.pipeline_paths['adjacency_maps']):
-        print(f'Already exists, skipping.')
-        return
 
     preprocessing = Filter(im_info, num_t, remove_edges=remove_edges)
     preprocessing.run()

--- a/nellie/segmentation/labelling.py
+++ b/nellie/segmentation/labelling.py
@@ -69,7 +69,7 @@ class Label:
         if not self.im_info.no_z:
             mask = ndi.binary_fill_holes(mask)
 
-        if not self.im_info.no_z and self.im_info.dim_sizes['Z'] < self.min_z_radius_um:
+        if not self.im_info.no_z and self.im_info.dim_sizes['Z'] >= self.min_z_radius_um:
             mask = ndi.binary_opening(mask, structure=xp.ones((2, 2, 2)))
         elif self.im_info.no_z:
             mask = ndi.binary_opening(mask, structure=xp.ones((2, 2)))

--- a/nellie/segmentation/mocap_marking.py
+++ b/nellie/segmentation/mocap_marking.py
@@ -10,6 +10,10 @@ class Markers:
     def __init__(self, im_info: ImInfo, num_t=None,
                  min_radius_um=0.20, max_radius_um=1, use_im='distance', num_sigma=5):
         self.im_info = im_info
+
+        # if self.im_info.no_t:
+        #     return
+
         self.num_t = num_t
         if self.im_info.no_t:
             self.num_t = 1

--- a/nellie/tracking/flow_interpolation.py
+++ b/nellie/tracking/flow_interpolation.py
@@ -9,6 +9,10 @@ from nellie.utils.general import get_reshaped_image
 class FlowInterpolator:
     def __init__(self, im_info: ImInfo, num_t=None, max_distance_um=0.5, forward=True):
         self.im_info = im_info
+
+        if self.im_info.no_t:
+            return
+
         self.num_t = num_t
         if num_t is None and not self.im_info.no_t:
             self.num_t = im_info.shape[im_info.axes.index('T')]

--- a/nellie/tracking/flow_interpolation.py
+++ b/nellie/tracking/flow_interpolation.py
@@ -23,7 +23,7 @@ class FlowInterpolator:
             self.scaling = (im_info.dim_sizes['Z'], im_info.dim_sizes['Y'], im_info.dim_sizes['X'])
 
         self.max_distance_um = max_distance_um * im_info.dim_sizes['T']
-        self.max_distance_um = np.max([self.max_distance_um, 0.5])
+        self.max_distance_um = np.max(np.array([self.max_distance_um, 0.5]))
 
         self.forward = forward
 

--- a/nellie/tracking/hu_tracking.py
+++ b/nellie/tracking/hu_tracking.py
@@ -24,7 +24,7 @@ class HuMomentTracking:
             self.scaling = (im_info.dim_sizes['Z'], im_info.dim_sizes['Y'], im_info.dim_sizes['X'])
 
         self.max_distance_um = max_distance_um * self.im_info.dim_sizes['T']
-        self.max_distance_um = xp.max([self.max_distance_um, 0.5])
+        self.max_distance_um = xp.max(xp.array([self.max_distance_um, 0.5]))
 
         self.vector_start_coords = []
         self.vectors = []
@@ -248,8 +248,8 @@ class HuMomentTracking:
         marker_indices_post = np.argwhere(marker_frame_post)
         marker_indices_post_scaled = marker_indices_post * self.scaling
 
-        distance_matrix = cdist(marker_indices_post_scaled, marker_indices_pre_scaled)
-        distance_mask = xp.array(distance_matrix) < self.max_distance_um
+        distance_matrix = xp.array(cdist(marker_indices_post_scaled, marker_indices_pre_scaled))
+        distance_mask = distance_matrix < self.max_distance_um
         distance_matrix = distance_matrix / self.max_distance_um  # normalize to furthest possible distance
         return distance_matrix, distance_mask
 

--- a/nellie/tracking/hu_tracking.py
+++ b/nellie/tracking/hu_tracking.py
@@ -10,6 +10,10 @@ class HuMomentTracking:
     def __init__(self, im_info: ImInfo, num_t=None,
                  max_distance_um=1):
         self.im_info = im_info
+
+        if self.im_info.no_t:
+            return
+
         self.num_t = num_t
         if num_t is None and not self.im_info.no_t:
             self.num_t = im_info.shape[im_info.axes.index('T')]

--- a/nellie/tracking/voxel_reassignment.py
+++ b/nellie/tracking/voxel_reassignment.py
@@ -12,6 +12,10 @@ from nellie.utils.general import get_reshaped_image
 class VoxelReassigner:
     def __init__(self, im_info: ImInfo, num_t=None):
         self.im_info = im_info
+
+        if self.im_info.no_t:
+            return
+
         self.num_t = num_t
         if num_t is None and not self.im_info.no_t:
             self.num_t = im_info.shape[im_info.axes.index('T')]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     pandas==2.2.1
     matplotlib==3.8.3
     napari[all]
+    imagecodecs
 include_package_data = True
 
 [options.package_data]


### PR DESCRIPTION
- Skips tracking and voxel reassignment for datasets without a temporal component
- Added imagecodecs as a dependency
- Fixed bug where cupy cannot grab the max value of a list
- Allows for CLI-based runs
- Allows for otsu intensity thresholding pre-segmentation via CLI
- Allows specification of an output directory different than input directory (e.g. for processing files in a read-only directory)
- Fixed tif tag resolution units