### PR TITLE
Pass 8 Stabilize: FrangiConfig dataclass + caller updates

### DIFF
--- a/nellie/run.py
+++ b/nellie/run.py
@@ -6,7 +6,7 @@ including filtering, segmentation, tracking, and feature extraction.
 """
 from nellie.feature_extraction.hierarchical import Hierarchy
 from nellie.im_info.verifier import FileInfo, ImInfo
-from nellie.segmentation.filtering import Filter
+from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label
 from nellie.segmentation.mocap_marking import Markers
 from nellie.segmentation.networking import Network
@@ -54,7 +54,8 @@ def run(
     if timeit:
         start_time = time.perf_counter()
     preprocessing = Filter(
-        im_info, remove_edges=remove_edges, device=device, low_memory=low_memory
+        im_info,
+        FrangiConfig(remove_edges=remove_edges, device=device, low_memory=low_memory),
     )
     preprocessing.run()
     if timeit:

--- a/nellie/segmentation/filtering.py
+++ b/nellie/segmentation/filtering.py
@@ -5,6 +5,8 @@ This module provides the Filter class, which implements a multi-scale Frangi fil
 optimized for large datasets with optional GPU acceleration.
 """
 
+from dataclasses import dataclass
+
 import numpy as np
 
 from nellie.im_info.verifier import ImInfo
@@ -12,6 +14,30 @@ from nellie.segmentation import frangi_math
 from nellie.utils import adaptive_run, chunking
 from nellie.utils.base_logger import logger
 from nellie.utils.gpu_functions import otsu_threshold, triangle_threshold
+
+
+@dataclass(frozen=True)
+class FrangiConfig:
+    """Algorithm configuration for `Filter`.
+
+    Frozen — represents the user's intent at construction time. Filter
+    copies these values into mutable instance attributes that the
+    OOM/availability cascade can update mid-run (`device`, `low_memory`).
+    Inspect `Filter.config` to see the original intent regardless of any
+    cascade-driven runtime fallbacks.
+    """
+
+    remove_edges: bool = False
+    min_radius_um: float = 0.25
+    max_radius_um: float = 1.0
+    alpha_sq: float = 0.5
+    beta_sq: float = 0.5
+    frob_thresh: float | None = None
+    frob_thresh_division: float = 2
+    device: str = "auto"
+    low_memory: bool = False
+    max_chunk_voxels: int = int(1e6)
+    max_threshold_samples: int = int(1e6)
 
 
 class Filter:
@@ -23,54 +49,33 @@ class Filter:
     def __init__(
         self,
         im_info: ImInfo,
-        num_t: int | None = None,
-        remove_edges: bool = False,
-        min_radius_um: float = 0.25,
-        max_radius_um: float = 1.0,
-        alpha_sq: float = 0.5,
-        beta_sq: float = 0.5,
-        frob_thresh: float | None = None,
-        frob_thresh_division: float = 2,
+        config: FrangiConfig = FrangiConfig(),
         viewer=None,
-        device: str = "auto",
-        # New optimization-related parameters
-        low_memory: bool = False,
-        max_chunk_voxels: int = int(1e6),
-        max_threshold_samples: int = int(1e6),
+        num_t: int | None = None,
     ) -> None:
         """
         Parameters
         ----------
         im_info : ImInfo
             Image metadata and file paths.
-        num_t : int, optional
-            Number of timepoints to process. If None, inferred from image.
-        remove_edges : bool
-            If True, aggressively zero out bounding-box edges.
-        min_radius_um, max_radius_um : float
-            Expected structure radius range in micrometers.
-        alpha_sq, beta_sq : float
-            Frangi parameters controlling sensitivity to blobness and plate-likeness.
-        frob_thresh : float or None
-            If given, fixed Frobenius norm threshold. Otherwise auto-estimated.
+        config : FrangiConfig
+            Algorithm configuration. Defaults to ``FrangiConfig()``.
         viewer : object or None
             Optional GUI viewer with a `.status` attribute.
-        device : {"auto", "cpu", "gpu"}
-            Backend selection. "auto" uses GPU if available, otherwise CPU.
-            "cpu" forces NumPy/Scipy, and "gpu" forces CuPy/CuPyX (error if unavailable).
-        low_memory : bool
-            If True, prefer strategies that reduce peak memory at the cost of speed
-            (e.g. smaller eigen-decomposition chunks).
-        max_chunk_voxels : int
-            Maximum number of voxels per processing chunk and eigen-decomposition chunk.
-        max_threshold_samples : int
-            Maximum number of samples to use when estimating thresholds
-            (triangle / Otsu) from very large arrays.
+        num_t : int, optional
+            Number of timepoints to process. If None, inferred from image.
         """
         self.im_info = im_info
