### PR TITLE
Slice 3 (Pass 8 Separate): Hoist Filter's backend code into adaptive_run

### DIFF
--- a/nellie/segmentation/filtering.py
+++ b/nellie/segmentation/filtering.py
@@ -69,7 +69,7 @@ class Filter:
         """
         self.im_info = im_info
         self.device = device
-        self.xp, self.ndi, self.device_type = self._resolve_backend(device)
+        self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(device)
         self.force_device = device is not None and device.lower() in ("cpu", "gpu", "cuda")
         self.truncate = 3.0
         if not self.im_info.no_z:
@@ -113,82 +113,13 @@ class Filter:
         # Cached per-run values
         self.halo = None
 
-    def _resolve_backend(self, device):
-        device = (device or "auto").lower()
-        if device not in ("auto", "cpu", "gpu", "cuda"):
-            raise ValueError(f"Unsupported device '{device}'. Use 'auto', 'cpu', or 'gpu'.")
-
-        if device in ("gpu", "cuda"):
-            xp, ndi = self._try_import_cupy(require=True)
-            return xp, ndi, "cuda"
-        if device == "cpu":
-            import numpy as np
-            import scipy.ndimage as ndi
-            return np, ndi, "cpu"
-
-        # auto
-        xp, ndi = self._try_import_cupy(require=False)
-        if xp is not None:
-            return xp, ndi, "cuda"
-        import numpy as np
-        import scipy.ndimage as ndi
-        return np, ndi, "cpu"
-
-    def _try_import_cupy(self, require):
-        try:
-            import cupy
-            import cupyx.scipy.ndimage as ndi
-        except ModuleNotFoundError as exc:
-            if require:
-                raise RuntimeError("GPU backend requested but CuPy is not installed.") from exc
-            return None, None
-
-        try:
-            device_count = cupy.cuda.runtime.getDeviceCount()
-        except Exception as exc:
-            if require:
-                raise RuntimeError("GPU backend requested but CUDA is not available.") from exc
-            return None, None
-
-        if device_count <= 0:
-            if require:
-                raise RuntimeError("GPU backend requested but no CUDA devices were found.")
-            return None, None
-
-        return cupy, ndi
-
-    def _is_oom_error(self, exc):
-        if isinstance(exc, MemoryError):
-            return True
-        if self.device_type != "cuda":
-            return False
-        try:
-            import cupy
-
-            return isinstance(exc, cupy.cuda.memory.OutOfMemoryError)
-        except Exception:
-            return "OutOfMemory" in repr(exc)
-
-    def _free_gpu_memory(self):
-        if self.device_type != "cuda":
-            return
-        try:
-            self.xp.get_default_memory_pool().free_all_blocks()
-        except Exception:
-            return
-
     def _switch_to_cpu(self):
-        import numpy as np
-        import scipy.ndimage as ndi
-
-        self.xp = np
-        self.ndi = ndi
-        self.device_type = "cpu"
+        self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend("cpu")
 
     def _set_backend(self, device):
         device = adaptive_run.normalize_device(device)
         self.device = device
-        self.xp, self.ndi, self.device_type = self._resolve_backend(device)
+        self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(device)
         self.force_device = device in ("cpu", "gpu", "cuda")
 
     def _set_low_memory(self, low_memory):
@@ -568,9 +499,9 @@ class Filter:
                     vessel_out = self._remove_edges(vessel_out)
                 return vessel_out
             except Exception as exc:
-                if not self._is_oom_error(exc):
+                if not adaptive_run.is_oom_error(exc):
                     raise
-                self._free_gpu_memory()
+                adaptive_run.free_gpu_memory(self.xp)
                 if chunk_voxels <= 1:
                     raise
                 chunk_voxels = max(1, chunk_voxels // 2)
@@ -603,14 +534,14 @@ class Filter:
                 vesselness = self._remove_edges(vesselness)
             return vesselness
         except Exception as exc:
-            if not self._is_oom_error(exc):
+            if not adaptive_run.is_oom_error(exc):
                 raise
-            self._free_gpu_memory()
+            adaptive_run.free_gpu_memory(self.xp)
             # Try chunked on current backend
             try:
                 return self._run_frame_chunked(t, mask=mask)
             except Exception as exc2:
-                if not self._is_oom_error(exc2):
+                if not adaptive_run.is_oom_error(exc2):
                     raise
                 if self.device_type == "cuda" and not self.force_device:
                     self._switch_to_cpu()

--- a/nellie/utils/adaptive_run.py
+++ b/nellie/utils/adaptive_run.py
@@ -5,10 +5,88 @@ from __future__ import annotations
 
 import math
 import os
+from typing import Any
 
 
 _ESTIMATED_PEAK_MULTIPLIER = 6.0
 _MEMORY_HEADROOM = 0.7
+
+
+def try_import_cupy(require: bool = False) -> tuple[Any | None, Any | None]:
+    """Return ``(cupy, cupyx.scipy.ndimage)`` or ``(None, None)`` if unavailable.
+
+    With ``require=True``, raises ``RuntimeError`` instead of returning
+    None when CuPy is missing or no CUDA device is present.
+    """
+    try:
+        import cupy
+        import cupyx.scipy.ndimage as cupy_ndi
+    except ModuleNotFoundError as exc:
+        if require:
+            raise RuntimeError("GPU backend requested but CuPy is not installed.") from exc
+        return None, None
+
+    try:
+        device_count = cupy.cuda.runtime.getDeviceCount()
+    except Exception as exc:
+        if require:
+            raise RuntimeError("GPU backend requested but CUDA is not available.") from exc
+        return None, None
+
+    if device_count <= 0:
+        if require:
+            raise RuntimeError("GPU backend requested but no CUDA devices were found.")
+        return None, None
+
+    return cupy, cupy_ndi
+
+
+def _cpu_backend() -> tuple[Any, Any, str]:
+    import numpy as np
+    import scipy.ndimage as ndi
+
+    return np, ndi, "cpu"
+
+
+def resolve_backend(device: str) -> tuple[Any, Any, str]:
+    """Resolve a device string to ``(xp, ndi, device_type)``.
+
+    Accepts ``"auto"``, ``"cpu"``, ``"gpu"``, ``"cuda"``. ``"cuda"`` is a
+    synonym for ``"gpu"``. ``"auto"`` uses GPU if available, otherwise CPU.
+
+    The returned ``device_type`` is ``"cuda"`` for GPU and ``"cpu"`` for CPU,
+    matching the per-stage convention.
+    """
+    device = (device or "auto").lower()
+    if device not in ("auto", "cpu", "gpu", "cuda"):
+        raise ValueError(f"Unsupported device '{device}'. Use 'auto', 'cpu', or 'gpu'.")
+
+    if device in ("gpu", "cuda"):
+        xp, ndi = try_import_cupy(require=True)
+        return xp, ndi, "cuda"
+    if device == "cpu":
+        return _cpu_backend()
+
+    # auto
+    xp, ndi = try_import_cupy(require=False)
+    if xp is not None:
+        return xp, ndi, "cuda"
+    return _cpu_backend()
+
+
+def free_gpu_memory(xp: Any) -> None:
+    """Free CuPy's default memory pool. No-op when ``xp`` is NumPy.
+
+    Detects the backend via duck-typing (``get_default_memory_pool``)
+    rather than importing cupy unconditionally.
+    """
+    pool_fn = getattr(xp, "get_default_memory_pool", None)
+    if pool_fn is None:
+        return
+    try:
+        pool_fn().free_all_blocks()
+    except Exception:
+        return
 
 
 def normalize_device(device: str | None) -> str:


### PR DESCRIPTION
## Summary

- Three new functions in `adaptive_run`: `resolve_backend`, `try_import_cupy`, `free_gpu_memory`
- Filter's `_resolve_backend`, `_try_import_cupy`, `_is_oom_error`, `_free_gpu_memory` deleted (~75 lines)
- Filter retains `_set_backend`, `_set_low_memory`, `_switch_to_cpu` as thin mutator wrappers (cascade contract requires them)
- All call sites for OOM/free-memory now use `adaptive_run.is_oom_error(exc)` and `adaptive_run.free_gpu_memory(self.xp)`
- `__init__` calls `adaptive_run.resolve_backend(device)` directly

## Test plan

- [x] Local pytest — 12 passed in 6.41s
- [ ] CI green on all 6 jobs (stacked PR — runs after slice 2 base lands)

## Stacked PR base

Base is `sep-2-chunking-extraction`. Once slices 1 (#63) and 2 (#64) merge to `dechao`, GitHub auto-rebases this PR's base to `dechao` and the diff collapses to just the backend hoist.

## Filter line count

After all three Pass 8 Separate slices: **~680 lines**, down from ~1090 before slice 1. Saved ~412 lines.

## Future work (deferred, tracked in wiki/queue.md)

The other 5 stages (`labelling`, `networking`, `mocap_marking`, `hu_tracking`, `voxel_reassignment`, plus `feature_extraction/hierarchical`) still have private duplicates of the backend code. Each migrates when it has its own characterization tests — same test-bootstrap pattern as PRD #51.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)