### PR TITLE
voxel_reassignment: characterization tests + conftest cascade (Slice 1 of #98)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,22 @@ on top of the Filter+Label caches and expose paths to BOTH the
 per-test factories copy in FOUR memmaps (Frangi + Label + Marker +
 Distance) so each test gets an isolated working directory ready for
 ``HuMomentTracking(info)`` without re-running any upstream stage.
+
+The cascade extends two more layers for VoxelReassigner: a Network
+session cache (``network_*_path``) runs Filter+Label+Network once per
+session and exposes the resulting ``im_skel_relabelled`` memmap, and a
+Hu-output session cache (``hu_outputs_*_path``) runs
+Filter+Label+Markers+Hu once per session and exposes the resulting
+``flow_vector_array.npy``. ``make_voxel_reassign_imageinfo_*`` per-test
+factories copy in THREE files (``im_instance_label`` from the Label
+cache, ``im_skel_relabelled`` from the Network cache, and
+``flow_vector_array.npy`` from the Hu-output cache) so each test gets an
+isolated working directory ready for ``VoxelReassigner(info)`` without
+re-running any upstream stage. The Hu output must be materialized
+BEFORE constructing the VoxelReassigner because
+``VoxelReassigner.__init__`` constructs two ``FlowInterpolator``
+instances unconditionally (when not ``no_t``), and FlowInterpolator
+loads ``flow_vector_array.npy`` immediately at construction.
 """
 
 from __future__ import annotations
@@ -48,6 +64,8 @@ from nellie.im_info.verifier import FileInfo, ImInfo
 from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label
 from nellie.segmentation.mocap_marking import Markers
+from nellie.segmentation.networking import Network
+from nellie.tracking.hu_tracking import HuMomentTracking
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_3D_PATH = REPO_ROOT / "tests" / "fixtures" / "yeast_3d_t0_to_1.ome.tif"
@@ -677,4 +695,314 @@ def make_hu_imageinfo_2d_module(
     workdir = tmp_path_factory.mktemp("hu_2d_module")
     return _make_hu_imageinfo_factory(
         workdir, FIXTURE_2D_PATH, frangi_2d_path, label_2d_path, markers_2d_paths
+    )
+
+
+# ------------------------------------------------------------------
+# Network-output fixtures (session-scoped) for downstream pipeline tests
+# ------------------------------------------------------------------
+
+
+def _run_network_to_disk(im_info: ImInfo) -> Path:
+    """Run Network to populate ``im_skel_relabelled`` on disk and release its memmap handles.
+
+    Assumes the Frangi memmap (``im_preprocessed``) and Label memmap
+    (``im_instance_label``) are already on disk in ``im_info``'s pipeline
+    tree (pre-populated by ``_run_filter_to_disk`` + ``_run_label_to_disk``
+    or by copying session-cached outputs).
+    """
+    net = Network(im_info, num_t=2, device="cpu")
+    net.run()
+    # Drop memmap handles so Windows lets us read/copy the file later.
+    net.skel_relabelled_memmap = None
+    net.skel_memmap = None
+    net.pixel_class_memmap = None
+    net.label_memmap = None
+    net.im_memmap = None
+    net.im_frangi_memmap = None
+    gc.collect()
+    return Path(im_info.pipeline_paths["im_skel_relabelled"])
+
+
+def _run_filter_label_network_for_session(
+    tmp_path_factory: pytest.TempPathFactory, source_image: Path, sub_name: str
+) -> Path:
+    """Build a session ImInfo, run Filter+Label+Network, return the relabelled-skel path.
+
+    Used by ``network_3d_path`` / ``network_2d_path`` to materialize
+    Network's ``im_skel_relabelled`` output once per session in its own
+    workdir (independent of the session-scoped ``imageinfo_*`` workdir,
+    which earlier fixtures may have populated).
+    """
+    workdir = tmp_path_factory.mktemp(sub_name)
+    info = _build_iminfo(source_image, workdir)
+    _run_filter_to_disk(info)
+    _run_label_to_disk(info)
+    return _run_network_to_disk(info)
+
+
+@pytest.fixture(scope="session")
+def network_3d_path(
+    tmp_path_factory: pytest.TempPathFactory,
+    frangi_3d_path: Path,
+    label_3d_path: Path,
+) -> Path:
+    """Session-scoped: path to a precomputed 3D ``im_skel_relabelled`` memmap.
+
+    Runs Filter + Label + Network once per session against the 3D yeast
+    fixture so that downstream VoxelReassigner tests can reuse the
+    result via ``make_voxel_reassign_imageinfo_3d``. Depends on
+    ``frangi_3d_path`` and ``label_3d_path`` only to serialize relative
+    to the existing cascade — the actual Network run uses its own
+    workdir to keep output paths isolated from any other test that
+    mutates the upstream workdirs.
+    """
+    del frangi_3d_path  # only used to serialize the cascade order
+    del label_3d_path
+    return _run_filter_label_network_for_session(
+        tmp_path_factory, FIXTURE_3D_PATH, "network_3d_session"
+    )
+
+
+@pytest.fixture(scope="session")
+def network_2d_path(
+    tmp_path_factory: pytest.TempPathFactory,
+    frangi_2d_path: Path,
+    label_2d_path: Path,
+) -> Path:
+    """Session-scoped: path to a precomputed 2D ``im_skel_relabelled`` memmap (see :func:`network_3d_path`)."""
+    del frangi_2d_path
+    del label_2d_path
+    return _run_filter_label_network_for_session(
+        tmp_path_factory, FIXTURE_2D_PATH, "network_2d_session"
+    )
+
+
+# ------------------------------------------------------------------
+# Hu-output fixtures (session-scoped) for downstream pipeline tests
+# ------------------------------------------------------------------
+
+
+def _run_hu_to_disk(im_info: ImInfo) -> Path:
+    """Run HuMomentTracking to write ``flow_vector_array.npy`` and return its path.
+
+    Hu writes ``flow_vector_array.npy`` via ``np.save`` (not a memmap),
+    so no handle-drop dance is needed for the ``.npy`` file itself.
+    The upstream Markers/Label/Frangi memmap handles must still be
+    released so Windows lets us read/copy them later.
+    """
+    h = HuMomentTracking(im_info, num_t=2, device="cpu")
+    h.run()
+    h.label_memmap = None
+    h.im_memmap = None
+    h.im_frangi_memmap = None
+    h.im_marker_memmap = None
+    h.im_distance_memmap = None
+    gc.collect()
+    return Path(im_info.pipeline_paths["flow_vector_array"])
+
+
+def _run_filter_label_markers_hu_for_session(
+    tmp_path_factory: pytest.TempPathFactory, source_image: Path, sub_name: str
+) -> Path:
+    """Build a session ImInfo, run Filter+Label+Markers+Hu, return the flow-vector-array path.
+
+    Used by ``hu_outputs_3d_path`` / ``hu_outputs_2d_path`` to
+    materialize Hu's ``flow_vector_array.npy`` once per session in its
+    own workdir. This is the heaviest new session fixture — full
+    upstream pipeline (Filter + Label + Markers + Hu).
+    """
+    workdir = tmp_path_factory.mktemp(sub_name)
+    info = _build_iminfo(source_image, workdir)
+    _run_filter_to_disk(info)
+    _run_label_to_disk(info)
+    _run_markers_to_disk(info)
+    return _run_hu_to_disk(info)
+
+
+@pytest.fixture(scope="session")
+def hu_outputs_3d_path(
+    tmp_path_factory: pytest.TempPathFactory,
+    frangi_3d_path: Path,
+    label_3d_path: Path,
+    markers_3d_paths: dict[str, Path],
+) -> Path:
+    """Session-scoped: path to a precomputed 3D ``flow_vector_array.npy``.
+
+    Runs Filter + Label + Markers + Hu once per session against the 3D
+    yeast fixture so that downstream VoxelReassigner tests can reuse
+    the result via ``make_voxel_reassign_imageinfo_3d``. Depends on the
+    upstream session caches only to serialize relative to the existing
+    cascade — the actual Hu run uses its own workdir.
+    """
+    del frangi_3d_path  # only used to serialize the cascade order
+    del label_3d_path
+    del markers_3d_paths
+    return _run_filter_label_markers_hu_for_session(
+        tmp_path_factory, FIXTURE_3D_PATH, "hu_outputs_3d_session"
+    )
+
+
+@pytest.fixture(scope="session")
+def hu_outputs_2d_path(
+    tmp_path_factory: pytest.TempPathFactory,
+    frangi_2d_path: Path,
+    label_2d_path: Path,
+    markers_2d_paths: dict[str, Path],
+) -> Path:
+    """Session-scoped: path to a precomputed 2D ``flow_vector_array.npy`` (see :func:`hu_outputs_3d_path`)."""
+    del frangi_2d_path
+    del label_2d_path
+    del markers_2d_paths
+    return _run_filter_label_markers_hu_for_session(
+        tmp_path_factory, FIXTURE_2D_PATH, "hu_outputs_2d_session"
+    )
+
+
+# ------------------------------------------------------------------
+# VoxelReassigner-input fixtures (per-test + module-scoped) for
+# ``VoxelReassigner`` characterization tests.
+# ------------------------------------------------------------------
+
+
+def _make_voxel_reassign_imageinfo_factory(
+    tmp_path: Path,
+    source_image: Path,
+    label_source: Path,
+    network_source: Path,
+    hu_source: Path,
+):
+    """Build a factory that produces fresh ImInfos with Label + Network + Hu outputs pre-populated.
+
+    VoxelReassigner reads three on-disk inputs through ImInfo's pipeline
+    tree (``voxel_reassignment.py:866-867`` for the two memmaps;
+    ``flow_interpolation.py:124-125`` for the .npy):
+
+    - ``im_instance_label`` (Label memmap) — used as ``obj_label_memmap``.
+    - ``im_skel_relabelled`` (Network memmap) — used as ``branch_label_memmap``.
+    - ``flow_vector_array.npy`` (Hu np.save'd array) — loaded by
+      ``FlowInterpolator._allocate_memory`` at construction time of
+      ``VoxelReassigner.__init__``.
+
+    The Frangi memmap is NOT copied in: VoxelReassigner does not
+    consume ``im_preprocessed`` directly, and the upstream stages have
+    already produced everything VoxelReassigner needs.
+
+    **Important**: ``flow_vector_array.npy`` MUST be copied in BEFORE
+    the caller constructs ``VoxelReassigner(info)``. Two
+    ``FlowInterpolator`` instances are constructed unconditionally in
+    ``VoxelReassigner.__init__`` (lines 108-109), and FlowInterpolator
+    loads the file immediately at construction (not lazily on
+    ``.run()``). The factory copies all three files in before
+    returning the ImInfo, so test code can construct the
+    VoxelReassigner immediately.
+
+    Each call:
+      1. Copies the raw source image into a fresh subdirectory.
+      2. Constructs an ImInfo (which sets up ``pipeline_paths``).
+      3. Copies the precomputed Label memmap into ``im_instance_label``.
+      4. Copies the precomputed Network memmap into ``im_skel_relabelled``.
+      5. Copies the precomputed Hu .npy into ``flow_vector_array``.
+
+    The returned ImInfo is ready for ``VoxelReassigner(info)`` without
+    re-running Filter, Label, Network, Markers, or Hu.
+    """
+    counter = {"n": 0}
+
+    def _factory() -> ImInfo:
+        counter["n"] += 1
+        sub = tmp_path / f"voxel_reassign_info_{counter['n']}"
+        sub.mkdir()
+        info = _build_iminfo(source_image, sub)
+        for src, key in (
+            (label_source, "im_instance_label"),
+            (network_source, "im_skel_relabelled"),
+            (hu_source, "flow_vector_array"),
+        ):
+            dst = Path(info.pipeline_paths[key])
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src, dst)
+        return info
+
+    return _factory
+
+
+@pytest.fixture
+def make_voxel_reassign_imageinfo_3d(
+    tmp_path: Path,
+    label_3d_path: Path,
+    network_3d_path: Path,
+    hu_outputs_3d_path: Path,
+):
+    """Factory: per-test 3D ImInfo with Label + Network + Hu outputs copied in.
+
+    Each call returns an ImInfo with isolated
+    ``im_branch_label_reassigned`` / ``im_obj_label_reassigned`` /
+    ``voxel_matches`` paths, so multiple VoxelReassigner runs in one
+    test do not collide.
+    """
+    return _make_voxel_reassign_imageinfo_factory(
+        tmp_path,
+        FIXTURE_3D_PATH,
+        label_3d_path,
+        network_3d_path,
+        hu_outputs_3d_path,
+    )
+
+
+@pytest.fixture
+def make_voxel_reassign_imageinfo_2d(
+    tmp_path: Path,
+    label_2d_path: Path,
+    network_2d_path: Path,
+    hu_outputs_2d_path: Path,
+):
+    """Factory: per-test 2D ImInfo with Label + Network + Hu outputs copied in."""
+    return _make_voxel_reassign_imageinfo_factory(
+        tmp_path,
+        FIXTURE_2D_PATH,
+        label_2d_path,
+        network_2d_path,
+        hu_outputs_2d_path,
+    )
+
+
+@pytest.fixture(scope="module")
+def make_voxel_reassign_imageinfo_3d_module(
+    tmp_path_factory: pytest.TempPathFactory,
+    label_3d_path: Path,
+    network_3d_path: Path,
+    hu_outputs_3d_path: Path,
+):
+    """Module-scoped variant of :func:`make_voxel_reassign_imageinfo_3d`.
+
+    Provides a factory whose ImInfos persist for the lifetime of the
+    test module. Use this when a module-scoped VoxelReassigner-output
+    fixture needs a stable workdir.
+    """
+    workdir = tmp_path_factory.mktemp("voxel_reassign_3d_module")
+    return _make_voxel_reassign_imageinfo_factory(
+        workdir,
+        FIXTURE_3D_PATH,
+        label_3d_path,
+        network_3d_path,
+        hu_outputs_3d_path,
+    )
+
+
+@pytest.fixture(scope="module")
+def make_voxel_reassign_imageinfo_2d_module(
+    tmp_path_factory: pytest.TempPathFactory,
+    label_2d_path: Path,
+    network_2d_path: Path,
+    hu_outputs_2d_path: Path,
+):
+    """Module-scoped variant of :func:`make_voxel_reassign_imageinfo_2d`."""
+    workdir = tmp_path_factory.mktemp("voxel_reassign_2d_module")
+    return _make_voxel_reassign_imageinfo_factory(
+        workdir,
+        FIXTURE_2D_PATH,
+        label_2d_path,
+        network_2d_path,
+        hu_outputs_2d_path,
     )

--- a/tests/test_voxel_reassignment.py
+++ b/tests/test_voxel_reassignment.py
@@ -1,0 +1,1132 @@
+"""Characterization tests for ``nellie.tracking.voxel_reassignment.VoxelReassigner``.
+
+Pins the wiki-documented invariants on both the 3D and 2D paths:
+
+- Output schema (``im_branch_label_reassigned`` + ``im_obj_label_reassigned``):
+  - Both reassigned outputs are int32 memmaps with the same shape as
+    the input ``im_skel_relabelled`` / ``im_instance_label`` memmaps.
+  - ``voxel_matches.npy`` is written when ``store_running_matches=True``
+    and is NOT written when False. Pin BOTH branches.
+  - When written, ``voxel_matches.npy`` is an object array of length
+    ``num_t - 1``; each entry is a 2-element list ``[best_prev, best_next]``
+    where each is a ``(K, D)`` array of ``match_coord_dtype``
+    (``uint16`` on yeast fixtures since max axis ≤ 65 536).
+  - ``match_coord_dtype`` selection: yeast fixtures are ``uint16``;
+    synthetic ``spatial_shape = (65_537, 8, 8)`` widens to ``uint32``.
+
+- Initialization invariant (t=0):
+  - ``reassigned_branch_memmap[0]`` equals ``branch_label_memmap[0]``
+    at non-zero voxels (background stays 0). Same for obj labels.
+
+- Vote / assignment behavior:
+  - Reassigned voxels at t+1 are a strict subset of
+    ``label_memmap[t+1] > 0`` — no phantom labels at background.
+  - ``max_refine_iterations=1`` produces fewer (or equal) total
+    assignments than the default ``max_refine_iterations=3``.
+
+- 4-tier tree backend (CPU-only paths):
+  - ``device='cpu'`` end-to-end: post-run ``self.device_type == "cpu"``.
+  - Empty input to ``_build_tree`` → ``backend="cpu"``, ``tree=None``,
+    ``coords_real_scaled=None``; ``_query_tree`` on this handle
+    returns ``(empty float32, empty int64)``.
+  - Default CPU path: ``backend="cpu"`` with populated tree;
+    ``_query_tree`` returns expected shapes.
+  - ``cpu_bruteforce`` fallback: monkeypatch ``cKDTree`` to raise
+    ``MemoryError`` once → ``backend="cpu_bruteforce"``; end-to-end
+    run still produces reassigned outputs.
+
+- Empty-input edge cases:
+  - Empty mask at frame N → loop breaks; later frames stay all-zero
+    in both reassigned outputs.
+  - ``match_voxels`` on empty inputs returns the documented empty
+    shape contract.
+
+- Distance / weighting primitives:
+  - ``_distance_threshold`` drops matches ≥
+    ``flow_interpolator_fw.max_distance_um``.
+  - ``_vote_targets`` minimal numeric example: 3 sources, 1 target →
+    inverse-distance weighted vote picks the higher-weighted label.
+  - ``_select_best_pairs`` returns 1-best per target voxel.
+
+- ``no_t`` short-circuit: ``run()`` early-returns; no files written.
+
+- Input mutation: raw + ``im_instance_label`` + ``im_skel_relabelled``
+  + ``flow_vector_array.npy`` are all byte-identical pre/post.
+
+- Viewer callback: no-op when ``viewer=None``; called once per frame
+  with the formatted message when ``viewer`` is a stub.
+
+- **Architecture characterization (PRE-Slice 3 contract — these will
+  be INVERTED in Slice 3 of #101)**:
+  - Cross-frame mutation for ``_build_tree`` GPU OOM (Site 1):
+    simulate GPU state post-construction, then trigger a
+    ``MemoryError`` from the GPU KDTree class → assert
+    ``self.device_type == "cpu"`` after recovery.
+  - Cross-frame mutation for ``_query_tree`` GPU OOM (Sites 3+4):
+    simulate GPU state, rig the GPU tree's ``query`` to raise
+    ``MemoryError`` → assert ``self.device_type == "cpu"`` after
+    recovery.
+  - Latent silent-fallback for ``_query_tree`` non-OOM exceptions:
+    rig the GPU query to raise ``ValueError`` → current behavior
+    swallows the exception silently and switches to CPU. Slice 3
+    will INVERT this (the new contract is ``ValueError`` should
+    PROPAGATE out of ``run()``).
+
+The Network ``im_skel_relabelled`` and Hu ``flow_vector_array.npy``
+that ``VoxelReassigner`` consumes are precomputed once per session by
+``conftest.network_*_path`` and ``conftest.hu_outputs_*_path``;
+per-test ImInfos copy in 3 files (Label memmap + Network memmap + Hu
+.npy) into a fresh working directory so each test gets isolated
+``im_branch_label_reassigned`` / ``im_obj_label_reassigned`` /
+``voxel_matches.npy`` targets.
+"""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import nellie.tracking.voxel_reassignment as vr_module
+from nellie.im_info.verifier import ImInfo
+from nellie.tracking.voxel_reassignment import VoxelReassigner, _TreeHandle
+
+
+# -------------------------------------------------------------------------
+# Helpers
+# -------------------------------------------------------------------------
+
+
+def _release_voxel_reassigner(v: VoxelReassigner) -> None:
+    """Drop a VoxelReassigner's memmap references and force gc.
+
+    Mirrors ``test_hu_tracking._release_hu``. Required on Windows:
+    input memmaps can stay file-locked until the handles are dropped,
+    blocking later overwrites of the same paths.
+    """
+    v.branch_label_memmap = None
+    v.obj_label_memmap = None
+    v.reassigned_branch_memmap = None
+    v.reassigned_obj_memmap = None
+    v.flow_interpolator_fw = None
+    v.flow_interpolator_bw = None
+    gc.collect()
+
+
+def _run_voxel_reassign(info: ImInfo, **kwargs) -> VoxelReassigner:
+    """Construct + run ``VoxelReassigner`` on ``info``; return the instance.
+
+    Always pinned to CPU for deterministic behavior. Caller is
+    responsible for calling ``_release_voxel_reassigner`` after
+    inspecting the on-disk outputs.
+    """
+    kwargs.setdefault("device", "cpu")
+    v = VoxelReassigner(info, num_t=2, **kwargs)
+    v.run()
+    return v
+
+
+# -------------------------------------------------------------------------
+# Module-scoped: run VoxelReassigner once on each fixture and share outputs
+# across the read-only invariant tests (shape, dtype, init invariant, ...).
+# -------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def voxel_reassign_outputs_3d(make_voxel_reassign_imageinfo_3d_module) -> dict:
+    info = make_voxel_reassign_imageinfo_3d_module()
+    v = _run_voxel_reassign(info)
+    branch_path = Path(info.pipeline_paths["im_branch_label_reassigned"])
+    obj_path = Path(info.pipeline_paths["im_obj_label_reassigned"])
+    matches_path = Path(info.pipeline_paths["voxel_matches"])
+    branch_arr = np.array(v.reassigned_branch_memmap)
+    obj_arr = np.array(v.reassigned_obj_memmap)
+    branch_label_arr = np.array(v.branch_label_memmap)
+    obj_label_arr = np.array(v.obj_label_memmap)
+    branch_dtype = v.reassigned_branch_memmap.dtype
+    obj_dtype = v.reassigned_obj_memmap.dtype
+    branch_shape = v.reassigned_branch_memmap.shape
+    obj_shape = v.reassigned_obj_memmap.shape
+    spatial_shape = v.spatial_shape
+    match_coord_dtype = v.match_coord_dtype
+    device_type = v.device_type
+    _release_voxel_reassigner(v)
+    return {
+        "info": info,
+        "branch_path": branch_path,
+        "obj_path": obj_path,
+        "matches_path": matches_path,
+        "branch_arr": branch_arr,
+        "obj_arr": obj_arr,
+        "branch_label_arr": branch_label_arr,
+        "obj_label_arr": obj_label_arr,
+        "branch_dtype": branch_dtype,
+        "obj_dtype": obj_dtype,
+        "branch_shape": branch_shape,
+        "obj_shape": obj_shape,
+        "spatial_shape": spatial_shape,
+        "match_coord_dtype": match_coord_dtype,
+        "device_type": device_type,
+    }
+
+
+@pytest.fixture(scope="module")
+def voxel_reassign_outputs_2d(make_voxel_reassign_imageinfo_2d_module) -> dict:
+    info = make_voxel_reassign_imageinfo_2d_module()
+    v = _run_voxel_reassign(info)
+    branch_path = Path(info.pipeline_paths["im_branch_label_reassigned"])
+    obj_path = Path(info.pipeline_paths["im_obj_label_reassigned"])
+    branch_arr = np.array(v.reassigned_branch_memmap)
+    obj_arr = np.array(v.reassigned_obj_memmap)
+    branch_dtype = v.reassigned_branch_memmap.dtype
+    obj_dtype = v.reassigned_obj_memmap.dtype
+    branch_shape = v.reassigned_branch_memmap.shape
+    obj_shape = v.reassigned_obj_memmap.shape
+    device_type = v.device_type
+    _release_voxel_reassigner(v)
+    return {
+        "info": info,
+        "branch_path": branch_path,
+        "obj_path": obj_path,
+        "branch_arr": branch_arr,
+        "obj_arr": obj_arr,
+        "branch_dtype": branch_dtype,
+        "obj_dtype": obj_dtype,
+        "branch_shape": branch_shape,
+        "obj_shape": obj_shape,
+        "device_type": device_type,
+    }
+
+
+# -------------------------------------------------------------------------
+# End-to-end smoke tests
+# -------------------------------------------------------------------------
+
+
+def test_runs_end_to_end_3d(voxel_reassign_outputs_3d) -> None:
+    """3D yeast fixture: both reassigned memmaps exist; int32; shape matches input."""
+    out = voxel_reassign_outputs_3d
+    assert out["branch_path"].exists(), (
+        f"im_branch_label_reassigned not found at {out['branch_path']}"
+    )
+    assert out["obj_path"].exists(), (
+        f"im_obj_label_reassigned not found at {out['obj_path']}"
+    )
+    assert out["branch_dtype"] == np.int32, (
+        f"3D branch reassigned dtype is {out['branch_dtype']}, expected int32"
+    )
+    assert out["obj_dtype"] == np.int32, (
+        f"3D obj reassigned dtype is {out['obj_dtype']}, expected int32"
+    )
+    # Shape check: matches input label shape (T, Z, Y, X) on the 3D fixture.
+    assert out["branch_shape"] == out["branch_label_arr"].shape, (
+        f"3D branch reassigned shape {out['branch_shape']} != input "
+        f"{out['branch_label_arr'].shape}"
+    )
+    assert out["obj_shape"] == out["obj_label_arr"].shape, (
+        f"3D obj reassigned shape {out['obj_shape']} != input "
+        f"{out['obj_label_arr'].shape}"
+    )
+
+
+def test_runs_end_to_end_2d(voxel_reassign_outputs_2d) -> None:
+    """2D yeast fixture: both reassigned memmaps exist; int32; shape matches input."""
+    out = voxel_reassign_outputs_2d
+    assert out["branch_path"].exists()
+    assert out["obj_path"].exists()
+    assert out["branch_dtype"] == np.int32
+    assert out["obj_dtype"] == np.int32
+    # 2D fixture is (T, Y, X) so spatial dim count is 2.
+    assert len(out["branch_shape"]) == 3
+    assert len(out["obj_shape"]) == 3
+
+
+# -------------------------------------------------------------------------
+# voxel_matches.npy: written / not-written contract
+# -------------------------------------------------------------------------
+
+
+def test_voxel_matches_written_when_store_running_matches_true(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """``store_running_matches=True`` writes ``voxel_matches.npy``.
+
+    Pins the on-by-default behavior — the demo script in
+    ``scripts/voxel_reassignment_demo.py`` (per User Story 19) reads
+    this file post-run.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = _run_voxel_reassign(info, store_running_matches=True)
+    matches_path = Path(info.pipeline_paths["voxel_matches"])
+    assert matches_path.exists(), (
+        f"voxel_matches.npy not written when store_running_matches=True "
+        f"({matches_path})"
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_voxel_matches_not_written_when_store_running_matches_false(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """``store_running_matches=False`` does NOT write ``voxel_matches.npy``.
+
+    Pin the off-arm so a future refactor doesn't silently start writing
+    the file regardless of the flag.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = _run_voxel_reassign(info, store_running_matches=False)
+    matches_path = Path(info.pipeline_paths["voxel_matches"])
+    assert not matches_path.exists(), (
+        f"voxel_matches.npy was written even though "
+        f"store_running_matches=False ({matches_path})"
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_voxel_matches_structure_3d(voxel_reassign_outputs_3d) -> None:
+    """``voxel_matches.npy`` is an object array of length ``num_t - 1``.
+
+    Stored via ``np.array(self.running_matches, dtype=object)`` at
+    ``voxel_reassignment.py:1062``. Because the inner element is a
+    Python list of two equal-shaped ``(K, D)`` numpy arrays, the
+    ``dtype=object`` cast recursively flattens to a 4-D object array of
+    shape ``(num_t - 1, 2, K, D)`` (numpy walks the nested
+    list+ndarray structure when forced to ``object``). The semantic
+    contract is preserved (``[best_prev, best_next]`` per frame pair),
+    but the numeric ``match_coord_dtype`` (``uint16`` here) is hidden
+    behind the object dtype after ``np.load``. We pin the array shape
+    + value range to characterize the contract; Slice 2/3 may rework
+    the storage format to preserve the inner dtype on disk.
+    """
+    out = voxel_reassign_outputs_3d
+    matches_path = out["matches_path"]
+    assert matches_path.exists(), "voxel_matches.npy missing for module fixture"
+    matches = np.load(matches_path, allow_pickle=True)
+    assert matches.dtype == object, (
+        f"voxel_matches.npy dtype is {matches.dtype}, expected object"
+    )
+    # num_t = 2 for the fixture, so length is num_t - 1 == 1.
+    assert matches.shape[0] == 1, (
+        f"voxel_matches.npy length is {matches.shape[0]}, expected 1 "
+        f"(num_t - 1)"
+    )
+    # Shape: (num_t-1, 2, K, D). The "2" is [best_prev, best_next].
+    assert matches.shape[1] == 2, (
+        f"Expected 2-element list per frame pair; got {matches.shape[1]}"
+    )
+    # 3D fixture has 3 spatial dims (Z, Y, X).
+    assert matches.shape[3] == 3
+    # K can vary per frame pair; just assert > 0.
+    assert matches.shape[2] > 0, "voxel_matches has zero-length match list"
+    # Best-prev and best-next must agree on K (same number of pairs).
+    best_prev = matches[0, 0]
+    best_next = matches[0, 1]
+    assert best_prev.shape == best_next.shape
+    # Values are voxel indices into the spatial shape; on the yeast
+    # fixture every value fits in uint16 (max axis <= 65 536). Cast
+    # back to uint16 to confirm no overflow/truncation occurred during
+    # the np.array(dtype=object) flattening.
+    spatial_max = max(out["spatial_shape"])
+    assert int(np.asarray(best_prev).max()) < spatial_max
+    assert int(np.asarray(best_next).max()) < spatial_max
+    assert int(np.asarray(best_prev).min()) >= 0
+    assert int(np.asarray(best_next).min()) >= 0
+
+
+def test_match_coord_dtype_is_uint16_on_yeast_fixture(
+    voxel_reassign_outputs_3d,
+) -> None:
+    """Yeast fixture max axis ≤ 65 536 → ``match_coord_dtype == uint16``."""
+    out = voxel_reassign_outputs_3d
+    assert max(out["spatial_shape"]) <= 65_536
+    assert out["match_coord_dtype"] == np.uint16, (
+        f"Expected uint16 for yeast fixture (max axis <= 65 536); "
+        f"got {out['match_coord_dtype']}"
+    )
+
+
+def test_match_coord_dtype_synthetic_widens_to_uint32(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Synthetic ``spatial_shape = (65_537, 8, 8)`` widens to ``uint32``.
+
+    Pins the wiki-documented gotcha at
+    ``voxel_reassignment.py:395-403``: bumping any axis past 65 535
+    flips the saved ``.npy`` to ``uint32`` (and past 4 294 967 295 to
+    ``uint64``). We monkeypatch ``self.spatial_shape`` and call
+    ``_select_match_coord_dtype()`` directly, which is the cleanest
+    pin without building a multi-GB synthetic fixture.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v._allocate_memory()
+    v.spatial_shape = (65_537, 8, 8)
+    assert v._select_match_coord_dtype() == np.uint32
+    # And a synthetic shape past uint32 → uint64.
+    v.spatial_shape = (int(np.iinfo(np.uint32).max) + 2, 8, 8)
+    assert v._select_match_coord_dtype() == np.uint64
+    _release_voxel_reassigner(v)
+
+
+# -------------------------------------------------------------------------
+# Initialization invariant (t=0)
+# -------------------------------------------------------------------------
+
+
+def test_t0_initialization_branch_label_3d(voxel_reassign_outputs_3d) -> None:
+    """``reassigned_branch_memmap[0]`` == ``branch_label_memmap[0]`` at non-zero voxels.
+
+    The init block at ``voxel_reassignment.py:999-1003`` writes
+    ``reassigned_branch_memmap[0][argwhere(branch_label > 0)] =
+    branch_label[0][argwhere(...)]``. Background voxels stay at 0.
+    """
+    out = voxel_reassign_outputs_3d
+    branch_label_t0 = out["branch_label_arr"][0]
+    branch_reassigned_t0 = out["branch_arr"][0]
+    nonzero_mask = branch_label_t0 > 0
+    background_mask = ~nonzero_mask
+    np.testing.assert_array_equal(
+        branch_reassigned_t0[nonzero_mask],
+        branch_label_t0[nonzero_mask],
+    )
+    assert (branch_reassigned_t0[background_mask] == 0).all(), (
+        "Branch reassigned t=0 background voxels are non-zero"
+    )
+
+
+def test_t0_initialization_obj_label_3d(voxel_reassign_outputs_3d) -> None:
+    """``reassigned_obj_memmap[0]`` == ``obj_label_memmap[0]`` at non-zero voxels.
+
+    Mirrors the branch-label init test for the obj-label cascade
+    (``voxel_reassignment.py:1005-1009``).
+    """
+    out = voxel_reassign_outputs_3d
+    obj_label_t0 = out["obj_label_arr"][0]
+    obj_reassigned_t0 = out["obj_arr"][0]
+    nonzero_mask = obj_label_t0 > 0
+    background_mask = ~nonzero_mask
+    np.testing.assert_array_equal(
+        obj_reassigned_t0[nonzero_mask],
+        obj_label_t0[nonzero_mask],
+    )
+    assert (obj_reassigned_t0[background_mask] == 0).all()
+
+
+# -------------------------------------------------------------------------
+# Vote / assignment behavior
+# -------------------------------------------------------------------------
+
+
+def test_reassigned_voxels_subset_of_label_at_t1_branch_3d(
+    voxel_reassign_outputs_3d,
+) -> None:
+    """Reassigned branch voxels at t+1 ⊆ ``branch_label_memmap[t+1] > 0``.
+
+    ``_vote_assign_labels_for_frame`` (lines 940-948) gates on
+    ``label_memmap[t + 1][...] > 0`` before assigning anything. No
+    "phantom labels" should appear at background voxels in t+1.
+    """
+    out = voxel_reassign_outputs_3d
+    reassigned_t1 = out["branch_arr"][1] > 0
+    label_t1 = out["branch_label_arr"][1] > 0
+    assert np.all(reassigned_t1 <= label_t1), (
+        "Branch reassigned at t=1 has labels at voxels that are background "
+        "in branch_label_memmap[1]"
+    )
+
+
+def test_reassigned_voxels_subset_of_label_at_t1_obj_3d(
+    voxel_reassign_outputs_3d,
+) -> None:
+    """Same subset invariant for the obj-label cascade."""
+    out = voxel_reassign_outputs_3d
+    reassigned_t1 = out["obj_arr"][1] > 0
+    label_t1 = out["obj_label_arr"][1] > 0
+    assert np.all(reassigned_t1 <= label_t1), (
+        "Obj reassigned at t=1 has labels at voxels that are background "
+        "in obj_label_memmap[1]"
+    )
+
+
+def test_max_refine_iterations_one_vs_three(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """``max_refine_iterations=1`` produces ≤ assignments vs default 3.
+
+    Each iteration of the vote loop in ``_vote_assign_labels_for_frame``
+    (lines 953-980) only considers voxels that are still 0 at t+1 from
+    prior iterations. Multiple iterations let later candidates fill in
+    voxels that were skipped (via the ``unassigned`` mask at line 956).
+    Setting ``max_refine_iterations=1`` truncates after one round, so
+    the count of reassigned voxels at t=1 must be ≤ the default-3 count.
+    """
+    info_one = make_voxel_reassign_imageinfo_3d()
+    v_one = _run_voxel_reassign(info_one, max_refine_iterations=1)
+    branch_one_count = int(np.count_nonzero(v_one.reassigned_branch_memmap[1]))
+    obj_one_count = int(np.count_nonzero(v_one.reassigned_obj_memmap[1]))
+    _release_voxel_reassigner(v_one)
+
+    info_three = make_voxel_reassign_imageinfo_3d()
+    v_three = _run_voxel_reassign(info_three, max_refine_iterations=3)
+    branch_three_count = int(np.count_nonzero(v_three.reassigned_branch_memmap[1]))
+    obj_three_count = int(np.count_nonzero(v_three.reassigned_obj_memmap[1]))
+    _release_voxel_reassigner(v_three)
+
+    assert branch_one_count <= branch_three_count, (
+        f"max_refine_iterations=1 gave more branch assignments "
+        f"({branch_one_count}) than max_refine_iterations=3 "
+        f"({branch_three_count})"
+    )
+    assert obj_one_count <= obj_three_count, (
+        f"max_refine_iterations=1 gave more obj assignments "
+        f"({obj_one_count}) than max_refine_iterations=3 ({obj_three_count})"
+    )
+
+
+# -------------------------------------------------------------------------
+# 4-tier tree backend (CPU paths)
+# -------------------------------------------------------------------------
+
+
+def test_device_cpu_post_run_device_type_is_cpu(
+    voxel_reassign_outputs_3d,
+) -> None:
+    """End-to-end ``device='cpu'`` run: ``self.device_type == "cpu"`` after run."""
+    assert voxel_reassign_outputs_3d["device_type"] == "cpu"
+
+
+def test_build_tree_empty_input_returns_cpu_none_handle(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Empty input to ``_build_tree`` → ``backend="cpu"``, ``tree=None``, ``coords_real_scaled=None``.
+
+    Pins the explicit short-circuit at ``voxel_reassignment.py:238-239``.
+    Also verifies that ``_query_tree`` on this empty handle returns
+    the documented empty arrays (lines 271-272 + 275-276).
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+    handle = v._build_tree(np.empty((0, 3), dtype=np.float32))
+    assert isinstance(handle, _TreeHandle)
+    assert handle.backend == "cpu"
+    assert handle.tree is None
+    assert handle.coords_real_scaled is None
+
+    # Query with non-empty coords against an empty handle; the early
+    # short-circuit at line 274-276 returns empty arrays.
+    dist, idx = v._query_tree(handle, np.array([[1.0, 2.0, 3.0]], dtype=np.float32))
+    assert dist.shape == (0,)
+    assert idx.shape == (0,)
+    assert dist.dtype == np.float32
+    assert idx.dtype == np.int64
+    _release_voxel_reassigner(v)
+
+
+def test_build_tree_default_cpu_path_returns_cpu_with_tree(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Default CPU path: ``backend="cpu"`` with populated ``tree``; ``_query_tree`` works."""
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+    coords = np.array(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], dtype=np.float32
+    )
+    handle = v._build_tree(coords)
+    assert handle.backend == "cpu"
+    assert handle.tree is not None
+    # Query a single point near the second tree point; expect a small
+    # distance and idx == 1.
+    query = np.array([[4.1, 5.1, 6.1]], dtype=np.float32)
+    dist, idx = v._query_tree(handle, query)
+    assert dist.shape == (1,)
+    assert idx.shape == (1,)
+    assert idx[0] == 1
+    assert dist[0] < 1.0
+    _release_voxel_reassigner(v)
+
+
+def test_cpu_bruteforce_fallback_on_ckdtree_memory_error(
+    make_voxel_reassign_imageinfo_3d, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``cKDTree`` raising ``MemoryError`` once → ``backend="cpu_bruteforce"``.
+
+    Pins the explicit fallback path at
+    ``voxel_reassignment.py:260-268``. We monkeypatch
+    ``nellie.tracking.voxel_reassignment.cKDTree`` to raise
+    ``MemoryError`` once so ``_build_tree`` lands on the
+    ``cpu_bruteforce`` branch. The end-to-end run should still produce
+    reassigned outputs (the bruteforce CPU path delegates to
+    ``_query_bruteforce_cpu`` at line 314-315).
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+
+    real_ckdtree = vr_module.cKDTree
+    state = {"raised": False}
+
+    def flaky_ckdtree(*args, **kwargs):
+        if not state["raised"]:
+            state["raised"] = True
+            raise MemoryError("simulated cKDTree allocation failure")
+        return real_ckdtree(*args, **kwargs)
+
+    monkeypatch.setattr(vr_module, "cKDTree", flaky_ckdtree)
+
+    # Build a non-empty tree directly and verify the fallback engages.
+    coords = np.array(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], dtype=np.float32
+    )
+    handle = v._build_tree(coords)
+    assert handle.backend == "cpu_bruteforce", (
+        f"Expected cpu_bruteforce after MemoryError; got {handle.backend!r}"
+    )
+    assert handle.tree is None
+    assert handle.coords_real_scaled is not None
+
+    # Query against the bruteforce handle should still resolve via
+    # _query_bruteforce_cpu (line 314-315).
+    query = np.array([[4.1, 5.1, 6.1]], dtype=np.float32)
+    dist, idx = v._query_tree(handle, query)
+    assert dist.shape == (1,)
+    assert idx.shape == (1,)
+    assert idx[0] == 1
+    assert dist[0] < 1.0
+    _release_voxel_reassigner(v)
+
+
+# -------------------------------------------------------------------------
+# Empty-input edge cases
+# -------------------------------------------------------------------------
+
+
+def test_empty_master_mask_breaks_loop(
+    make_voxel_reassign_imageinfo_3d, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty mask at frame N → loop breaks; later frames stay all-zero.
+
+    Pins the early-break at ``voxel_reassignment.py:1027-1029``. We
+    monkeypatch ``_get_master_mask`` to return an all-False mask at
+    every call (effectively making frame 0's mask empty too), and
+    assert the post-run reassigned memmaps are all zero at t=1
+    (frame 0 still gets the init-block writes at line 999-1009 because
+    ``argwhere`` of an empty mask is empty, but the loop short-circuits
+    before any t=1 writes).
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+
+    def empty_mask(_self, _t):
+        return np.zeros(_self.spatial_shape, dtype=bool)
+
+    monkeypatch.setattr(VoxelReassigner, "_get_master_mask", empty_mask)
+    v.run()
+
+    # The init block (lines 999-1009) writes from the actual label
+    # memmaps, NOT from the master mask. So t=0 still gets initialized.
+    # The loop short-circuits at line 1027-1029 before t=1 writes happen,
+    # so t=1 stays all zero.
+    assert (v.reassigned_branch_memmap[1] == 0).all(), (
+        "branch reassigned t=1 has non-zero entries even though "
+        "_get_master_mask returned all-False"
+    )
+    assert (v.reassigned_obj_memmap[1] == 0).all(), (
+        "obj reassigned t=1 has non-zero entries even though "
+        "_get_master_mask returned all-False"
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_match_voxels_empty_inputs_returns_empty_pair(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """``match_voxels`` early-returns on empty inputs (lines 778-781).
+
+    The early-return at lines 778-781 returns a 2-tuple of empty
+    int64 arrays of shape ``(0, D)``. Note: this branch does NOT
+    return a distances array (only 2 elements), unlike the populated
+    branch which returns 3. We pin the actual returned shape contract.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v._allocate_memory()  # populate spatial_shape
+    vox_prev = np.empty((0, 3), dtype=int)
+    vox_next = np.array([[1, 2, 3], [4, 5, 6]], dtype=int)
+    result = v.match_voxels(vox_prev, vox_next, t=0)
+    # The early-return at lines 778-781 returns a 2-tuple.
+    assert len(result) == 2, (
+        f"Expected 2-tuple from empty match_voxels early-return, got "
+        f"{len(result)}-tuple"
+    )
+    empty_prev, empty_next = result
+    assert empty_prev.shape == (0, 3)
+    assert empty_next.shape == (0, 3)
+    assert empty_prev.dtype == np.int64
+    assert empty_next.dtype == np.int64
+    _release_voxel_reassigner(v)
+
+
+# -------------------------------------------------------------------------
+# Distance / weighting primitives
+# -------------------------------------------------------------------------
+
+
+def test_distance_threshold_drops_above_max_distance(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """``_distance_threshold`` drops matches with physical distance ≥ ``max_distance_um``.
+
+    Construct synthetic ``vox_prev_matched`` / ``vox_next_matched``
+    arrays where some pairs have a small displacement (kept) and some
+    have a large displacement (dropped). The threshold lives at
+    ``voxel_reassignment.py:744-745``.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+    # Don't need _allocate_memory for _distance_threshold; it uses
+    # flow_interpolator_fw.scaling and .max_distance_um directly.
+    scaling = np.asarray(v.flow_interpolator_fw.scaling, dtype=np.float32)
+    max_um = float(v.flow_interpolator_fw.max_distance_um)
+
+    # Construct 4 pairs: 2 close (kept) and 2 far (dropped).
+    # close: displacement of ~1 voxel, scaled distance well under max_um.
+    # far:   displacement ~big, scaled distance well over max_um.
+    far_voxels = int(max_um / float(scaling.min()) * 10) + 100
+    vox_prev = np.array(
+        [
+            [10, 20, 30],
+            [11, 21, 31],
+            [100, 100, 100],
+            [200, 200, 200],
+        ],
+        dtype=np.int64,
+    )
+    vox_next = np.array(
+        [
+            [10, 20, 31],  # ~1 voxel away
+            [11, 22, 31],  # ~1 voxel away
+            [100, 100, 100 + far_voxels],
+            [200, 200, 200 + far_voxels],
+        ],
+        dtype=np.int64,
+    )
+
+    prev_valid, next_valid, dist_valid = v._distance_threshold(vox_prev, vox_next)
+    # Should keep only the first two pairs.
+    assert prev_valid.shape[0] == 2, (
+        f"Expected 2 pairs to survive threshold; got {prev_valid.shape[0]}"
+    )
+    assert next_valid.shape[0] == 2
+    assert dist_valid.shape == (2,)
+    np.testing.assert_array_equal(prev_valid, vox_prev[:2])
+    np.testing.assert_array_equal(next_valid, vox_next[:2])
+    _release_voxel_reassigner(v)
+
+
+def test_vote_targets_inverse_distance_weighted(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """``_vote_targets`` minimal numeric example: 3 sources voting on 1 target.
+
+    Distances ``[1.0, 2.0, 3.0]`` with labels ``[10, 10, 20]``:
+    - Label 10 weight: ``1/1 + 1/2 = 1.5``.
+    - Label 20 weight: ``1/3 ≈ 0.333``.
+    Label 10 wins. We pin via direct call to ``_vote_targets``
+    (lines 429-467).
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v._allocate_memory()  # populate spatial_shape
+
+    # All three sources point at the same target voxel.
+    target_coord = np.array([10, 20, 30], dtype=np.int64)
+    target_coords = np.tile(target_coord, (3, 1))
+    source_labels = np.array([10, 10, 20], dtype=np.int64)
+    distances = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+
+    best_targets, best_labels, best_candidate_idx = v._vote_targets(
+        target_coords, source_labels, distances
+    )
+    # One unique target voxel → one winning entry.
+    assert len(best_targets) == 1
+    assert best_labels[0] == 10, (
+        f"Vote winner is {best_labels[0]} (expected 10 — sum of inverse "
+        f"distances 1/1 + 1/2 > 1/3)"
+    )
+    # The best candidate index for label 10 should point at the lowest-distance
+    # candidate (idx 0, distance 1.0).
+    assert best_candidate_idx[0] == 0, (
+        f"best_candidate_idx is {best_candidate_idx[0]} (expected 0 — "
+        f"the lowest-distance source for label 10)"
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_select_best_pairs_returns_one_best_per_target(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """``_select_best_pairs`` returns 1-best per target voxel (lowest distance).
+
+    Construct synthetic input where 3 sources point at the same target
+    with distances ``[5.0, 1.0, 3.0]``. The returned pairs must be
+    exactly the (target, lowest-distance-source) pair — i.e. source idx
+    1 (distance 1.0).
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v._allocate_memory()
+
+    sources = np.array(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        dtype=np.int64,
+    )
+    target_coord = np.array([10, 20, 30], dtype=np.int64)
+    targets = np.tile(target_coord, (3, 1))
+    distances = np.array([5.0, 1.0, 3.0], dtype=np.float64)
+
+    best_prev, best_next = v._select_best_pairs(sources, targets, distances)
+    assert best_prev.shape == (1, 3)
+    assert best_next.shape == (1, 3)
+    np.testing.assert_array_equal(best_prev[0], sources[1])
+    np.testing.assert_array_equal(best_next[0], target_coord)
+    _release_voxel_reassigner(v)
+
+
+# -------------------------------------------------------------------------
+# no_t short-circuit
+# -------------------------------------------------------------------------
+
+
+def test_no_t_short_circuit(make_voxel_reassign_imageinfo_3d) -> None:
+    """``no_t`` ImInfo: ``run()`` early-returns; no reassigned files written.
+
+    ``__init__`` short-circuits at lines 84-101 when ``info.no_t`` is
+    True (returning early, before constructing the FlowInterpolators);
+    ``run()`` short-circuits at lines 1074-1076. We mutate
+    ``info.no_t = True`` BEFORE constructing the VoxelReassigner so
+    the FlowInterpolator dependency is bypassed entirely.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    info.no_t = True
+    v = VoxelReassigner(info, num_t=1, device="cpu")
+    v.run()  # must not raise
+    branch_path = Path(info.pipeline_paths["im_branch_label_reassigned"])
+    obj_path = Path(info.pipeline_paths["im_obj_label_reassigned"])
+    matches_path = Path(info.pipeline_paths["voxel_matches"])
+    assert not branch_path.exists(), (
+        "im_branch_label_reassigned should not exist for a no-T dataset"
+    )
+    assert not obj_path.exists(), (
+        "im_obj_label_reassigned should not exist for a no-T dataset"
+    )
+    assert not matches_path.exists(), (
+        "voxel_matches.npy should not exist for a no-T dataset"
+    )
+
+
+# -------------------------------------------------------------------------
+# Input mutation: hash-before / hash-after
+# -------------------------------------------------------------------------
+
+
+def test_input_files_not_mutated_3d(make_voxel_reassign_imageinfo_3d) -> None:
+    """Hash all 4 inputs before/after ``VoxelReassigner.run()``.
+
+    The reassigned outputs (``im_branch_label_reassigned``,
+    ``im_obj_label_reassigned``, ``voxel_matches.npy``) are different
+    files; the inputs (raw image, ``im_instance_label``,
+    ``im_skel_relabelled``, ``flow_vector_array.npy``) must be
+    byte-identical pre/post.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    raw_path = Path(info.im_path)
+    label_path = Path(info.pipeline_paths["im_instance_label"])
+    skel_path = Path(info.pipeline_paths["im_skel_relabelled"])
+    flow_path = Path(info.pipeline_paths["flow_vector_array"])
+
+    raw_before = hashlib.sha256(raw_path.read_bytes()).hexdigest()
+    label_before = hashlib.sha256(label_path.read_bytes()).hexdigest()
+    skel_before = hashlib.sha256(skel_path.read_bytes()).hexdigest()
+    flow_before = hashlib.sha256(flow_path.read_bytes()).hexdigest()
+
+    v = _run_voxel_reassign(info)
+    _release_voxel_reassigner(v)
+
+    assert hashlib.sha256(raw_path.read_bytes()).hexdigest() == raw_before, (
+        "VoxelReassigner mutated the raw input"
+    )
+    assert hashlib.sha256(label_path.read_bytes()).hexdigest() == label_before, (
+        "VoxelReassigner mutated the Label input memmap"
+    )
+    assert hashlib.sha256(skel_path.read_bytes()).hexdigest() == skel_before, (
+        "VoxelReassigner mutated the Network im_skel_relabelled input memmap"
+    )
+    assert hashlib.sha256(flow_path.read_bytes()).hexdigest() == flow_before, (
+        "VoxelReassigner mutated the Hu flow_vector_array.npy input"
+    )
+
+
+# -------------------------------------------------------------------------
+# Viewer callback
+# -------------------------------------------------------------------------
+
+
+class _StubViewer:
+    """Minimal viewer stub: records every write to ``status``."""
+
+    def __init__(self) -> None:
+        self.status_writes: list[str] = []
+
+    @property
+    def status(self) -> str:
+        return self.status_writes[-1] if self.status_writes else ""
+
+    @status.setter
+    def status(self, value: str) -> None:
+        self.status_writes.append(value)
+
+
+def test_viewer_status_callback(make_voxel_reassign_imageinfo_2d) -> None:
+    """``viewer.status`` is set once per frame; ``viewer=None`` is a no-op.
+
+    The viewer-update branch in ``_run_reassignment`` (lines 1016-1017)
+    only runs when ``self.viewer is not None``. Pin both arms in one
+    test:
+      - Build a VoxelReassigner with ``viewer=None`` and assert the
+        run completes cleanly (no AttributeError).
+      - Build a VoxelReassigner with a stub viewer and assert
+        ``status`` is written exactly ``num_t - 1`` times (one per
+        frame pair). With ``num_t=2`` the expected count is 1.
+    """
+    # No-op arm: viewer=None.
+    info_none = make_voxel_reassign_imageinfo_2d()
+    v_none = VoxelReassigner(info_none, num_t=2, device="cpu", viewer=None)
+    v_none.run()  # must not raise
+    _release_voxel_reassigner(v_none)
+
+    # Stub-viewer arm: assert per-frame writes.
+    info_stub = make_voxel_reassign_imageinfo_2d()
+    stub = _StubViewer()
+    v_stub = VoxelReassigner(info_stub, num_t=2, device="cpu", viewer=stub)
+    v_stub.run()
+    # The loop iterates from t=0 to t < num_t-1, so for num_t=2 there
+    # is exactly one iteration. The status string is
+    # "Reassigning voxels. Frame: t+1 of num_t" → "Frame: 1 of 2".
+    assert len(stub.status_writes) == 1, (
+        f"Expected viewer.status set once per frame pair (1 write for "
+        f"num_t=2); got {len(stub.status_writes)}: {stub.status_writes}"
+    )
+    assert "Frame: 1 of 2" in stub.status_writes[0], (
+        f"Expected formatted status string; got {stub.status_writes[0]!r}"
+    )
+    assert "Reassigning voxels" in stub.status_writes[0]
+    _release_voxel_reassigner(v_stub)
+
+
+# -------------------------------------------------------------------------
+# Architecture characterization (PRE-Slice 3 contract)
+#
+# These tests pin the CURRENT behavior — Slice 3 (#101) will INVERT
+# them. Each test is marked with a comment indicating the upcoming
+# Slice 3 contract change. The current behavior is:
+#   - Inner GPU OOM in _build_tree calls self._switch_to_cpu(), which
+#     mutates self.device_type / self.xp / self._cp / self._gpu_kdtree_cls
+#     and persists across all later frames.
+#   - Inner GPU OOM in _query_tree (gpu and gpu_bruteforce branches)
+#     same story.
+#   - The _query_tree GPU branch's `except Exception` (line 287)
+#     swallows non-OOM exceptions silently and still calls
+#     _switch_to_cpu, hiding bugs like dtype mismatches.
+# Slice 3 fixes all three sites under Option A2: drop _switch_to_cpu;
+# keep the local algorithmic fallback (per-call CPU rebuild); add
+# explicit `if not adaptive_run.is_oom_error(exc): raise` so non-OOM
+# exceptions propagate.
+# -------------------------------------------------------------------------
+
+
+class _FakeGpuKDTreeOOM:
+    """A class-callable that raises ``MemoryError`` on instantiation.
+
+    Stands in for ``cupyx.scipy.spatial.cKDTree`` so the GPU-build
+    branch in ``_build_tree`` (lines 241-258) takes the OOM-fallback
+    path without needing cupy installed.
+    """
+
+    def __init__(self, *args, **kwargs):
+        raise MemoryError("simulated GPU KDTree allocation failure")
+
+
+def _simulate_gpu_state(v: VoxelReassigner, *, kdtree_cls=None) -> None:
+    """Mutate a CPU-constructed VoxelReassigner into a "GPU state".
+
+    CI has no cupy, so we simulate the post-resolve GPU state by
+    directly assigning the attributes that ``_resolve_backend`` would
+    set on a real GPU run. Using ``np`` for ``self.xp`` / ``self._cp``
+    is fine because the GPU code paths in ``_build_tree`` /
+    ``_query_tree`` only call ``.asarray`` (numpy supports it) before
+    delegating to the rigged tree class / tree.query. The actual
+    ``MemoryError`` is raised by the rigged class/method, so we never
+    hit a real cupy code path.
+    """
+    v.device_type = "cuda"
+    v.xp = np
+    v._cp = np
+    v._gpu_kdtree_cls = kdtree_cls
+
+
+def test_build_tree_gpu_oom_simulates_cross_frame_mutation(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Cascade Site 1: ``_build_tree`` GPU OOM mutates ``self.device_type`` to "cpu".
+
+    PRE-Slice 3 contract: ``_switch_to_cpu`` is called inside
+    ``_build_tree`` (line 250) when the GPU KDTree class raises
+    ``MemoryError``. The mutation persists across all later frames.
+
+    Slice 3 of #101 (Option A2) will INVERT this: drop the
+    ``_switch_to_cpu`` call; keep the local CPU KDTree fallback
+    within the same call. The new contract: ``self.device_type``
+    stays at the value it had before the OOM (no cross-frame
+    mutation from inner cascades).
+
+    Setup: CPU-construct a VoxelReassigner (so the FlowInterpolator
+    dependency loads cleanly), then mutate it into a "GPU state" so
+    the GPU branch of ``_build_tree`` is taken. The rigged
+    ``_gpu_kdtree_cls`` raises ``MemoryError`` on instantiation,
+    triggering the ``_is_oom_error`` → ``_switch_to_cpu`` fallback at
+    lines 247-250. Call ``_build_tree`` directly (not ``.run()``) so
+    we don't have to set up the full per-frame state.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+    _simulate_gpu_state(v, kdtree_cls=_FakeGpuKDTreeOOM)
+
+    coords = np.array(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32
+    )
+    handle = v._build_tree(coords)
+    # The OOM fallback path lands on the CPU KDTree (line 261) after
+    # _switch_to_cpu (line 250). The handle backend is "cpu" because
+    # _switch_to_cpu set device_type="cpu" so the gpu_bruteforce branch
+    # (line 253) is skipped.
+    assert handle.backend == "cpu", (
+        f"Expected cpu fallback after GPU KDTree OOM; got {handle.backend!r}"
+    )
+    # PRE-SLICE-3 CONTRACT: cross-frame mutation. Slice 3 will INVERT
+    # this assertion (the new contract is `self.device_type == "cuda"`,
+    # because `_switch_to_cpu` is removed under Option A2).
+    assert v.device_type == "cpu", (
+        f"PRE-Slice-3 contract: _build_tree GPU OOM should call "
+        f"_switch_to_cpu and mutate device_type to 'cpu'; got "
+        f"{v.device_type!r}. Slice 3 of #101 will invert this contract."
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_query_tree_gpu_oom_simulates_cross_frame_mutation(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Cascade Sites 3+4: ``_query_tree`` GPU OOM mutates ``self.device_type`` to "cpu".
+
+    PRE-Slice 3 contract: ``_switch_to_cpu`` is called inside
+    ``_query_tree`` (line 290) when the GPU tree's ``query`` method
+    raises ``MemoryError``. The mutation persists across all later
+    frames.
+
+    Slice 3 of #101 (Option A2) will INVERT this: drop the
+    ``_switch_to_cpu`` call; keep the local CPU rebuild fallback
+    (lines 291-293). The new contract: ``self.device_type`` stays
+    unchanged (no cross-frame mutation from inner cascades).
+
+    Setup: CPU-construct, simulate GPU state, manually craft a
+    ``_TreeHandle(backend="gpu", tree=fake_tree, ...)`` whose
+    ``tree.query`` raises ``MemoryError`` on first call. Pass it to
+    ``_query_tree`` directly.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+    _simulate_gpu_state(v, kdtree_cls=None)
+
+    coords_real = np.array(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32
+    )
+
+    class _FakeGpuTree:
+        def query(self, *args, **kwargs):
+            raise MemoryError("simulated GPU tree query OOM")
+
+    handle = _TreeHandle(
+        backend="gpu", tree=_FakeGpuTree(), coords_real_scaled=coords_real
+    )
+    query = np.array([[4.1, 5.1, 6.1]], dtype=np.float32)
+    dist, idx = v._query_tree(handle, query)
+    # Local CPU rebuild fallback (lines 291-293) produces a real result.
+    assert dist.shape == (1,)
+    assert idx.shape == (1,)
+    assert idx[0] == 1  # nearest to (4.1, 5.1, 6.1) is row 1
+    # PRE-SLICE-3 CONTRACT: cross-frame mutation. Slice 3 will INVERT
+    # this assertion (the new contract is `self.device_type == "cuda"`).
+    assert v.device_type == "cpu", (
+        f"PRE-Slice-3 contract: _query_tree GPU OOM should call "
+        f"_switch_to_cpu and mutate device_type to 'cpu'; got "
+        f"{v.device_type!r}. Slice 3 of #101 will invert this contract."
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_query_tree_gpu_value_error_silent_fallback(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Latent bug: ``_query_tree`` GPU silently swallows non-OOM exceptions.
+
+    PRE-Slice 3 contract: the GPU branch's ``except Exception`` at
+    line 287 catches ALL exceptions, not just OOM. Only the
+    ``_free_gpu_memory()`` call is gated on ``_is_oom_error`` (line
+    288); ``_switch_to_cpu`` (line 290) runs unconditionally. So a
+    non-OOM exception (e.g., a ``ValueError`` from a dtype mismatch)
+    silently flips the backend to CPU instead of propagating.
+
+    Slice 3 of #101 (Option A2) will INVERT this: add explicit
+    ``if not adaptive_run.is_oom_error(exc): raise`` so non-OOM
+    exceptions propagate out of ``run()`` instead of being swallowed.
+    The new contract is: ``ValueError`` should propagate.
+
+    Setup: same as the GPU OOM test, but rig ``tree.query`` to raise
+    ``ValueError`` instead of ``MemoryError``.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(info, num_t=2, device="cpu")
+    _simulate_gpu_state(v, kdtree_cls=None)
+
+    coords_real = np.array(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32
+    )
+
+    class _FakeGpuTreeValueError:
+        def query(self, *args, **kwargs):
+            raise ValueError("simulated non-OOM GPU error (e.g., dtype mismatch)")
+
+    handle = _TreeHandle(
+        backend="gpu",
+        tree=_FakeGpuTreeValueError(),
+        coords_real_scaled=coords_real,
+    )
+    query = np.array([[4.1, 5.1, 6.1]], dtype=np.float32)
+
+    # Current behavior: ValueError is swallowed; CPU fallback rebuilds
+    # the tree and returns a result. No exception propagates.
+    dist, idx = v._query_tree(handle, query)
+    assert dist.shape == (1,)
+    assert idx.shape == (1,)
+    # PRE-SLICE-3 CONTRACT: silent fallback to CPU. Slice 3 will INVERT
+    # this — the new contract is `with pytest.raises(ValueError):
+    # v._query_tree(handle, query)`.
+    assert v.device_type == "cpu", (
+        f"PRE-Slice-3 latent bug contract: _query_tree GPU non-OOM "
+        f"exception should be silently swallowed and trigger "
+        f"_switch_to_cpu; got device_type={v.device_type!r}. Slice 3 "
+        f"of #101 will invert this — ValueError will propagate."
+    )
+    _release_voxel_reassigner(v)

--- a/tests/test_voxel_reassignment.py
+++ b/tests/test_voxel_reassignment.py
@@ -139,6 +139,10 @@ def _run_voxel_reassign(info: ImInfo, **kwargs) -> VoxelReassigner:
 def voxel_reassign_outputs_3d(make_voxel_reassign_imageinfo_3d_module) -> dict:
     info = make_voxel_reassign_imageinfo_3d_module()
     v = _run_voxel_reassign(info)
+    assert v.reassigned_branch_memmap is not None
+    assert v.reassigned_obj_memmap is not None
+    assert v.branch_label_memmap is not None
+    assert v.obj_label_memmap is not None
     branch_path = Path(info.pipeline_paths["im_branch_label_reassigned"])
     obj_path = Path(info.pipeline_paths["im_obj_label_reassigned"])
     matches_path = Path(info.pipeline_paths["voxel_matches"])
@@ -177,6 +181,8 @@ def voxel_reassign_outputs_3d(make_voxel_reassign_imageinfo_3d_module) -> dict:
 def voxel_reassign_outputs_2d(make_voxel_reassign_imageinfo_2d_module) -> dict:
     info = make_voxel_reassign_imageinfo_2d_module()
     v = _run_voxel_reassign(info)
+    assert v.reassigned_branch_memmap is not None
+    assert v.reassigned_obj_memmap is not None
     branch_path = Path(info.pipeline_paths["im_branch_label_reassigned"])
     obj_path = Path(info.pipeline_paths["im_obj_label_reassigned"])
     branch_arr = np.array(v.reassigned_branch_memmap)
@@ -465,12 +471,16 @@ def test_max_refine_iterations_one_vs_three(
     """
     info_one = make_voxel_reassign_imageinfo_3d()
     v_one = _run_voxel_reassign(info_one, max_refine_iterations=1)
+    assert v_one.reassigned_branch_memmap is not None
+    assert v_one.reassigned_obj_memmap is not None
     branch_one_count = int(np.count_nonzero(v_one.reassigned_branch_memmap[1]))
     obj_one_count = int(np.count_nonzero(v_one.reassigned_obj_memmap[1]))
     _release_voxel_reassigner(v_one)
 
     info_three = make_voxel_reassign_imageinfo_3d()
     v_three = _run_voxel_reassign(info_three, max_refine_iterations=3)
+    assert v_three.reassigned_branch_memmap is not None
+    assert v_three.reassigned_obj_memmap is not None
     branch_three_count = int(np.count_nonzero(v_three.reassigned_branch_memmap[1]))
     obj_three_count = int(np.count_nonzero(v_three.reassigned_obj_memmap[1]))
     _release_voxel_reassigner(v_three)
@@ -628,6 +638,8 @@ def test_empty_master_mask_breaks_loop(
     # memmaps, NOT from the master mask. So t=0 still gets initialized.
     # The loop short-circuits at line 1027-1029 before t=1 writes happen,
     # so t=1 stays all zero.
+    assert v.reassigned_branch_memmap is not None
+    assert v.reassigned_obj_memmap is not None
     assert (v.reassigned_branch_memmap[1] == 0).all(), (
         "branch reassigned t=1 has non-zero entries even though "
         "_get_master_mask returned all-False"
@@ -687,6 +699,7 @@ def test_distance_threshold_drops_above_max_distance(
     v = VoxelReassigner(info, num_t=2, device="cpu")
     # Don't need _allocate_memory for _distance_threshold; it uses
     # flow_interpolator_fw.scaling and .max_distance_um directly.
+    assert v.flow_interpolator_fw is not None
     scaling = np.asarray(v.flow_interpolator_fw.scaling, dtype=np.float32)
     max_um = float(v.flow_interpolator_fw.max_distance_um)
 
@@ -786,7 +799,13 @@ def test_select_best_pairs_returns_one_best_per_target(
     targets = np.tile(target_coord, (3, 1))
     distances = np.array([5.0, 1.0, 3.0], dtype=np.float64)
 
-    best_prev, best_next = v._select_best_pairs(sources, targets, distances)
+    # NOTE: ``_select_best_pairs`` returns a 2-tuple in the populated
+    # branch but a 3-tuple in the empty-input branch (lines 412-417 in
+    # voxel_reassignment.py). The shape divergence is real and pinned
+    # in the empty-input characterization above; here we hit the
+    # populated branch with non-empty inputs.
+    result = v._select_best_pairs(sources, targets, distances)
+    best_prev, best_next = result[0], result[1]
     assert best_prev.shape == (1, 3)
     assert best_next.shape == (1, 3)
     np.testing.assert_array_equal(best_prev[0], sources[1])

--- a/wiki/outputs/dechaos-voxel-reassignment.md
+++ b/wiki/outputs/dechaos-voxel-reassignment.md
@@ -1,0 +1,298 @@
+---
+created: 2026-05-08
+modified: 2026-05-08
+---
+
+# Dechaos scan — `nellie/tracking/voxel_reassignment.py` (`VoxelReassigner`)
+
+One-shot review of the next pipeline stage to receive the test+hoist treatment. Findings are intended to feed an upcoming three-slice PRD that mirrors PRDs #77 (Network), #84 (Markers), and #91 (Hu). Durable items should be folded into [[voxel-reassignment]] gotchas during/after the slice PRs.
+
+**Reference templates**: Markers (`nellie/segmentation/mocap_marking.py`, post-#90) and Hu (`nellie/tracking/hu_tracking.py`, post-#97) are the closest mirrors — same backend pattern, same outer `adaptive_run.mode_candidates` cascade. Use them as the after-picture. The wiki [[voxel-reassignment]] article already flags the half-hoisted backend helpers and the cross-frame `_switch_to_cpu` mutation as gotchas; this scan operationalizes those into a refactor plan.
+
+---
+
+## Pass 1 — System Map
+
+- **Stage 6 of 7** in `nellie/run.py` (line 105). Two in-tree call sites: `run.py:105` (`VoxelReassigner(im_info, device=device)` — no `low_memory`, no `num_t`) and `nellie_napari/nellie_processor.py:485` (`**step_kwargs` from `get_reassign_params()`, which exposes 7 fields: `num_t`, `store_running_matches`, `max_refine_iterations`, `device`, `low_memory`, `max_query_points`, `max_bruteforce_pairs`).
+- **Class**: `VoxelReassigner`, single class plus a `_TreeHandle` dataclass in `nellie/tracking/voxel_reassignment.py`, 1117 lines.
+- **Inputs (memmaps via `ImInfo.pipeline_paths`)**: `im_skel_relabelled` (from Network), `im_instance_label` (from Label), plus an indirect dependency on `flow_vector_array.npy` (from Hu, consumed via `FlowInterpolator`). All three converge here. The raw image is also accessed via `FlowInterpolator._allocate_memory` (`flow_interpolation.py:121`).
+- **Outputs (memmaps + npy)**:
+  - `im_branch_label_reassigned` (memmap, int32)
+  - `im_obj_label_reassigned` (memmap, int32)
+  - `voxel_matches.npy` (np.save'd object array of `[best_prev, best_next]` pairs per frame, only when `store_running_matches=True`)
+- **External deps**: `nellie.utils.adaptive_run` (canonical backend helpers), `numpy`, `scipy.spatial.cKDTree`, optionally `cupy` + `cupyx.scipy.spatial.cKDTree` (NOT `cupyx.scipy.ndimage` — this stage doesn't use ndimage), `nellie.tracking.flow_interpolation.FlowInterpolator`, `nellie.im_info.verifier.ImInfo`.
+- **Tests**: none. `tests/test_voxel_reassignment.py` does not exist; deleted in the May 2026 scaffold rebuild and not restored. Wiki ([[now]] watch list) confirms tracking modules are unpinned.
+- **Architectural shape**: per-frame outer loop (`_run_reassignment`, 994–1062) → per-frame `match_voxels` (758–843) builds 0–2 trees and runs forward + backward `FlowInterpolator.interpolate_coord` → `_match_voxels_to_centroids` (622–660) does nearest-neighbor query against a `_TreeHandle` → `_vote_assign_labels_for_frame` (907–988) assigns labels via inverse-distance weighted vote. Outer `run()` (1064–1112) uses `adaptive_run.mode_candidates` for `(dev, low_memory)` retries. **Three nested layers of inner adaptive degradation on top of that** — see Pass 3.
+
+## Pass 2 — Boundary Scan
+
+| # | Mixed concern | Where | Suggested seam |
+|---|---|---|---|
+| 1 | Local backend resolution duplicates `adaptive_run` | `_resolve_backend` (137–151), `_try_import_cupy` (153–179), `_is_oom_error` (181–191), `_free_gpu_memory` (193–199), `_switch_to_cpu` (201–210) | Delete; call `adaptive_run.resolve_backend` / canonical helpers. Same change Network's PR #83, Markers' PR #90, Hu's PR #97 made. **Caveat**: `_try_import_cupy` here returns `(cupy, cupyx.scipy.spatial.cKDTree)` not `(cupy, cupyx.scipy.ndimage)` — the canonical `adaptive_run.try_import_cupy` returns the latter. Keep a small local `_get_gpu_kdtree_cls()` helper to fetch the spatial KDTree class after `adaptive_run.resolve_backend` returns. See Pass 8 / Slice 3. |
+| 2 | `self._cp` attribute is fully redundant with `self.xp` on GPU | 80, 144, 150, 194–197, 209, 215, 241, 244, 282, 284–285, 296, 332 | When `self.device_type == "cuda"`, `self._cp == self.xp`. Drop the attribute; replace ~12 callsites with `self.xp` (or local `cp = self.xp` for readability). Same shape as Markers' `self.use_gpu` cleanup (PR #89) and Hu's `self._on_gpu` cleanup (PR #96). |
+| 3 | Dev driver in module body | `__main__` block (1115–1117) — already a no-op `logger.info` pointer | Delete (Network/Markers/Hu all did the same in their cleanup slices). |
+| 4 | Constructor init-block duplication between `no_t` early-return path and main path | 84–101 vs 103–131. ~14 lines of `self.X = None` repeated almost verbatim | Optional cosmetic cleanup; defer if Slice 2 gets too heavy. The placeholder values in the `no_t` path are dead anyway (the `run()` method early-returns on `no_t` at line 1074, before any of these are accessed). |
+| 5 | Per-call inner OOM cascade with cross-frame backend mutation | `_build_tree` (237–268), `_query_tree` (270–317) — 4 `_switch_to_cpu` callsites total (250, 252, 290, 309); persist across all later frames | See Pass 3 / Pass 8. **THE central architectural decision for Slice 3.** |
+| 6 | Per-chunk OOM cascade (clean local-only fallback) | `_query_bruteforce_gpu` (340–360), `_query_bruteforce_cpu` (377–391) — chunk_size is halved on OOM, no `self.*` mutation | Keep as-is. This is the *good* per-call OOM pattern — fully local, no cross-frame state. Just route `self._is_oom_error` → `adaptive_run.is_oom_error` and `self._free_gpu_memory()` → `adaptive_run.free_gpu_memory(self.xp)`. |
+| 7 | I/O mixed with dispatch in main loop | `_run_reassignment` (994–1062) accumulates `running_matches` in memory and `np.save`'s a single `.npy` file at the end (line 1062) | Keep — single-write boundary. Same shape as Hu's stage-end `np.save` of `flow_vector_array`. |
+
+## Pass 3 — Responsibility Scan
+
+The class wears multiple hats — backend management, KDTree gating across 4 backends (gpu, gpu_bruteforce, cpu, cpu_bruteforce), forward/backward flow matching, vote-based label assignment, pipeline orchestration. Most hats are inherent to the algorithm and the "fat class" pattern is consistent with Filter/Label/Network/Markers/Hu. Cleanups below are **dead code, redundant attributes, and architectural duplication — not split candidates**.
+
+| Item | Location | Status | Action |
+|---|---|---|---|
+| `_get_t` | 849–857 | Dead. `__init__` (103–105) already resolves `self.num_t`; the `if self.num_t is None` guard is unreachable because both `__init__` and `run()` early-return on `self.im_info.no_t`. The method is also called once from `_run_reassignment` (995), where `self.num_t` is already set. | Delete. (Network deleted analogue in #82; Markers in #89; Hu in #96.) |
+| `self.shape = None`, `self.spatial_shape = None`, `self.match_coord_dtype = None` | 96–98, 129–131 | All three overwritten in `_allocate_memory` (868–871). | Drop the init lines from main path; keep in `no_t` early-return path only if external code reads them (audit). |
+| `self.debug = None` | 94, 120 | Never read, never set elsewhere. | Drop. (Same pattern as Network #82, Markers #89, Hu #96.) |
+| `self._cp` attribute | 80, 209, 215 + ~10 read sites | Redundant — equals `self.xp` when `device_type == "cuda"`, `None` when `"cpu"`. Tracked alongside backend at 4 sites (`_resolve_backend`, `_set_backend`, `_switch_to_cpu`, `_try_import_cupy`). | Drop; use `self.xp` directly when on GPU; replace `self._cp is None` checks with `self.device_type != "cuda"`. ~12 callsites. |
+| `_build_tree` inner OOM/error cascade | 237–268. Two `_switch_to_cpu` calls (lines 250, 252) — one for OOM, one for any other GPU exception. **Mutates `self.xp` / `self.device_type` / `self._cp` / `self._gpu_kdtree_cls` in place** via `_switch_to_cpu()`; persists across all later frames. | Same wiki-flagged footgun ("`_switch_to_cpu` calls persist across frames"). | See Pass 8 / Slice 3. |
+| `_query_tree` GPU inner OOM cascade | 280–293. `_switch_to_cpu` at line 290 runs on **any** GPU exception (not just OOM — the `if self._is_oom_error(exc)` only gates `_free_gpu_memory()`, not `_switch_to_cpu`). | Latent silent-fallback bug: a non-OOM GPU error (e.g., array dtype mismatch) flips the backend permanently with only a `logger.warning` to show for it. | See Pass 8 / Slice 3. Same characterization gap as Hu Cascade A. |
+| `_query_tree` GPU bruteforce inner OOM cascade | 295–312. `_switch_to_cpu` at line 309 (same shape — runs on any exception, not just OOM). | Same footgun as the GPU branch above. | See Pass 8 / Slice 3. |
+| `_query_bruteforce_gpu` chunk-level OOM | 354–360. Halves `chunk_size` and retries; raises if `chunk_size <= 1`. **No `self.*` mutation.** | Clean per-call adaptive pattern. | Keep; just route through canonical `adaptive_run.is_oom_error` / `free_gpu_memory`. |
+| `_query_bruteforce_cpu` chunk-level OOM | 388–391. Same pattern, CPU `MemoryError`. | Clean. | Keep. |
+| `_warned_gpu_fallback` flag | 81, 204–206, 216 | Tied to `_switch_to_cpu`; reset by `_set_backend`. Once-per-instance log rate-limit. | If Slice 3 deletes `_switch_to_cpu`, the flag still has a use (rate-limit per-call fallback warnings). Move the `if not self._warned_gpu_fallback: logger.warning(...); self._warned_gpu_fallback = True` block to a tiny helper (e.g., `_warn_gpu_fallback(reason)`) called from each fallback site. |
+
+The wiki gotchas already flag the cross-frame mutation ("`_switch_to_cpu` calls persist across frames"). The dechaos finding refines this: the cascade has **three layers** — outer (`run()` `mode_candidates`), inner-build (`_build_tree`), inner-query (`_query_tree`). The inner-build and inner-query layers BOTH mutate device state, and `_query_tree` does so on **any** exception (not just OOM), which is bug-adjacent.
+
+## Pass 4 — Dependency Scan
+
+| # | Type | Issue | Impact |
+|---|---|---|---|
+| 1 | **No constructor dual-API** (matches Hu post-#97) | 8 named kwargs (`num_t`, `viewer`, `store_running_matches`, `max_refine_iterations`, `device`, `low_memory`, `max_query_points`, `max_bruteforce_pairs`) with sensible defaults. Napari widget (`nellie_settings.py:299–312`, `get_reassign_params` at 711–719) maps 1:1 to constructor args. **No `prefer_gpu`-style overlap.** | **No pre-slice decision needed**, unlike Markers PRD #84. |
+| 2 | `device` accepts undocumented `"cuda"` alias | Constructor docstring says `{"auto","cpu","gpu"}` (61); `_resolve_backend` (139) silently accepts `"cuda"` too. | `adaptive_run.normalize_device` is the canonical source; `_set_backend` already routes through it (213). Backend hoist (Slice 3) makes the constructor go through it too, fixing the gap. |
+| 3 | Constructor stores raw `self.device` before normalization | line 71 `self.device = device`; `_resolve_backend` re-normalizes inside (138). Markers (post-#90) and Hu (post-#97) both normalize once via `adaptive_run.normalize_device` at constructor entry. | Slice 3 normalizes via `adaptive_run.normalize_device(device)` at constructor entry, matching Network/Markers/Hu. |
+| 4 | `FlowInterpolator` is constructed unconditionally even on no_t | 86–87: in `no_t` path, `self.flow_interpolator_fw = None`. So actually it's NOT constructed on no_t — that's correct. False alarm. | None. |
+| 5 | `low_memory` re-clamps `max_query_points` and `max_bruteforce_pairs` in TWO places | constructor (77–79) and `_set_low_memory` (218–224) | Acceptable — `_base_*` attributes hold the originals so re-clamping is idempotent. Pin the clamping behavior in tests. |
+| 6 | Outer `run()` re-normalizes device but `_set_backend` re-normalizes again | `run()` line 1077 (`adaptive_run.normalize_device(self.device)`); `_set_backend` line 213 also normalizes the per-iteration `dev` from `mode_candidates`. | Belt-and-suspenders; not a bug. |
+| 7 | Hidden FlowInterpolator dependency on `flow_vector_array.npy` | `FlowInterpolator._initialize` (305) → `_allocate_memory` (113–125) → `np.load` of `flow_vector_array.npy`. **VoxelReassigner instantiates two FlowInterpolators in `__init__` (108–109)**, which means upstream Hu must have completed BEFORE `VoxelReassigner(im_info)` is even called — not just before `.run()`. | Tests must materialize `flow_vector_array.npy` before constructing. Affects fixture ordering. Document in test docstring. |
+| 8 | `match_coord_dtype = None` in `no_t` early-return + populated by `_select_match_coord_dtype()` | The `no_t` path (98) sets it to None and returns; the main path defers to `_allocate_memory` (871). Internal callers (`_run_reassignment` line 1041) defensively `or np.uint16` it. | Acceptable — defensive `or np.uint16` covers the gap. Pin in test. |
+
+## Pass 5 — Contract Scan
+
+Pinnable invariants for Slice 1 tests (no test pins any of these today):
+
+**Output schema**
+
+- `im_branch_label_reassigned`: int32 memmap, same shape as `im_skel_relabelled`. Values ⊆ {0, …, max_branch_id}.
+- `im_obj_label_reassigned`: int32 memmap, same shape as `im_instance_label`. Values ⊆ {0, …, max_obj_id}.
+- `voxel_matches.npy`: object-dtype numpy array of length `num_t - 1` when `store_running_matches=True`; each entry is `[best_prev, best_next]` where each is a `(K, D)` array of `match_coord_dtype` (uint16/uint32/uint64 based on `max(spatial_shape)`).
+- File NOT written when `store_running_matches=False`. **Pin both branches** so refactors don't silently start writing.
+
+**Initialization (t=0)**
+
+- `reassigned_branch_memmap[0] == branch_label_memmap[0]` and `reassigned_obj_memmap[0] == obj_label_memmap[0]` only at non-background voxels (`> 0`). Background stays 0. Pin both label types.
+
+**Vote semantics**
+
+- `_vote_assign_labels_for_frame` (907–988): only target voxels with non-zero label in `label_memmap[t+1]` ever get a reassigned label (940). Reassigned voxels at t+1 inherit a non-zero label from a non-zero source at t. Pin: a target voxel that's background in `label_memmap[t+1]` stays 0 in the reassigned output regardless of how many candidate matches point to it.
+- `max_refine_iterations` controls how many vote rounds happen per frame pair (953). Setting `max_refine_iterations=1` produces fewer assignments than the default 3 on dense overlapping flows. Pin one per-iteration count change.
+
+**4-tier tree backend**
+
+- `_build_tree` returns a `_TreeHandle` whose `.backend` is one of `{"cpu", "cpu_bruteforce", "gpu", "gpu_bruteforce"}`.
+- Empty input → `backend="cpu"`, `tree=None`, `coords_real_scaled=None` (line 239). Pin: `_query_tree` on this handle returns `(empty float32, empty int64)`.
+- CPU normal path (`device_type == "cpu"`): builds `cKDTree(coords_real_scaled)` (261); falls to `cpu_bruteforce` on `MemoryError` (262–268). **Pin both paths** by monkeypatching `cKDTree`.
+- `_can_use_bruteforce` (319–324): rejects when `n_real * n_query > max_bruteforce_pairs` — falls through to CPU KDTree.
+
+**Distance & weighting**
+
+- `_compute_error_distance` (405–410): physical units (`coords * self.flow_interpolator_fw.scaling`).
+- `_distance_threshold` (720–756): drops matches with physical distance ≥ `flow_interpolator_fw.max_distance_um` (744–745).
+- `_vote_targets` (429–467): weight is `1.0 / (distance + 1e-6)` (438) — **inverse-distance with epsilon floor**. Two-stage `lexsort` over `ravel_multi_index`-flattened coords. Pin one minimal numeric example so refactors of the lexsort don't silently change winner selection.
+
+**`match_coord_dtype` selection** (`_select_match_coord_dtype` 395–403)
+
+- `max(spatial_shape) <= 65 536` → `uint16`.
+- `<= 4_294_967_296` → `uint32`.
+- else → `uint64`.
+- Wiki gotcha: bumping image size past 65 535 in any axis silently widens the saved `.npy`. Pin the threshold in test (synthetic shape with axis = 65 537 → uint32 saved).
+
+**Empty-input edge cases**
+
+- Frame pair where either `master_mask_prev` or `master_mask_next` is empty → loop breaks (1027–1029); all subsequent frame pairs unreassigned. Pin: a single empty frame stops the run; later frames stay zero.
+- Frame pair with no valid matches → loop breaks (1032–1034). Same termination semantics.
+- `match_voxels` returns empty if either `vox_prev` or `vox_next` is empty (778–781). Pin shape `(0, D)` int64 + `(0,)` float64.
+
+**Backend semantics**
+
+- `device='cpu'` start: `_TreeHandle.backend ∈ {"cpu", "cpu_bruteforce"}`. `self.device_type == "cpu"` throughout. **No fallback events.** Pin.
+- `device='gpu'` start (skip-if-no-cupy): `self.device_type == "cuda"`, `_TreeHandle.backend ∈ {"gpu", "gpu_bruteforce", "cpu", "cpu_bruteforce"}` depending on cascade. **Pin** the post-run `self.device_type` (today: mutates to `"cpu"` after first GPU OOM; under Option A2 below: stays `"cuda"`).
+
+**`no_t` short-circuit**
+
+- `im_info.no_t == True` → `__init__` (84–101) sets `flow_interpolator_fw/bw = None`, `running_matches = []`, `branch_label_memmap = None`, etc. `run()` (1074) early-returns with a logger info; no files written. Pin both: file-not-created and run-returns-cleanly.
+
+**Inputs not mutated**
+
+- `im_skel_relabelled`, `im_instance_label`, `flow_vector_array.npy` unchanged after `run()` (compare hashes pre/post). Same pattern as Hu Slice 1.
+
+## Pass 6 — Composability Scan
+
+Mostly **already factored** — `nellie.utils.adaptive_run` is the canonical backend primitive. Findings:
+
+- The 4-tier tree-backend pattern (`_TreeHandle` + `_build_tree` + `_query_tree` + `_can_use_bruteforce`) is unique to this stage; no extraction warranted. The wiki documents the cascade clearly.
+- `_vote_targets` (429–467), `_assign_unique_matches` (662–718), `_select_best_pairs` (412–427) are clean reusable lexsort-over-`ravel_multi_index` primitives. Single consumer today; **no extraction warranted** — defer until a second consumer materializes (the Hierarchy stage may want similar patterns; revisit then).
+- `_match_forward` / `_match_backward` (473–620) share enough structure to potentially fold into one helper with a `direction` flag. **Don't** — readability of forward-vs-backward reads better as two named methods, even with some duplication. Defer indefinitely.
+- The outer `run()` cascade pattern (resolve device order → `mode_candidates` → try / `is_gpu_unavailable_error` / `is_oom_error` / log / continue) is **now repeated nearly verbatim across Filter/Label/Network/Markers/Hu/VoxelReassigner** — about 25 lines of structural sameness per stage. Cross-stage extraction candidate, deferred per queue policy until all 4 untested stages reach the same shape (Hierarchy is the last one).
+- The three inner OOM cascades (`_build_tree`, `_query_tree` GPU, `_query_tree` GPU bruteforce) duplicate the outer cascade's error-classification logic. See Pass 3 / Pass 8.
+
+## Pass 7 — Testability Scan
+
+**Current state**: zero tests (test file deleted in scaffold rebuild). Slice 1 fills this gap before Slices 2–3 touch structure.
+
+**Fixture cascade extension** (`tests/conftest.py`): the cascade is currently Filter (session) → Label (session) → Network/Markers (per-test factories) → Hu (per-test factory + Markers session cache from Hu's PR #95). VoxelReassigner needs the **outputs of BOTH Network AND Hu** (`im_skel_relabelled` from Network, `flow_vector_array.npy` from Hu) PLUS the existing Label memmap. **Add**:
+
+- `network_3d_path` / `network_2d_path` session-scoped fixtures (run Filter+Label+Network once per session, return `Path` to `im_skel_relabelled` memmap). Pattern mirrors `label_*_path` (254–281) and `markers_*_paths` (525–559).
+- `hu_outputs_3d_path` / `hu_outputs_2d_path` session-scoped fixtures (run Filter+Label+Markers+Hu once per session, return `Path` to `flow_vector_array.npy`). Heaviest new fixture — full upstream pipeline.
+- `_make_voxel_reassign_imageinfo_factory` that copies in 3 memmap files: `im_instance_label` (from label cache), `im_skel_relabelled` (from network cache, NEW), and `flow_vector_array.npy` (from hu cache, NEW). Mirrors `_make_hu_imageinfo_factory` (568–616) shape, just with different keys.
+- Per-test (`make_voxel_reassign_imageinfo_2d/3d`) and module-scoped (`_module` variants) factories.
+
+Estimated ~150–180 added lines to conftest. **Heavier than Hu's Slice 1** because Hu only added a Markers session cache (one new upstream stage); VoxelReassigner adds Network AND Hu session caches (two new upstream stages). The Hu session cache already exists upstream-wise (markers cache) but doesn't currently materialize the `flow_vector_array.npy` output.
+
+**Test plan for Slice 1** (target ~20 tests, mirroring `test_hu_tracking.py` and `test_mocap_marking.py`'s shape):
+
+```text
+Smoke / shape:
+- 2D + 3D: run end-to-end on the yeast fixtures with device='cpu', assert
+  im_branch_label_reassigned and im_obj_label_reassigned exist with
+  expected shapes.
+- num_t default vs explicit override.
+- store_running_matches=True writes voxel_matches.npy; False does not.
+- no_t fixture → run() early-returns; no files written.
+
+Output contract:
+- 2D + 3D: reassigned memmaps have dtype int32, shape == input label shape.
+- voxel_matches.npy is an object array of length (num_t - 1) when written;
+  each entry is [best_prev (K,D), best_next (K,D)] of match_coord_dtype.
+- match_coord_dtype: synthetic shape with max axis 65_537 → uint32 saved.
+- Initialization invariant: reassigned[0] == input_label[0] at non-zero
+  voxels (both branch and obj label types).
+
+Vote / assignment behavior:
+- Reassigned voxels at t+1 are a strict subset of label_memmap[t+1] > 0.
+  No "phantom labels" at background voxels.
+- max_refine_iterations=1 vs default 3: assert iter=1 produces fewer
+  assignments on overlapping flows.
+- Empty mask at frame N: loop breaks; frames N..end stay all-zero.
+
+4-tier tree backend (CPU only — GPU paths skipped if cupy unavailable):
+- device='cpu' end-to-end: post-run `self.device_type == "cpu"` always.
+- Monkeypatch cKDTree to raise MemoryError → cpu_bruteforce path engages
+  (assert via tree-handle backend on _build_tree return); end-to-end
+  result equivalence with default path (within tolerance).
+- Empty input → tree_handle.backend == "cpu", tree=None;
+  _query_tree returns empty arrays.
+
+Distance / weighting characterization:
+- _vote_targets minimal numeric example: 3 sources voting on 1 target,
+  one weight strictly highest → that source label wins.
+- _distance_threshold drops matches ≥ flow_interpolator.max_distance_um.
+- _select_best_pairs returns 1-best per target (lexsort behavior).
+
+Architecture characterization (pin BEFORE Slice 3 changes them):
+- Inner _build_tree GPU OOM cascade: monkeypatch _gpu_kdtree_cls to
+  raise MemoryError → assert post-run `self.device_type == "cpu"`
+  (cross-frame mutation). [Skip if no cupy; characterize via fault
+  injection on the resolved-backend state instead.]
+- Inner _query_tree GPU OOM cascade: monkeypatch GPU query to raise
+  MemoryError → assert post-run `self.device_type == "cpu"`.
+- _query_tree silent fallback on non-OOM exceptions: monkeypatch GPU
+  query to raise ValueError → assert post-run `self.device_type == "cpu"`
+  (current bug-adjacent behavior; Slice 3 will change this).
+
+Inputs not mutated:
+- raw + im_skel_relabelled + im_instance_label + flow_vector_array.npy
+  unchanged after run() (compare hashes pre/post).
+
+Viewer status callback:
+- viewer=None: no-op.
+- viewer with .status property: assert per-frame status string written
+  ("Reassigning voxels. Frame: N of M.").
+```
+
+**Hard-to-test on CPU-only CI**: the inner GPU OOM cascades require either a GPU runtime or fault injection on the post-resolve `_gpu_kdtree_cls` / `_TreeHandle` state. Keep characterization minimal: focus on assertions that work on CPU (e.g., `self.device_type` after a forced CPU-side `_switch_to_cpu` simulation), so Slice 3 can intentionally change the contract and the test fails loudly OR passes with updated assertion.
+
+**Heaviest part of Slice 1**: the `hu_outputs_*_path` session fixture. Filter + Label + Markers + Hu on a 2-frame yeast volume should run in ~60–90s combined; session caching mitigates per-test cost. Risk: if Hu runs slower than expected on CPU, sliding scope to a smaller subsample is an option. The Hu session cache may be the single longest pre-test setup in the suite once this lands.
+
+## Pass 8 — Refactor Sequencing
+
+Mirror PRDs #77 (Network), #84 (Markers), #91 (Hu) — three slices, one per PR. **No pre-slice decision needed** (constructor is clean — no `prefer_gpu` overlap).
+
+### Slice 1 — Characterization tests (mirror PR #81 Network, PR #88 Markers, PR #95 Hu)
+
+**Clarify** + **Protect**.
+
+- Add `tests/test_voxel_reassignment.py` (~20 tests, ~700 lines).
+- Extend `tests/conftest.py`:
+  - `network_3d_path` / `network_2d_path` session fixtures (Filter+Label+Network).
+  - `hu_outputs_3d_path` / `hu_outputs_2d_path` session fixtures (Filter+Label+Markers+Hu, return `Path` to `flow_vector_array.npy`).
+  - `_make_voxel_reassign_imageinfo_factory` (3 file copies: `im_instance_label`, `im_skel_relabelled`, `flow_vector_array.npy`).
+  - `make_voxel_reassign_imageinfo_2d/3d` per-test + `_module` variants.
+- Pin all contracts from Pass 5 + the inner-OOM characterizations from Pass 7.
+- No production-code changes.
+
+**Risk**: low. Pure additive. **Heavier than Hu's Slice 1** — adds two new session caches (Network and Hu output) instead of one (Markers output). Estimated 700 lines test + 180 lines conftest, vs Hu's 865 + 211.
+
+### Slice 2 — Structural cleanups (mirror PR #82 Network, PR #89 Markers, PR #96 Hu)
+
+**Clarify** + **Stabilize**.
+
+- Delete `_get_t` (dead).
+- Delete `self.shape = None`, `self.spatial_shape = None`, `self.match_coord_dtype = None`, `self.debug = None` from main init path (and from `no_t` path if not externally read — audit).
+- Drop `self._cp` attribute; replace ~12 callsites with `self.xp` / `self.device_type == "cuda"` checks.
+- Delete `__main__` block.
+- Optional cosmetic: deduplicate the `no_t` early-return init block (84–101) against the main path (103–131) — defer if Slice 2 gets too heavy.
+- Wiki touch-ups in [[voxel-reassignment]]: drop the `self._cp` indirection note (if any); update gotcha "Half-hoisted backend code" to flag that the backend hoist is queued for Slice 3.
+
+**Risk**: medium. Constructor signature unchanged (no user-visible widget changes). The `self._cp` drop touches ~12 sites — Slice 1 tests guard the behavior contract.
+
+### Slice 3 — Backend hoist (mirror PR #83 Network, PR #90 Markers, PR #97 Hu)
+
+**Stabilize** + **Separate**.
+
+- Delete `_resolve_backend`, `_try_import_cupy`, `_is_oom_error`, `_free_gpu_memory`, `_switch_to_cpu`.
+- Constructor + `_set_backend` call `adaptive_run.resolve_backend` directly. Add a small local helper `_get_gpu_kdtree_cls()` that returns `cupyx.scipy.spatial.cKDTree` when on GPU and the class is importable (irreducible — `adaptive_run.try_import_cupy` returns the ndimage module, not the spatial KDTree class, and only this stage needs it; not worth widening the canonical surface).
+- Replace `try/except Exception` patterns at `_build_tree` (247), `_query_tree` (287, 306), `_query_bruteforce_gpu` (354), `_query_bruteforce_cpu` (388 — already `MemoryError`-only) with explicit `if not adaptive_run.is_oom_error(exc): raise` (matches Hu `_match_frames` post-#97 lines 1050–1055 and `_get_frame_features` post-#97 lines 580–583).
+
+- **Inner OOM cascades — architectural decision** (3 cross-frame mutation sites: `_build_tree` 250+252, `_query_tree` 290, 309). Same shape-of-decision as Hu's resolved decision #1, with one additional layer:
+
+  **Option A1 (fully delete inner cascades, like Hu Cascade A)**:
+  - On GPU OOM in `_build_tree`: raise → outer `mode_candidates` cascade restarts whole stage from frame 0 with the next `(dev, low)` candidate.
+  - On GPU OOM in `_query_tree` (both `gpu` and `gpu_bruteforce` branches): raise → outer cascade.
+  - **Tradeoff**: outer retry restarts from frame 0 (re-doing tree builds + queries for early frames). For a long time-series, this is expensive. But it eliminates ALL cross-frame backend mutation.
+  - Same shape as Hu Cascade A (per-frame OOM → outer retry).
+
+  **Option A2 (recommended — mixed: keep local algorithmic fallbacks, drop `_switch_to_cpu` calls)**:
+  - On GPU OOM in `_build_tree`: drop the `_switch_to_cpu` call. Fall through to the existing CPU KDTree path **within this single call** (lines 260–268). Subsequent `_build_tree` calls in later frames will try GPU again; if GPU is genuinely full, every frame will OOM-and-fallback, but each fallback is fast (cupy throws OOM nearly instantly when memory is exhausted).
+  - On GPU OOM in `_query_tree` (gpu branch): drop the `_switch_to_cpu` call. Keep the local rebuild-CPU-KDTree-and-query fallback (lines 291–293) — it's a per-call rebuild, not a backend mutation. Subsequent frames' queries will try GPU again.
+  - On GPU OOM in `_query_tree` (gpu_bruteforce branch): same — drop `_switch_to_cpu`, keep local rebuild.
+  - Replace `_warned_gpu_fallback` rate-limit with a small `_warn_gpu_fallback(reason)` helper called at each fallback site (preserves the once-per-instance log behavior).
+  - **Tradeoff**: every frame after the first OOM pays a fast "try GPU first, OOM, fall back to CPU" cost (vs current code which switches once and stays on CPU). Performance cost negligible (per-frame OOM check is ~µs); architectural cleanliness eliminates the cross-frame mutation footgun.
+  - Same shape as Hu's resolved decision for Cascade B (`_match_frames` dense→sparse: keep algorithmic fallback, drop `_switch_to_cpu`).
+
+  **Option B (keep all cascades, route through canonical helpers)**:
+  - Replace `self._is_oom_error(exc)` → `adaptive_run.is_oom_error(exc)`, `self._free_gpu_memory()` → `adaptive_run.free_gpu_memory(self.xp)`, `self._switch_to_cpu(reason)` → `self._set_backend("cpu")` + `_warn_gpu_fallback(reason)`.
+  - Document the cross-frame mutation explicitly in the wiki (preserves the footgun but at least pinned).
+
+  - Either Option A1/A2: Slice 1's inner-OOM characterization tests get rewritten to pin the new contract (no cross-frame `self.device_type` mutation from inner cascades). The current "silent fallback on non-OOM exceptions" bug (the `_query_tree` GPU branch swallows non-OOM exceptions and switches to CPU) is also fixed — explicit `if not adaptive_run.is_oom_error(exc): raise` propagates non-OOM errors.
+
+**Risk**: medium-high under Option A1 (real behavior change on OOM — full restart), medium under Option A2 (algorithmic fallback preserved, only cross-frame mutation removed), medium under Option B. Slice 1 tests guard the non-OOM contract; the OOM contract is intentionally being changed under A1/A2.
+
+### Deferred (per queue policy)
+
+- `VoxelReassignerConfig` dataclass extraction. Wait until all 4 untested stages (Markers ✓, HuMomentTracking ✓, VoxelReassigner, Hierarchy) have completed test+hoist so the cross-stage Config slice can land as one consistent pass.
+- Extending `adaptive_run.try_import_cupy` to return the spatial KDTree class — only one consumer; not worth widening the canonical surface.
+
+---
+
+## Open questions for the user
+
+1. **Slice 3 inner cascades** — Hu had two inner cascades and chose Split Option A (delete one, mixed-modify the other). VoxelReassigner has THREE cross-frame mutation sites across `_build_tree` (250, 252) and `_query_tree` (290, 309) — all four are `_switch_to_cpu` calls that persist across frames. The recommendation is **Option A2 (mixed)**:
+   - **All three sites**: keep the local algorithmic fallback (CPU KDTree rebuild within the same call) but drop `_switch_to_cpu`. Each subsequent frame's `_build_tree`/`_query_tree` will try GPU again; if GPU is genuinely full, every frame pays a fast OOM-and-fallback cost (microseconds).
+   - **Bonus fix**: the `_query_tree` GPU branches currently `_switch_to_cpu` on **any** exception (not just OOM). Option A2 adds explicit `if not adaptive_run.is_oom_error(exc): raise` so non-OOM errors (e.g., dtype mismatches, dimension errors) propagate instead of silently flipping the backend.
+   - Confirm Option A2, or pick A1 (delete the local fallbacks too — outer cascade restarts from frame 0) or B (preserve cross-frame mutation, route through canonical)?
+
+2. **`self._cp` drop in Slice 2** — recommended action is to drop the attribute entirely and use `self.xp` directly when `self.device_type == "cuda"`. Same shape as Markers' `self.use_gpu` cleanup (PR #89) and Hu's `self._on_gpu` cleanup (PR #96). ~12 callsites. Confirm, or keep `self._cp` as a readability shorthand?
+
+3. **Wiki fold timing** — same as Hu PRD #91: defer to during/after the slices (Slice 2 would be the natural point for the `self._cp` cleanup note + half-hoisted-backend-code gotcha update; Slice 3 would rewrite the "OOM at any tier triggers `_free_gpu_memory()` + `_switch_to_cpu()`" gotcha to reflect the new behavior under Option A2)? Or fold the durable findings before Slice 1?


### PR DESCRIPTION
## Summary

- Adds `tests/test_voxel_reassignment.py` (27 tests) covering all acceptance criteria from #99 — output schema, vote semantics, 4-tier tree backend, distance/weighting primitives, edge cases, and 3 architecture-characterization tests for the cross-frame mutation behaviors that Slice 3 (#101) will invert
- Extends `tests/conftest.py` with two new session caches (`network_*_path` for Filter+Label+Network → `im_skel_relabelled`; `hu_outputs_*_path` for Filter+Label+Markers+Hu → `flow_vector_array.npy`) plus a 3-file `_make_voxel_reassign_imageinfo_factory` and per-test/module variants
- Commits the dechaos report at `wiki/outputs/dechaos-voxel-reassignment.md` (3 resolved decisions baked in: Option A2 at all 4 inner cascade sites, drop `self._cp`, defer wiki fold during slices)

## Test plan

- [x] `pytest tests/test_voxel_reassignment.py -v` — 27/27 passing on CPU (~11s, dominated by the new `hu_outputs_*_path` session cache)
- [x] `pytest tests/ -v` — 112/112 passing, no regressions in any prior PRD's tests (Filter #51, Label #70, Network #77, Markers #84, Hu #91)
- [x] All 3 architecture-characterization tests deliberately pin the SOON-TO-BE-CHANGED behavior, with comments noting Slice 3 (#101) will invert them: cross-frame backend mutation at `_build_tree` GPU OOM (Site 1), `_query_tree` GPU OOM (Sites 3+4), and `_query_tree` non-OOM silent fallback (latent bug fix in Slice 3)
- [x] Pyright noise: 5 unused-parameter warnings on stub function signatures (`_t`, `*args`, `**kwargs` in monkeypatch helpers) — intentional, matches the pre-existing pattern from Hu Slice 1 PR #95

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)