-        self.device = device
-        self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(device)
-        self.force_device = device is not None and device.lower() in ("cpu", "gpu", "cuda")
+        self.config = config
+        self.viewer = viewer
+
+        # Cascade-mutable runtime state. Initial values come from config;
+        # `_set_backend` and `_set_low_memory` may update them on retry.
+        self.device = config.device
+        self.low_memory = config.low_memory
+
+        self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(self.device)
+        self.force_device = self.device.lower() in ("cpu", "gpu", "cuda")
         self.truncate = 3.0
         if not self.im_info.no_z:
             z_res = self.im_info.dim_res.get("Z") or self.im_info.dim_res.get("X") or 1.0
@@ -79,32 +84,26 @@ class Filter:
         self.num_t = num_t
         if num_t is None and not self.im_info.no_t:
             self.num_t = im_info.shape[im_info.axes.index("T")]
-        self.remove_edges = remove_edges
-        # either (roughly) diffraction limit, or pixel size, whichever is larger
-        # self.min_radius_um = max(min_radius_um, self.im_info.dim_res["X"])
-        self.min_radius_um = min_radius_um
-        self.max_radius_um = max_radius_um
 
+        # Aliases for hot path readability — config remains the source of truth.
+        self.remove_edges = config.remove_edges
+        # either (roughly) diffraction limit, or pixel size, whichever is larger
+        # self.min_radius_um = max(config.min_radius_um, self.im_info.dim_res["X"])
+        self.min_radius_um = config.min_radius_um
+        self.max_radius_um = config.max_radius_um
         self.min_radius_px = self.min_radius_um / self.im_info.dim_res["X"]
         self.max_radius_px = self.max_radius_um / self.im_info.dim_res["X"]
 
+        self.alpha_sq = float(config.alpha_sq)
+        self.beta_sq = float(config.beta_sq)
+        self.frob_thresh = config.frob_thresh
+        self.frob_thresh_division = config.frob_thresh_division
+        self.max_chunk_voxels = int(config.max_chunk_voxels)
+        self.max_threshold_samples = int(config.max_threshold_samples)
+
         self.im_memmap = None
         self.frangi_memmap = None
-
         self.sigmas = None
-
-        self.alpha_sq = float(alpha_sq)
-        self.beta_sq = float(beta_sq)
-
-        self.frob_thresh = frob_thresh
-        self.frob_thresh_division = frob_thresh_division
-
-        self.viewer = viewer
-
-        # Optimization-related settings
-        self.low_memory = low_memory
-        self.max_chunk_voxels = int(max_chunk_voxels)
-        self.max_threshold_samples = int(max_threshold_samples)
 
         # Dtypes
         self.work_dtype = "float32"

--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -8,7 +8,7 @@ from qtpy.QtGui import QFont
 from qtpy.QtCore import Qt, QTimer
 
 from nellie.feature_extraction.hierarchical import Hierarchy
-from nellie.segmentation.filtering import Filter
+from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label
 from nellie.segmentation.mocap_marking import Markers
 from nellie.segmentation.networking import Network
