### PR TITLE
hu_tracking: structural cleanups + cost_cutoff module constant (Slice 2 of #91)

### DIFF
--- a/nellie/tracking/hu_tracking.py
+++ b/nellie/tracking/hu_tracking.py
@@ -23,6 +23,13 @@ except Exception:  # ImportError or others
     GPU_OOM_ERRORS = ()
 
 
+# Single source of truth for the match-acceptance cost cutoff used in BOTH the
+# dense (``_find_best_matches``) and sparse (``_match_frames_sparse``) paths.
+# Pinned by ``test_cost_cutoff_pinned_in_both_paths``; lifting to a constructor
+# arg is deferred to the cross-stage HuMomentTrackingConfig slice.
+_COST_CUTOFF = 1.0
+
+
 @dataclass
 class _FrameFeatures:
     """Internal container for per-frame features."""
@@ -113,21 +120,18 @@ class HuMomentTracking:
             logger.warning("Time resolution missing; assuming 1.0s for max_distance_um scaling.")
         self.max_distance_um = max(max_distance_um * dt, 0.5)
 
-        self.shape = ()
-
         self.im_memmap = None
         self.im_frangi_memmap = None
         self.im_distance_memmap = None
         self.im_marker_memmap = None
         self.flow_vector_array_path = None
 
-        self.debug = None
         self.viewer = viewer
 
-        # Backend / device info
-        self.device = device
-        self.xp, self.ndi, self.device_type = self._resolve_backend(device)
-        self._on_gpu = self.device_type == "cuda"
+        # Backend / device info — normalize aliases ("cuda" → "gpu") at the
+        # constructor edge so downstream code only sees "auto" | "cpu" | "gpu".
+        self.device = adaptive_run.normalize_device(device)
+        self.xp, self.ndi, self.device_type = self._resolve_backend(self.device)
 
         # Matching / ROI mode tuning
         self.mode = mode  # "auto", "dense", "sparse"
@@ -183,7 +187,7 @@ class HuMomentTracking:
     def _is_oom_error(self, exc):
         if isinstance(exc, MemoryError):
             return True
-        if not self._on_gpu:
+        if self.device_type != "cuda":
             return False
         try:
             import cupy
@@ -192,7 +196,7 @@ class HuMomentTracking:
         return isinstance(exc, cupy.cuda.memory.OutOfMemoryError)
 
     def _free_gpu_memory(self):
-        if not self._on_gpu:
+        if self.device_type != "cuda":
             return
         try:
             self.xp.get_default_memory_pool().free_all_blocks()
@@ -203,18 +207,16 @@ class HuMomentTracking:
         self.xp = np
         self.ndi = sp_ndi
         self.device_type = "cpu"
-        self._on_gpu = False
 
     def _set_backend(self, device):
         device = adaptive_run.normalize_device(device)
         self.device = device
         self.xp, self.ndi, self.device_type = self._resolve_backend(device)
-        self._on_gpu = self.device_type == "cuda"
 
     def _set_low_memory(self, low_memory):
         self.low_memory = bool(low_memory)
 
-    def _to_cpu_array(self, arr):
+    def _to_cpu(self, arr):
         if isinstance(arr, np.ndarray):
             return arr
         if hasattr(arr, "get"):
@@ -492,14 +494,6 @@ class HuMomentTracking:
     # Meta / memory allocation
     # -------------------------------------------------------------------------
 
-    def _get_t(self):
-        """Determines the number of timepoints to process."""
-        if self.num_t is None:
-            if self.im_info.no_t:
-                self.num_t = 1
-            else:
-                self.num_t = self.im_info.shape[self.im_info.axes.index('T')]
-
     def _allocate_memory(self):
         """
         Allocates memory / memmaps for the necessary image data.
@@ -545,10 +539,6 @@ class HuMomentTracking:
         hu_moments = xp.concatenate((hu_moments_z, hu_moments_y, hu_moments_x), axis=1)
         return hu_moments
 
-    def _concatenate_hu_matrices(self, hu_matrices):
-        """Concatenates multiple feature matrices along the feature axis."""
-        return self.xp.concatenate(hu_matrices, axis=1)
-
     # -------------------------------------------------------------------------
     # Per-frame feature extraction (stats + Hu + coordinates)
     # -------------------------------------------------------------------------
@@ -573,7 +563,7 @@ class HuMomentTracking:
         try:
             return self._get_frame_features_impl(t)
         except GPU_OOM_ERRORS + (MemoryError,) as exc:
-            if self._on_gpu and self._is_oom_error(exc):
+            if self.device_type == "cuda" and self._is_oom_error(exc):
                 logger.warning(
                     f"Frame {t}: GPU OOM during feature extraction; switching to CPU."
                 )
@@ -636,7 +626,11 @@ class HuMomentTracking:
         dim = 2 if self.im_info.no_z else 3
         voxels_per_roi = max_radius ** dim
         total_voxels = int(num_markers * voxels_per_roi)
-        dense_limit = self.max_dense_roi_voxels_gpu if self._on_gpu else self.max_dense_roi_voxels_cpu
+        dense_limit = (
+            self.max_dense_roi_voxels_gpu
+            if self.device_type == "cuda"
+            else self.max_dense_roi_voxels_cpu
+        )
         use_dense = total_voxels <= dense_limit
         if self.low_memory:
             use_dense = False
@@ -659,14 +653,14 @@ class HuMomentTracking:
 
                 intensity_stats = self._calculate_mean_and_variance(intensity_sub_volumes)
                 frangi_stats = self._calculate_mean_and_variance(frangi_sub_volumes)
-                stats_feature_matrix = self._concatenate_hu_matrices([intensity_stats, frangi_stats])
+                stats_feature_matrix = xp.concatenate([intensity_stats, frangi_stats], axis=1)
 
                 intensity_hus = self._get_hu_moments(intensity_sub_volumes)
                 log_hu_feature_matrix = self._log_hu(intensity_hus)
 
                 del intensity_sub_volumes, frangi_sub_volumes, intensity_stats, frangi_stats, intensity_hus
             except GPU_OOM_ERRORS + (MemoryError,) as exc:
-                if self._on_gpu and self._is_oom_error(exc):
+                if self.device_type == "cuda" and self._is_oom_error(exc):
                     self._free_gpu_memory()
                 logger.warning(
                     f"Frame {t}: dense ROI extraction OOM; falling back to streaming ROI extraction."
@@ -770,7 +764,7 @@ class HuMomentTracking:
         if coords_post_phys.size == 0 or coords_pre_phys.size == 0:
             return xp.zeros((0, 0), dtype=xp.float32), xp.zeros((0, 0), dtype=bool)
 
-        if self._on_gpu:
+        if self.device_type == "cuda":
             A = xp.asarray(coords_post_phys)
             B = xp.asarray(coords_pre_phys)
             diff = A[:, None, :] - B[None, :, :]
@@ -906,8 +900,6 @@ class HuMomentTracking:
         if cost_matrix.size == 0:
             return [], [], []
 
-        cost_cutoff = 1.0
-
         # Row-wise minima
         row_min_idx = xp.argmin(cost_matrix, axis=1)
         row_min_val = xp.min(cost_matrix, axis=1)
@@ -923,7 +915,7 @@ class HuMomentTracking:
         # Row candidates
         for i, (r_idx, r_val) in enumerate(zip(row_min_idx, row_min_val)):
             val = float(r_val)
-            if val > cost_cutoff:
+            if val > _COST_CUTOFF:
                 continue
             row_matches.append(int(i))
             col_matches.append(int(r_idx))
@@ -932,7 +924,7 @@ class HuMomentTracking:
         # Column candidates
         for j, (c_idx, c_val) in enumerate(zip(col_min_idx, col_min_val)):
             val = float(c_val)
-            if val > cost_cutoff:
+            if val > _COST_CUTOFF:
                 continue
             row_matches.append(int(c_idx))
             col_matches.append(int(j))
@@ -1030,8 +1022,6 @@ class HuMomentTracking:
         col_min_val = np.full(n_pre, np.inf, dtype=np.float32)
         col_min_idx = np.full(n_pre, -1, dtype=np.int64)
 
-        cost_cutoff = 1.0
-
         for i_post, pre_list in enumerate(candidates_per_row):
             if not pre_list:
                 continue
@@ -1051,7 +1041,7 @@ class HuMomentTracking:
             z_hu = (hu_diff - mean_hu) / std_hu
 
             cost = z_dist + np.mean(z_stats, axis=1) + np.mean(z_hu, axis=1)
-            valid_mask = cost <= cost_cutoff
+            valid_mask = cost <= _COST_CUTOFF
             if not np.any(valid_mask):
                 continue
 
@@ -1080,14 +1070,14 @@ class HuMomentTracking:
 
         # Row-based candidates
         for i_post, (j_pre, c) in enumerate(zip(row_min_idx, row_min_val)):
-            if j_pre >= 0 and c <= cost_cutoff:
+            if j_pre >= 0 and c <= _COST_CUTOFF:
                 row_matches.append(int(i_post))
                 col_matches.append(int(j_pre))
                 costs.append(float(c))
 
         # Column-based candidates
         for j_pre, (i_post, c) in enumerate(zip(col_min_idx, col_min_val)):
-            if i_post >= 0 and c <= cost_cutoff:
+            if i_post >= 0 and c <= _COST_CUTOFF:
                 row_matches.append(int(i_post))
                 col_matches.append(int(j_pre))
                 costs.append(float(c))
@@ -1103,16 +1093,16 @@ class HuMomentTracking:
         hu_vecs = frame_t.hu
         pre_hu_vecs = frame_prev.hu
 
-        if self._on_gpu:
+        if self.device_type == "cuda":
             stats_vecs = self.xp.asarray(stats_vecs)
             pre_stats_vecs = self.xp.asarray(pre_stats_vecs)
             hu_vecs = self.xp.asarray(hu_vecs)
             pre_hu_vecs = self.xp.asarray(pre_hu_vecs)
         else:
-            stats_vecs = self._to_cpu_array(stats_vecs)
-            pre_stats_vecs = self._to_cpu_array(pre_stats_vecs)
-            hu_vecs = self._to_cpu_array(hu_vecs)
-            pre_hu_vecs = self._to_cpu_array(pre_hu_vecs)
+            stats_vecs = self._to_cpu(stats_vecs)
+            pre_stats_vecs = self._to_cpu(pre_stats_vecs)
+            hu_vecs = self._to_cpu(hu_vecs)
+            pre_hu_vecs = self._to_cpu(pre_hu_vecs)
 
         n_post = stats_vecs.shape[0]
         n_pre = pre_stats_vecs.shape[0]
@@ -1138,7 +1128,7 @@ class HuMomentTracking:
                 )
                 return self._find_best_matches(cost_matrix)
             except GPU_OOM_ERRORS + (MemoryError,) as exc:
-                if self._on_gpu and self._is_oom_error(exc):
+                if self.device_type == "cuda" and self._is_oom_error(exc):
                     logger.warning(
                         "Dense matching OOM; switching to CPU and falling back to sparse KDTree matching."
                     )
@@ -1262,7 +1252,6 @@ class HuMomentTracking:
             try:
                 self._set_backend(dev)
                 self._set_low_memory(low)
-                self._get_t()
                 self._allocate_memory()
                 self._run_hu_tracking()
                 return
@@ -1280,10 +1269,3 @@ class HuMomentTracking:
                     continue
                 raise
         raise last_exc
-
-
-if __name__ == "__main__":
-    im_path = r"D:\test_files\nelly_smorgasbord\deskewed-iono_pre.ome.tif"
-    im_info = ImInfo(im_path)
-    hu = HuMomentTracking(im_info, num_t=2)
-    hu.run()

--- a/tests/test_hu_tracking.py
+++ b/tests/test_hu_tracking.py
@@ -595,7 +595,6 @@ def test_dense_vs_sparse_match_set_equivalence(tmp_path: Path) -> None:
 
     h.ndi = sp_ndi
     h.device_type = "cpu"
-    h._on_gpu = False
     h.max_dense_pairs = int(1e12)
     h.max_dense_roi_voxels_cpu = int(1e12)
     h.max_dense_roi_voxels_gpu = int(1e12)
@@ -815,15 +814,14 @@ def test_cascade_a_per_frame_oom_mutates_device_type(
     This pins the PRE-Slice-3 contract for the per-frame inner OOM
     cascade (``hu_tracking.py:572-583``). On GPU OOM during feature
     extraction, ``_get_frame_features`` calls ``self._switch_to_cpu()``
-    which mutates ``self.xp`` / ``self.ndi`` / ``self.device_type`` /
-    ``self._on_gpu`` for the rest of the run.
+    which mutates ``self.xp`` / ``self.ndi`` / ``self.device_type``
+    for the rest of the run.
 
     CI has no GPU, so we simulate GPU state by direct attribute
-    assignment AFTER construction (``hu._on_gpu = True``,
-    ``hu.device_type = "cuda"``). The monkeypatched
-    ``_get_frame_features_impl`` raises ``MemoryError`` exactly once
-    on the second call (the first frame succeeds normally), then
-    delegates to the real implementation.
+    assignment AFTER construction (``hu.device_type = "cuda"``). The
+    monkeypatched ``_get_frame_features_impl`` raises ``MemoryError``
+    exactly once on the second call (the first frame succeeds
+    normally), then delegates to the real implementation.
 
     **Slice 3 (#94) will DELETE this test entirely** — the per-frame
     cascade is going away (resolved decision #1, dechaos report);
@@ -833,9 +831,8 @@ def test_cascade_a_per_frame_oom_mutates_device_type(
     info = make_hu_imageinfo_3d()
     h = HuMomentTracking(info, num_t=2, device="cpu")
 
-    # Simulate GPU state so the inner cascade's `if self._on_gpu`
-    # guard fires (line 576) and `_switch_to_cpu()` mutates state.
-    h._on_gpu = True
+    # Simulate GPU state so the inner cascade's `device_type == "cuda"`
+    # guard fires (line 566) and `_switch_to_cpu()` mutates state.
     h.device_type = "cuda"
 
     real_impl = HuMomentTracking._get_frame_features_impl
@@ -861,9 +858,6 @@ def test_cascade_a_per_frame_oom_mutates_device_type(
     assert h.device_type == "cpu", (
         f"Expected Cascade A to mutate device_type to 'cpu' after OOM; "
         f"got {h.device_type!r}. Slice 3 (#94) will delete this contract."
-    )
-    assert h._on_gpu is False, (
-        "Expected Cascade A to flip _on_gpu to False after OOM"
     )
 
 
@@ -891,9 +885,8 @@ def test_cascade_b_dense_match_oom_mutates_device_type(
     info = make_hu_imageinfo_3d()
     h = HuMomentTracking(info, num_t=2, device="cpu", mode="dense")
 
-    # Simulate GPU state so the inner cascade's `if self._on_gpu`
-    # guard fires (line 1141) and `_switch_to_cpu()` mutates state.
-    h._on_gpu = True
+    # Simulate GPU state so the inner cascade's `device_type == "cuda"`
+    # guard fires (line 1131) and `_switch_to_cpu()` mutates state.
     h.device_type = "cuda"
 
     real_get_cost = HuMomentTracking._get_cost_matrix
@@ -915,7 +908,4 @@ def test_cascade_b_dense_match_oom_mutates_device_type(
     assert h.device_type == "cpu", (
         f"Expected Cascade B to mutate device_type to 'cpu' after dense OOM; "
         f"got {h.device_type!r}. Slice 3 (#94) will invert this contract."
-    )
-    assert h._on_gpu is False, (
-        "Expected Cascade B to flip _on_gpu to False after dense OOM"
     )

--- a/wiki/tracking/hu-tracking.md
+++ b/wiki/tracking/hu-tracking.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-06
-modified: 2026-05-07
+modified: 2026-05-08
 ---
 
 # Hu-moment tracking
@@ -26,7 +26,7 @@ Match [[mocap-marking|mocap markers]] across consecutive frames and write a `flo
   - **Matching** — dense pairwise cost matrix vs sparse `cKDTree`. Switched by `N_post * N_pre <= max_dense_pairs` (1e7). Sparse path is **CPU-only**.
 - **Adaptive degradation has two layers, both silent.** Inner: GPU OOM during a frame catches and retries that frame on CPU; dense ROI OOM falls to streaming; dense matching OOM falls to sparse. Outer: `run()` walks `adaptive_run.mode_candidates` over `(device, low_memory)` combos and retries the whole pipeline on each OOM. A run can degrade across both layers with only `logger.warning` to show for it.
 - **`low_memory` may be auto-enabled** by `adaptive_run.should_use_low_memory(im_info)` based on estimated memory usage — the constructor default is `False` but the actual run may force streaming ROI extraction anyway.
-- **Match-acceptance cost cutoff is a hardcoded `1.0`** in both `_find_best_matches` and the sparse path — not a constructor parameter, so changing the cost weighting in one place without changing the other will silently shift acceptance rates.
+- **Match-acceptance cost cutoff is a single module constant `_COST_CUTOFF = 1.0`** at the top of `hu_tracking.py`. Both `_find_best_matches` (dense) and `_match_frames_sparse` (sparse) reference the same constant, so the dense/sparse acceptance rates can no longer drift apart. `test_cost_cutoff_pinned_in_both_paths` is the authoritative spec — bumping the constant flips both paths atomically. Lifting to a constructor arg is deferred to the cross-stage `HuMomentTrackingConfig` slice; there is no documented tuning use case today.
 - **`_find_best_matches` returns the union of row-min and col-min candidates** (not Hungarian), so a target can appear in multiple pairs and downstream code sees duplicates.
 - **Hu moment 7 (mirror invariance) is intentionally omitted.**
 - **3D ROIs are reduced via 3-axis max projection then stacked into 18 features** (not a true 3D moment).


### PR DESCRIPTION
Closes #93. Mirrors PR #82 (Network Slice 2) and PR #89 (Markers Slice 2). Parent PRD: #91.

## Summary

Structural cleanups in `nellie/tracking/hu_tracking.py` plus lifting the duplicated `cost_cutoff = 1.0` literal into a module-level `_COST_CUTOFF` constant. Guarded by Slice 1's characterization tests (#92). No constructor signature change; no napari widget change; `nellie/run.py` untouched.

## Changes

**Module constant lift (resolved decision #2 in dechaos report):**
- New `_COST_CUTOFF = 1.0` at the top of `hu_tracking.py`, between the `GPU_OOM_ERRORS` block and `_FrameFeatures`.
- `_find_best_matches` and `_match_frames_sparse` both reference `_COST_CUTOFF` — the dense and sparse paths can no longer drift apart. Pinned by Slice 1's `test_cost_cutoff_pinned_in_both_paths`.

**Dead code deletions:**
- `self.shape = ()` (overwritten in `_allocate_memory`)
- `self.debug = None` (never read)
- `_get_t()` method (`__init__` already resolves `self.num_t`; both paths early-return on `no_t`) and its `run()` call site
- `__main__` block (hardcoded Windows path)

**`self._on_gpu` derivation:**
- Removed the duplicate boolean attribute. All ~10 read sites now check `self.device_type == "cuda"` directly, matching Network and Markers.

**Naming + inlining:**
- `_to_cpu_array` → `_to_cpu` for cross-stage naming consistency with Network.
- `_concatenate_hu_matrices` (single-line wrapper around `xp.concatenate(_, axis=1)`) inlined at its two call sites.

**Constructor edge normalization:**
- `device` is now normalized via `adaptive_run.normalize_device(device)` at constructor entry, so downstream code only sees `"auto" | "cpu" | "gpu"` (the `"cuda"` alias is collapsed to `"gpu"` once at the edge). Mirrors Markers' post-#89 flow.

**Slice 1 test updates:**
- `test_cascade_a_per_frame_oom_mutates_device_type` and `test_cascade_b_dense_match_oom_mutates_device_type` updated to drop the vestigial `h._on_gpu = True` setup and `assert h._on_gpu is False` assertions (the attribute no longer exists). The underlying `device_type == "cpu"` contract is preserved exactly. Slice 3 (#94) will delete cascade A and invert cascade B.

**Wiki:**
- `wiki/tracking/hu-tracking.md` gotcha #4 rewritten to reference `_COST_CUTOFF` and `test_cost_cutoff_pinned_in_both_paths`. `modified` bumped to 2026-05-08.

## Test plan

- [x] All 26 Slice 1 Hu tests pass (including the inner-OOM cascade tests)
- [x] All 60 upstream Filter / Label / Network / Markers tests pass
- [x] No new pyright errors (138 → 129; 9 pre-existing errors removed by deleting dead code)
- [x] Constructor signature unchanged; napari widget files unchanged; `nellie/run.py` unchanged

## Line-count delta

`nellie/tracking/hu_tracking.py`: 1289 → 1271 (-18 lines).

## Out of scope (Slice 3 / #94)

- Inner OOM cascades (`_get_frame_features` wrapper, `_match_frames` dense-OOM cascade)
- `_resolve_backend` / `_try_import_cupy` / `_is_oom_error` / `_free_gpu_memory` / `_switch_to_cpu` (hoist to `adaptive_run`)
- Local `GPU_OOM_ERRORS` tuple
- "Adaptive degradation has two layers" wiki gotcha rewrite