### PR TITLE
Slice 2 (PRD #77): Structural cleanups + wiki updates for networking.py

### DIFF
--- a/nellie/segmentation/networking.py
+++ b/nellie/segmentation/networking.py
@@ -6,9 +6,7 @@ and analyzing their topology with optimized CPU/GPU processing.
 """
 import itertools
 import numpy as np
-import skimage.measure
 import skimage.morphology as morph
-from scipy.spatial import cKDTree
 from scipy import ndimage as ndi_cpu
 
 from nellie.utils import adaptive_run
@@ -84,19 +82,12 @@ class Network:
         else:
             self.scaling = (im_info.dim_res['Z'], im_info.dim_res['Y'], im_info.dim_res['X'])
 
-        self.shape = ()
-
         self.im_memmap = None
         self.im_frangi_memmap = None
         self.label_memmap = None
-        self.network_memmap = None  # kept for compatibility, not used
         self.pixel_class_memmap = None
         self.skel_memmap = None
         self.skel_relabelled_memmap = None
-
-        self.sigmas = None
-
-        self.debug = None
 
         self.viewer = viewer
 
@@ -104,11 +95,9 @@ class Network:
     # Helper methods for device handling
     # -------------------------------------------------------------------------
     def _resolve_backend(self, device):
-        device = (device or "auto").lower()
-        if device not in ("auto", "cpu", "gpu", "cuda"):
-            raise ValueError(f"Unsupported device '{device}'. Use 'auto', 'cpu', or 'gpu'.")
+        device = adaptive_run.normalize_device(device)
 
-        if device in ("gpu", "cuda"):
+        if device == "gpu":
             xp, ndi = self._try_import_cupy(require=True)
             return xp, ndi, "cuda"
         if device == "cpu":
@@ -231,32 +220,20 @@ class Network:
     # -------------------------------------------------------------------------
     # Neighborhood-based skeleton cleanup
     # -------------------------------------------------------------------------
-    def _remove_connected_label_pixels(self, skel_labels, force_cpu: bool = False):
+    def _remove_connected_label_pixels(self, skel_labels):
         """
         Removes skeleton pixels that are connected to multiple labeled regions.
 
-        This vectorized implementation replaces the original per-pixel Python loop
-        with min/max filters over 3x3 (2D) or 3x3x3 (3D) neighborhoods.
+        Always runs on CPU: the sole pipeline caller (``_run_frame_backend``)
+        feeds CPU arrays in, and the vectorized 3×3(×3) min/max neighborhood
+        filters are inexpensive enough on CPU that the GPU branch was never
+        worth exercising. The chunked low-memory variant is retained for
+        peak-memory control on very large frames.
         """
-        if force_cpu:
-            labels_np = np.asarray(skel_labels)
-            if self.low_memory:
-                return self._remove_connected_label_pixels_chunked(labels_np)
-            return self._remove_connected_label_pixels_impl(labels_np, np, ndi_cpu)
-
-        labels_xp = self._to_xp(skel_labels)
+        labels_np = np.asarray(skel_labels)
         if self.low_memory:
-            labels_np = self._to_cpu(labels_xp)
             return self._remove_connected_label_pixels_chunked(labels_np)
-
-        try:
-            return self._remove_connected_label_pixels_impl(labels_xp, self.xp, self.ndi)
-        except Exception as exc:
-            if not self._is_oom_error(exc):
-                raise
-            self._free_gpu_memory()
-            labels_np = self._to_cpu(labels_xp)
-            return self._remove_connected_label_pixels_chunked(labels_np)
+        return self._remove_connected_label_pixels_impl(labels_np, np, ndi_cpu)
 
     def _remove_connected_label_pixels_impl(self, labels, xp, ndi):
         mask = labels > 0
@@ -448,38 +425,6 @@ class Network:
         return skel_out
 
     # -------------------------------------------------------------------------
-    # Sigma management for multi-scale filters
-    # -------------------------------------------------------------------------
-    def _get_sigma_vec(self, sigma):
-        """
-        Computes the sigma vector for multi-scale filtering based on image dimensions.
-        """
-        if self.im_info.no_z:
-            sigma_vec = (sigma, sigma)
-        else:
-            sigma_vec = (sigma / self.z_ratio, sigma, sigma)
-        return sigma_vec
-
-    def _set_default_sigmas(self):
-        """
-        Sets the default sigma values for multi-scale filtering based on the
-        minimum and maximum radius in pixels.
-        """
-        logger.debug('Setting sigma values for multi-scale filters.')
-        min_sigma_step_size = 0.2
-        num_sigma = 5
-
-        self.sigma_min = self.min_radius_px / 2
-        self.sigma_max = self.max_radius_px / 3
-
-        sigma_step_size_calculated = (self.sigma_max - self.sigma_min) / num_sigma
-        sigma_step_size = max(min_sigma_step_size, sigma_step_size_calculated)
-
-        # Use numpy here; sigma values are small and do not need GPU.
-        self.sigmas = np.arange(self.sigma_min, self.sigma_max, sigma_step_size).tolist()
-        logger.debug(f'Calculated sigma step size = {sigma_step_size_calculated}. Sigmas = {self.sigmas}')
-
-    # -------------------------------------------------------------------------
     # Branch relabeling using per-object distance transforms
     # -------------------------------------------------------------------------
     def _relabel_objects(self, branch_skel_labels, label_frame):
@@ -577,58 +522,6 @@ class Network:
         return relabelled_np
 
     # -------------------------------------------------------------------------
-    # Multi-scale peak detection with reduced memory footprint
-    # -------------------------------------------------------------------------
-    def _local_max_peak(self, frame, mask):
-        """
-        Detects local maxima using multi-scale Laplacian of Gaussian filtering.
-
-        This implementation is memory-friendly: instead of allocating a full
-        (num_sigma, *frame.shape) array, it keeps track of the best response
-        per voxel across scales.
-
-        Parameters
-        ----------
-        frame : xp.ndarray or numpy.ndarray
-            Input image.
-        mask : xp.ndarray or numpy.ndarray
-            Binary mask for regions of interest.
-
-        Returns
-        -------
-        xp.ndarray
-            Coordinates of detected local maxima.
-        """
-        if self.sigmas is None:
-            self._set_default_sigmas()
-
-        frame_xp = self._to_xp(frame)
-        mask_xp = self._to_xp(mask).astype(bool)
-
-        ndim = frame_xp.ndim
-        footprint = self.xp.ones((3,) * ndim)
-
-        best_response = self.xp.zeros_like(frame_xp, dtype=float)
-        peak_mask = self.xp.zeros_like(frame_xp, dtype=bool)
-
-        for s in self.sigmas:
-            sigma_vec = self._get_sigma_vec(float(s))
-
-            current = -self.ndi.gaussian_laplace(frame_xp, sigma_vec)
-            current *= (float(s) ** 2)
-            current *= mask_xp
-            current = self.xp.where(current < 0, 0, current)
-
-            max_local = self.ndi.maximum_filter(current, footprint=footprint, mode="nearest")
-            is_peak = (current == max_local) & (current > best_response) & (current > 0)
-
-            best_response = self.xp.where(is_peak, current, best_response)
-            peak_mask = peak_mask | is_peak
-
-        coords_3d = self.xp.argwhere(peak_mask)
-        return coords_3d
-
-    # -------------------------------------------------------------------------
     # Skeleton pixel classification
     # -------------------------------------------------------------------------
     def _get_pixel_class(self, skel, force_cpu: bool = False):
@@ -701,19 +594,6 @@ class Network:
             out[core] = core_sum.astype(np.uint8, copy=False)
 
         return out
-
-    # -------------------------------------------------------------------------
-    # Time dimension handling
-    # -------------------------------------------------------------------------
-    def _get_t(self):
-        """
-        Determines the number of timepoints to process.
-        """
-        if self.num_t is None:
-            if self.im_info.no_t:
-                self.num_t = 1
-            else:
-                self.num_t = self.im_info.shape[self.im_info.axes.index('T')]
 
     # -------------------------------------------------------------------------
     # Memory allocation for outputs
@@ -831,7 +711,7 @@ class Network:
         frangi_frame_cpu = np.asarray(self.im_frangi_memmap[t])
 
         skel_frame = self._skeletonize(label_frame_cpu)
-        skel_clean = self._remove_connected_label_pixels(skel_frame, force_cpu=True)
+        skel_clean = self._remove_connected_label_pixels(skel_frame)
         skel_clean = self._add_missing_skeleton_labels(
             skel_clean, label_frame_cpu, frangi_frame_cpu
         )
@@ -849,52 +729,6 @@ class Network:
         branch_labels = self._relabel_objects(branch_skel_labels, label_frame_cpu)
 
         return branch_skel_labels, pixel_class, branch_labels
-
-    # -------------------------------------------------------------------------
-    # Optional junction cleanup
-    # -------------------------------------------------------------------------
-    def _clean_junctions(self, pixel_class):
-        """
-        Cleans up junctions by removing closely spaced junction pixels.
-
-        This method uses regionprops to group junction pixels and keeps only the
-        pixel closest to the junction centroid as a junction, converting the
-        others to branch pixels.
-
-        Parameters
-        ----------
-        pixel_class : numpy.ndarray or xp.ndarray
-            Pixel classification of skeleton points.
-
-        Returns
-        -------
-        numpy.ndarray
-            Cleaned pixel classification with redundant junctions removed.
-        """
-        pc_np = self._to_cpu(pixel_class).copy()
-
-        junctions = pc_np == 4
-        if not junctions.any():
-            return pc_np
-
-        junction_labels = skimage.measure.label(junctions)
-        junction_objects = skimage.measure.regionprops(junction_labels)
-        junction_centroids = [obj.centroid for obj in junction_objects]
-
-        for junction_num, junction in enumerate(junction_objects):
-            coords = junction.coords
-            if len(coords) < 2:
-                continue
-            # Use KD-tree to find closest pixel to centroid
-            junction_tree = cKDTree(coords)
-            _, nearest_idx = junction_tree.query(junction_centroids[junction_num], k=1, workers=-1)
-            # Convert all other pixels in this junction component to branch class (3)
-            coords_list = coords.tolist()
-            coords_list.pop(nearest_idx)
-            coords_arr = np.array(coords_list).T
-            pc_np[tuple(coords_arr)] = 3
-
-        return pc_np
 
     # -------------------------------------------------------------------------
     # Full networking pipeline
@@ -957,7 +791,6 @@ class Network:
             try:
                 self._set_backend(dev)
                 self._set_low_memory(low)
-                self._get_t()
                 self._allocate_memory()
                 self._run_networking()
                 return
@@ -975,10 +808,3 @@ class Network:
                     continue
                 raise
         raise last_exc
-
-
-if __name__ == "__main__":
-    im_path = r"D:\\test_files\\nelly_tests\\deskewed-2023-07-13_14-58-28_000_wt_0_acquire.ome.tif"
-    im_info = ImInfo(im_path)
-    skel = Network(im_info, num_t=3)
-    skel.run()

--- a/tests/test_networking.py
+++ b/tests/test_networking.py
@@ -84,7 +84,6 @@ def _build_cpu_network(info: ImInfo, **kwargs) -> Network:
     net = Network(info, num_t=2, **kwargs)
     net._set_backend("cpu")
     net._set_low_memory(kwargs.get("low_memory", False))
-    net._get_t()
     net._allocate_memory()
     return net
 

--- a/wiki/queue.md
+++ b/wiki/queue.md
@@ -10,7 +10,6 @@ Unresolved decisions, design questions, or known unknowns surfaced by the wiki s
 ## Open
 
 - **macOS hard-pinned to CPU** in `nellie/__init__.py` — the MPS branch is commented out. Will Apple Silicon GPU support be revived? See [[gpu-runtime]].
-- **`_clean_junctions` in `segmentation/networking.py` is dead code** — defined but never called from the main path. **Scoped to Slice 2 (cleanups) of the upcoming Network PRD**, which mirrors PRD #70's three-slice shape (tests → cleanups → backend hoist). Bundled with the other Network dead-code findings from the recent dechaos pass: `_local_max_peak` + the LoG/sigma machinery, the `__main__` block, and the unreachable `force_cpu=False` branch of `_remove_connected_label_pixels`. See [[networking]].
 - **`SettingsConfig` round-trip in the [[settings|napari settings widget]] is dead code today** — preset save/load not wired. Ship or remove?
 - **Hu-moment cost weighting is unjustified in code** — z-scored sum of distance + stats + Hu blocks with no learned weights or rationale committed. Document the heuristic or replace? See [[hu-tracking]].
 - **`flow_interpolation.py __main__` block has a `self.im_info` typo bug** — uses `self` outside a class. Remove or fix. See [[flow-interpolation]].
@@ -27,5 +26,6 @@ Unresolved decisions, design questions, or known unknowns surfaced by the wiki s
 
 ## Recently resolved
 
+- **Network dead-code consolidation landed** (2026-05-08) — Slice 2 of PRD #77 deleted `_clean_junctions`, `_local_max_peak`, the LoG/sigma machinery (`_set_default_sigmas`, `_get_sigma_vec`, `self.sigmas`), the `__main__` block, dead instance state (`self.network_memmap`, `self.shape = ()`, `self.debug`), the vestigial `_get_t`, and the unreachable `force_cpu=False` branch of `_remove_connected_label_pixels` (and its `force_cpu` parameter); also normalized the `device="cuda"` alias through `adaptive_run.normalize_device`. Guarded by Slice 1's 17 characterization tests. See [[networking]] and PR #82.
 - **`nellie/run copy.py` deleted** (2026-05-07) — confirmed orphan, no importers. Removed alongside `cli.py` cleanup.
 - **`nellie/cli.py` deleted** (2026-05-07) — broken since `run.py`'s signature change; no console-script entry point referenced it; not worth fixing for a stale UI nobody uses.

--- a/wiki/segmentation/networking.md
+++ b/wiki/segmentation/networking.md
@@ -3,6 +3,7 @@ created: 2026-05-06
 modified: 2026-05-08
 ---
 
+
 # Networking
 
 Skeletonize each instance, classify each skeleton voxel (background / isolated / tip / edge / junction), label branches, and propagate branch IDs back to fill each object's volume. Outputs: `im_skel` (int32, branch ID at non-junction skel voxels; 0 at junction voxels and off-skeleton), `im_pixel_class` (uint8 ∈ {0,1,2,3,4}), `im_skel_relabelled` (uint32, every voxel of an object gets a branch ID).
@@ -39,8 +40,6 @@ Topology — branches, junctions, tips — is what enables network metrics (leng
 - **Pixel class uses 3×3(×3) convolution count, clipped at 4** — so "junction" means "≥ 4 neighbors", not specifically "exactly 4".
 - **Per-object EDT uses anisotropic `sampling=self.scaling`**; the [[mocap-marking|marker-stage EDT]] does **not**. Different design choices in the two stages — be aware when comparing distance values.
 - **`im_skel`'s value at each skel voxel is a *branch* ID, not a parent-object ID.** It comes from `_run_frame_backend` returning `branch_skel_labels` (the connected-component IDs from `_get_branch_skel_labels`, which excludes pixel-class 4) as the first tuple element, which `_run_networking` writes to `skel_memmap`. Junction voxels and off-skeleton voxels are 0. Downstream ([[feature-extraction|`hierarchical.py`]]) reads it as branch labels — that's the actual contract; the parent-label framing in older docs/comments is wrong.
-- **`_clean_junctions`, `_local_max_peak`, and the multi-scale sigma machinery (`_set_default_sigmas`, `_get_sigma_vec`, `self.sigmas`/`sigma_min`/`sigma_max`) are dead** — defined but never called from any code path in the repo. The `__main__` block at the bottom is also dead (hardcoded Windows path). Slated for removal in the cleanups slice of the upcoming Network refactor (mirrors PRD #70's three-slice shape — see [[queue]]).
-- **`_remove_connected_label_pixels` GPU/auto branch is unreachable in the pipeline.** The sole pipeline caller (`_run_frame_backend`) always passes `force_cpu=True`, so the `_to_xp` path with OOM fallback never executes. The `force_cpu` knob and the GPU branch will likely collapse during the cleanups slice.
 
 ## Invariants
 


### PR DESCRIPTION
## Summary

No-behavior-change cleanup pass on `nellie/segmentation/networking.py` (985 -> 810 lines, -175 net) plus two stale-gotcha removals in `wiki/segmentation/networking.md` and a queue resolution. Guarded by Slice 1's 17 characterization tests.

Closes #79. Slice 2 of PRD #77. Stacked on #81 (Slice 1, merged).

## Code cleanups

- Drop dead instance state (`self.shape = ()`, `self.network_memmap`, `self.sigmas`, `self.debug`)
- Drop dead method cluster: `_clean_junctions`, `_local_max_peak`, `_set_default_sigmas`, `_get_sigma_vec` (the latter two were only consumed by `_local_max_peak`)
- Drop now-orphan imports (`skimage.measure`, `scipy.spatial.cKDTree`); keep `skimage.morphology as morph` (used by `_skeletonize`) and `scipy.ndimage as ndi_cpu` (used widely)
- Drop `_get_t` (vestigial; constructor already sets `num_t` when `no_t` is False; mirrors Label's PR #75 deletion)
- Drop `__main__` block (hardcoded Windows path; not used)
- Collapse unreachable GPU branch in `_remove_connected_label_pixels`: the sole pipeline caller (`_run_frame_backend`) always passed `force_cpu=True`, so the `_to_xp` + OOM-fallback path never executed. Removed the `force_cpu` parameter and the GPU branch; kept the always-CPU implementation including the `low_memory` chunked dispatch
- Fix `device="cuda"` doc/code mismatch by routing through `adaptive_run.normalize_device` in `_resolve_backend`, dropping the redundant local "cuda" branch and validation set (mirrors Label's PR #75 pattern; downstream comparisons now see only `auto`/`cpu`/`gpu`)

## Test helper update

- `tests/test_networking.py::_build_cpu_network`: drop the `net._get_t()` call (the helper was the only test-side caller of the deleted method; the constructor already covers the only case the helper exercised, `num_t=2`)

## Wiki edits

- **`wiki/segmentation/networking.md`**: remove the two dead-code gotchas added during the dechaos pass that no longer apply (the consolidated `_clean_junctions` / `_local_max_peak` / sigma machinery / `__main__` gotcha, and the `_remove_connected_label_pixels` GPU-branch-unreachable gotcha). The `im_skel` branch-IDs contract gotcha and per-stage device choreography gotcha stay -- they describe unchanged behavior.
- **`wiki/queue.md`**: move the consolidated Network dead-code item from "Open" to "Recently resolved" with a pointer to this PR.

## Test plan

- [x] `pytest tests/ -v` -- 43 passed locally (Slice 1's Network tests + PRD #51 Filter + PRD #70 Label all green)
- [ ] CI: full matrix from PRD #51 / #70

## Out of scope (Slice 3)

The four backend-lifecycle reimplementations (`_resolve_backend`, `_try_import_cupy`, `_is_oom_error`, `_free_gpu_memory`) and `_switch_to_cpu` are deferred to Slice 3 (#80). The two-layer OOM-fallback structure is deferred to a future Stabilize PRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)