@@ -323,11 +323,14 @@ class NellieProcessor(QWidget):
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Preprocessing file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            base_kwargs = {
-                "im_info": self.current_im_info,
-                "viewer": self.viewer,
-            }
-            preprocessing = Filter(**base_kwargs, **step_kwargs)
+            config_kwargs = dict(step_kwargs)
+            num_t = config_kwargs.pop("num_t", None)
+            preprocessing = Filter(
+                im_info=self.current_im_info,
+                config=FrangiConfig(**config_kwargs),
+                viewer=self.viewer,
+                num_t=num_t,
+            )
             preprocessing.run()
 
     def run_preprocessing(self):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -14,7 +14,12 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from nellie.segmentation.filtering import Filter
+from nellie.segmentation.filtering import Filter, FrangiConfig
+
+
+_CPU = FrangiConfig(device="cpu")
+_CPU_KEEP_EDGES = FrangiConfig(device="cpu", remove_edges=False)
+_CPU_STRIP_EDGES = FrangiConfig(device="cpu", remove_edges=True)
 
 
 def _release_filter(filt: Filter) -> None:
@@ -35,7 +40,7 @@ def _release_filter(filt: Filter) -> None:
 
 @pytest.fixture(scope="module")
 def frangi_3d_output(imageinfo_3d) -> np.ndarray:
-    filt = Filter(imageinfo_3d, num_t=2, device="cpu")
+    filt = Filter(imageinfo_3d, _CPU, num_t=2)
     filt.run()
     out = np.array(filt.frangi_memmap)
     _release_filter(filt)
@@ -44,7 +49,7 @@ def frangi_3d_output(imageinfo_3d) -> np.ndarray:
 
 @pytest.fixture(scope="module")
 def frangi_2d_output(imageinfo_2d) -> np.ndarray:
-    filt = Filter(imageinfo_2d, num_t=2, device="cpu")
+    filt = Filter(imageinfo_2d, _CPU, num_t=2)
     filt.run()
     out = np.array(filt.frangi_memmap)
     _release_filter(filt)
@@ -75,7 +80,7 @@ def test_input_memmap_unchanged(make_imageinfo_3d) -> None:
     info = make_imageinfo_3d()
     src = Path(info.im_path)
     before = hashlib.sha256(src.read_bytes()).hexdigest()
-    filt = Filter(info, num_t=2, device="cpu")
+    filt = Filter(info, _CPU, num_t=2)
     filt.run()
     after = hashlib.sha256(src.read_bytes()).hexdigest()
     _release_filter(filt)
@@ -113,7 +118,7 @@ def test_spacing_geomean_gamma_regression(frangi_3d_output) -> None:
 
 def test_oom_fallback_does_not_nameerror(imageinfo_3d, monkeypatch) -> None:
     """Inject a synthetic OOM into the per-frame path; fallback should run, not raise NameError."""
-    filt = Filter(imageinfo_3d, num_t=2, device="cpu")
+    filt = Filter(imageinfo_3d, _CPU, num_t=2)
 
     original = Filter._compute_vesselness
     state = {"raised": False}
@@ -131,12 +136,12 @@ def test_oom_fallback_does_not_nameerror(imageinfo_3d, monkeypatch) -> None:
 
 
 def test_remove_edges_zeroes_border(make_imageinfo_3d) -> None:
-    filt_keep = Filter(make_imageinfo_3d(), num_t=2, device="cpu", remove_edges=False)
+    filt_keep = Filter(make_imageinfo_3d(), _CPU_KEEP_EDGES, num_t=2)
     filt_keep.run()
     nonzero_keep = int(np.count_nonzero(np.asarray(filt_keep.frangi_memmap)))
     _release_filter(filt_keep)
 
-    filt_strip = Filter(make_imageinfo_3d(), num_t=2, device="cpu", remove_edges=True)
+    filt_strip = Filter(make_imageinfo_3d(), _CPU_STRIP_EDGES, num_t=2)
     filt_strip.run()
     nonzero_strip = int(np.count_nonzero(np.asarray(filt_strip.frangi_memmap)))
     _release_filter(filt_strip)
@@ -159,7 +164,7 @@ def test_2d_log_blobness_fusion(make_imageinfo_2d, monkeypatch) -> None:
     """LoG fusion should add non-zero voxels beyond what Frangi alone produces."""
     from nellie.segmentation import frangi_math
 
-    filt_with = Filter(make_imageinfo_2d(), num_t=2, device="cpu")
+    filt_with = Filter(make_imageinfo_2d(), _CPU, num_t=2)
     filt_with.run()
     nonzero_with = int(np.count_nonzero(np.asarray(filt_with.frangi_memmap)))
     _release_filter(filt_with)
@@ -168,7 +173,7 @@ def test_2d_log_blobness_fusion(make_imageinfo_2d, monkeypatch) -> None:
         return xp.zeros_like(image)
 
     monkeypatch.setattr(frangi_math, "log_blobness", zero_log)
-    filt_without = Filter(make_imageinfo_2d(), num_t=2, device="cpu")
+    filt_without = Filter(make_imageinfo_2d(), _CPU, num_t=2)
     filt_without.run()
     nonzero_without = int(np.count_nonzero(np.asarray(filt_without.frangi_memmap)))
     _release_filter(filt_without)
@@ -187,7 +192,7 @@ def test_2d_output_invariants(frangi_2d_output, make_imageinfo_2d) -> None:
     info = make_imageinfo_2d()
     src = Path(info.im_path)
     digest_now = hashlib.sha256(src.read_bytes()).hexdigest()
-    filt = Filter(info, num_t=2, device="cpu")
+    filt = Filter(info, _CPU, num_t=2)
     filt.run()
     digest_after = hashlib.sha256(src.read_bytes()).hexdigest()
     _release_filter(filt)

--- a/wiki/napari-plugin/processor.md
+++ b/wiki/napari-plugin/processor.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-06
-modified: 2026-05-06
+modified: 2026-05-07
 ---
 
 # Processor widget
@@ -13,7 +13,7 @@ The CLI / `run.py` path is synchronous and would freeze the UI. The processor wr
 
 ## Interactions
 
-- Reads per-step kwargs from [[settings|`Settings.get_*_params()`]] at click time.
+- Reads per-step kwargs from [[settings|`Settings.get_*_params()`]] at click time. The dict returned by `get_preprocessing_params()` is wrapped into a `FrangiConfig` (after popping `num_t`) before being passed to [[filtering|`Filter`]]. Other stages still take kwargs directly until they get their own `*Config` dataclasses.
 - Reads basic-tab checkboxes from [[settings|`Settings`]] directly: `remove_edges`, `analyze_node_level`, `voxel_reassign`, `remove_intermediates`. The basic tab is **shared mutable state**, not just a settings store.
 - Final step calls `analyzer.rewrite_dropdown()` on the main thread to refresh the [[analysis|Analyze tab]].
 - `check_file_existence` flips the loader's `analysis_tab` enabled when `features_organelles` exists.

--- a/wiki/queue.md
+++ b/wiki/queue.md
@@ -9,8 +9,8 @@ Unresolved decisions, design questions, or known unknowns surfaced by the wiki s
 
 ## Open
 
-- **`run copy.py` is a stale developer scratch fork.** Not imported anywhere; older `run()` signature; Jupyter-style cells against a hard-coded Windows path. Decision needed: delete? See [[pipeline]].
-- **CLI is broken / out-of-date with `run.py`.** `nellie/cli.py` calls `run(tif_file, ..., ch=, num_t=, output_dirpath=)` but `run.py` no longer accepts those kwargs. Decision: fix `cli.py`, deprecate it, or delete? See [[pipeline]].
+- **`run copy.py` is a stale developer scratch fork.** Not imported anywhere; older `run()` signature; Jupyter-style cells against a hard-coded Windows path. Now also out-of-date with the `FrangiConfig` constructor (PRD #66). Decision needed: delete? See [[pipeline]].
+- **CLI is broken / out-of-date with `run.py`.** `nellie/cli.py` calls `run(tif_file, ..., ch=, num_t=, output_dirpath=)` but `run.py` no longer accepts those kwargs, and now also calls `Filter` via the pre-`FrangiConfig` kwargs (PRD #66). Decision: fix `cli.py`, deprecate it, or delete? See [[pipeline]].
 - **macOS hard-pinned to CPU** in `nellie/__init__.py` — the MPS branch is commented out. Will Apple Silicon GPU support be revived? See [[gpu-runtime]].
 - **`_clean_junctions` in `segmentation/networking.py` is dead code** — defined but never called from the main path. Remove or wire up? See [[networking]].
 - **`SettingsConfig` round-trip in the [[settings|napari settings widget]] is dead code today** — preset save/load not wired. Ship or remove?

--- a/wiki/segmentation/filtering.md
+++ b/wiki/segmentation/filtering.md
@@ -16,6 +16,7 @@ Tubular organelles (mitochondria, ER tubules) are low-contrast and varied in rad
 - Input: any [[im-info|ImInfo]] raw memmap.
 - Output `im_preprocessed` consumed by [[labelling]], [[networking]], [[mocap-marking]] (when `use_im='frangi'`), and [[feature-extraction]] (as the "structure image").
 - Calls `triangle_threshold` / `otsu_threshold` from [[gpu-runtime]].
+- Algorithm config is bundled in a `FrangiConfig` frozen dataclass colocated in `filtering.py`. `Filter(im_info, FrangiConfig(alpha_sq=0.3, ...), viewer=None, num_t=None)` is the construction shape. The cascade may mutate `Filter.device` / `Filter.low_memory` runtime state; `Filter.config` preserves the original intent.
 - Pure math primitives (Frangi formula, Hessian, multi-scale LoG, γ estimation) live in `nellie/segmentation/frangi_math.py` — Filter is the thin caller that holds `xp`, `ndi`, `alpha_sq`, `beta_sq`, etc. and passes them through.
 - Chunking primitives (`iter_chunks`, `compute_chunk_shape`, `safe_eigvalsh`, `subsample_for_thresholds`) live in `nellie/utils/chunking.py` — stage-agnostic, default `is_oom` predicate handles both NumPy and CuPy errors.
 - Backend resolution (`resolve_backend`, `try_import_cupy`, `free_gpu_memory`, `is_oom_error`) lives in [[gpu-runtime|`adaptive_run`]] — Filter's `_set_backend` / `_set_low_memory` / `_switch_to_cpu` are thin mutator wrappers required by the cascade contract.


### PR DESCRIPTION
## Summary

- New `FrangiConfig` frozen dataclass colocated in `nellie/segmentation/filtering.py`
- `Filter.__init__` becomes `Filter(im_info, config: FrangiConfig = FrangiConfig(), viewer=None, num_t=None)`
- `nellie/run.py`, `nellie_napari/nellie_processor.py`, and `tests/test_filtering.py` updated atomically — no backwards-compat shim
- `nellie_napari/nellie_settings.py:get_preprocessing_params()` unchanged in shape (returns dict; consistent with the other three `get_*_params` methods)
- Wiki: `filtering.md` Interactions, `napari-plugin/processor.md` kwarg flow, `queue.md` notes about `cli.py` / `run copy.py` being further out-of-date

## Test plan

- [x] Local pytest — 12 passed in 6.34s
- [ ] CI green on all 6 jobs

## Design highlights

- `config.device` and `config.low_memory` are copied into mutable `Filter.device` / `Filter.low_memory` instance attrs at init. The OOM/availability cascade keeps mutating the instance attrs; `Filter.config` preserves the original intent.
- All other algorithm values aliased into `Filter.X` instance attrs in `__init__` for hot-path access — body of Filter unchanged.
- Module-level `_CPU` / `_CPU_KEEP_EDGES` / `_CPU_STRIP_EDGES` constants in the test file factor out the common config so each `Filter(...)` test call is one line.

## Out of scope (deferred)

- `LabelConfig`, `NetworkConfig`, `MarkersConfig` for the other three segmentation stages — each gets its own future slice using this slice's pattern.
- `nellie/cli.py` and `nellie/run copy.py` cleanup — already on `wiki/queue.md`.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)