### PR TITLE
voxel_reassignment: structural cleanups + self._cp drop (Slice 2 of #98)

### DIFF
--- a/nellie/tracking/voxel_reassignment.py
+++ b/nellie/tracking/voxel_reassignment.py
@@ -182,8 +182,11 @@ class VoxelReassigner:
     def _free_gpu_memory(self):
         if self.device_type != "cuda":
             return
+        pool_fn = getattr(self.xp, "get_default_memory_pool", None)
+        if pool_fn is None:
+            return
         try:
-            self.xp.get_default_memory_pool().free_all_blocks()
+            pool_fn().free_all_blocks()
         except Exception:
             return
 

--- a/nellie/tracking/voxel_reassignment.py
+++ b/nellie/tracking/voxel_reassignment.py
@@ -77,7 +77,7 @@ class VoxelReassigner:
         if self.low_memory:
             self.max_query_points = min(self.max_query_points, int(2e5))
             self.max_bruteforce_pairs = min(self.max_bruteforce_pairs, int(2e6))
-        self.xp, self.device_type, self._cp, self._gpu_kdtree_cls = self._resolve_backend(device)
+        self.xp, self.device_type, self._gpu_kdtree_cls = self._resolve_backend(device)
         self._warned_gpu_fallback = False
 
         # handle single-timepoint data early
@@ -91,11 +91,7 @@ class VoxelReassigner:
             self.obj_label_memmap = None
             self.reassigned_branch_memmap = None
             self.reassigned_obj_memmap = None
-            self.debug = None
             self.viewer = viewer
-            self.shape = None
-            self.spatial_shape = None
-            self.match_coord_dtype = None
             self.store_running_matches = store_running_matches
             self.max_refine_iterations = max_refine_iterations
             return
@@ -117,18 +113,11 @@ class VoxelReassigner:
         self.reassigned_branch_memmap = None
         self.reassigned_obj_memmap = None
 
-        self.debug = None
-
         self.viewer = viewer
 
         # optimization / behavior controls
         self.store_running_matches = store_running_matches
         self.max_refine_iterations = max_refine_iterations
-
-        # will be set in _allocate_memory
-        self.shape = None
-        self.spatial_shape = None
-        self.match_coord_dtype = None
 
     # -------------------------------------------------------------------------
     # Backend helpers
@@ -141,14 +130,14 @@ class VoxelReassigner:
 
         if device in ("gpu", "cuda"):
             xp, kdtree_cls = self._try_import_cupy(require=True)
-            return xp, "cuda", xp, kdtree_cls
+            return xp, "cuda", kdtree_cls
         if device == "cpu":
-            return np, "cpu", None, None
+            return np, "cpu", None
 
         xp, kdtree_cls = self._try_import_cupy(require=False)
         if xp is not None:
-            return xp, "cuda", xp, kdtree_cls
-        return np, "cpu", None, None
+            return xp, "cuda", kdtree_cls
+        return np, "cpu", None
 
     def _try_import_cupy(self, require):
         try:
@@ -191,10 +180,10 @@ class VoxelReassigner:
             return "OutOfMemory" in repr(exc)
 
     def _free_gpu_memory(self):
-        if self.device_type != "cuda" or self._cp is None:
+        if self.device_type != "cuda":
             return
         try:
-            self._cp.get_default_memory_pool().free_all_blocks()
+            self.xp.get_default_memory_pool().free_all_blocks()
         except Exception:
             return
 
@@ -206,13 +195,12 @@ class VoxelReassigner:
             self._warned_gpu_fallback = True
         self.xp = np
         self.device_type = "cpu"
-        self._cp = None
         self._gpu_kdtree_cls = None
 
     def _set_backend(self, device):
         device = adaptive_run.normalize_device(device)
         self.device = device
-        self.xp, self.device_type, self._cp, self._gpu_kdtree_cls = self._resolve_backend(device)
+        self.xp, self.device_type, self._gpu_kdtree_cls = self._resolve_backend(device)
         self._warned_gpu_fallback = False
 
     def _set_low_memory(self, low_memory):
@@ -238,10 +226,10 @@ class VoxelReassigner:
         if coords_real_scaled.size == 0:
             return _TreeHandle(backend="cpu", tree=None, coords_real_scaled=None)
 
-        if self.device_type == "cuda" and self._cp is not None:
+        if self.device_type == "cuda":
             if self._gpu_kdtree_cls is not None:
                 try:
-                    coords_gpu = self._cp.asarray(coords_real_scaled, dtype=self._cp.float32)
+                    coords_gpu = self.xp.asarray(coords_real_scaled, dtype=self.xp.float32)
                     tree = self._gpu_kdtree_cls(coords_gpu)
                     return _TreeHandle(backend="gpu", tree=tree, coords_real_scaled=coords_real_scaled)
                 except Exception as exc:
@@ -279,10 +267,10 @@ class VoxelReassigner:
 
         if tree_handle.backend == "gpu":
             try:
-                coords_query_gpu = self._cp.asarray(coords_query_scaled, dtype=self._cp.float32)
+                coords_query_gpu = self.xp.asarray(coords_query_scaled, dtype=self.xp.float32)
                 dist_gpu, idx_gpu = tree_handle.tree.query(coords_query_gpu, k=1)
-                dist = self._cp.asnumpy(dist_gpu).astype(np.float32, copy=False)
-                idx = self._cp.asnumpy(idx_gpu).astype(np.int64, copy=False)
+                dist = self.xp.asnumpy(dist_gpu).astype(np.float32, copy=False)
+                idx = self.xp.asnumpy(idx_gpu).astype(np.int64, copy=False)
                 return dist, idx
             except Exception as exc:
                 if self._is_oom_error(exc):
@@ -293,7 +281,7 @@ class VoxelReassigner:
                 return dist, idx
 
         if tree_handle.backend == "gpu_bruteforce":
-            if self._cp is None:
+            if self.device_type != "cuda":
                 cpu_tree = cKDTree(tree_handle.coords_real_scaled)
                 dist, idx = cpu_tree.query(coords_query_scaled, k=1, workers=-1)
                 return dist, idx
@@ -329,7 +317,7 @@ class VoxelReassigner:
         if n_real == 0 or n_query == 0:
             return np.empty((0,), dtype=np.float32), np.empty((0,), dtype=np.int64)
 
-        cp = self._cp
+        cp = self.xp
         coords_real_gpu = cp.asarray(coords_real_scaled, dtype=cp.float32)
         chunk_size = max(1, min(n_query, self.max_bruteforce_pairs // max(n_real, 1)))
 
@@ -846,16 +834,6 @@ class VoxelReassigner:
     # Dataset / memory helpers
     # -------------------------------------------------------------------------
 
-    def _get_t(self):
-        """
-        Gets the number of timepoints from the image metadata or sets it if not provided.
-        """
-        if self.num_t is None:
-            if self.im_info.no_t:
-                self.num_t = 1
-            else:
-                self.num_t = self.im_info.shape[self.im_info.axes.index('T')]
-
     def _allocate_memory(self):
         """
         Allocates memory for voxel reassignment, including initializing memory-mapped arrays for branch and object labels.
@@ -992,7 +970,6 @@ class VoxelReassigner:
     # -------------------------------------------------------------------------
 
     def _run_reassignment(self):
-        self._get_t()
         self._allocate_memory()
 
         # initialize reassigned labels at t=0
@@ -1110,7 +1087,3 @@ class VoxelReassigner:
                     continue
                 raise
         raise last_exc
-
-
-if __name__ == "__main__":
-    logger.info("See scripts/voxel_reassignment_demo.py for example usage.")

--- a/tests/test_voxel_reassignment.py
+++ b/tests/test_voxel_reassignment.py
@@ -982,16 +982,16 @@ def _simulate_gpu_state(v: VoxelReassigner, *, kdtree_cls=None) -> None:
 
     CI has no cupy, so we simulate the post-resolve GPU state by
     directly assigning the attributes that ``_resolve_backend`` would
-    set on a real GPU run. Using ``np`` for ``self.xp`` / ``self._cp``
-    is fine because the GPU code paths in ``_build_tree`` /
-    ``_query_tree`` only call ``.asarray`` (numpy supports it) before
-    delegating to the rigged tree class / tree.query. The actual
-    ``MemoryError`` is raised by the rigged class/method, so we never
-    hit a real cupy code path.
+    set on a real GPU run. Using ``np`` for ``self.xp`` is fine
+    because the GPU code paths in ``_build_tree`` / ``_query_tree``
+    only call ``.asarray`` (numpy supports it) before delegating to
+    the rigged tree class / tree.query. The actual ``MemoryError`` is
+    raised by the rigged class/method, so we never hit a real cupy
+    code path. (``self._cp`` was dropped in Slice 2 of #98 — the
+    code now reads from ``self.xp`` directly when on GPU.)
     """
     v.device_type = "cuda"
     v.xp = np
-    v._cp = np
     v._gpu_kdtree_cls = kdtree_cls
 
 

--- a/wiki/tracking/voxel-reassignment.md
+++ b/wiki/tracking/voxel-reassignment.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-06
-modified: 2026-05-07
+modified: 2026-05-08
 ---
 
 # Voxel reassignment
@@ -41,7 +41,7 @@ OOM at any tier triggers `_free_gpu_memory()` + `_switch_to_cpu()`; chunk-level 
 ## Gotchas
 
 - **Streams over timepoints**, not voxels-by-frame. Only two frames' worth of `argwhere` coordinates plus the candidate match arrays live in memory at once; outputs go straight into memmaps. Loop breaks early if any frame pair produces zero candidates — *all subsequent frames are then unreassigned*.
-- **Half-hoisted backend code.** `_resolve_backend`, `_try_import_cupy`, `_is_oom_error` are local copies that shadow the canonical versions in [[gpu-runtime|`adaptive_run`]]. The outer `run()` *does* call the canonical helpers; the inner per-tree path doesn't. Tracked in [[queue]] as part of the per-stage backend hoist.
+- **Half-hoisted backend code.** `_resolve_backend`, `_try_import_cupy`, `_is_oom_error` are local copies that shadow the canonical versions in [[gpu-runtime|`adaptive_run`]]. The outer `run()` *does* call the canonical helpers; the inner per-tree path doesn't. **Queued for the next slice (Slice 3 of #98)**, which hoists these onto `adaptive_run` alongside the other per-stage backends. Tracked in [[queue]].
 - **Uses ravel-index tricks on `spatial_shape` for fast uniqueness** — `_allocate_memory()` must run first or `_select_best_pairs` / `_vote_targets` / `_assign_unique_matches` raise.
 - **`match_coord_dtype` is auto-selected** from `max(spatial_shape)` (`uint16` / `uint32` / `uint64`). Saved `running_matches` round-trip back to int coordinates correctly only if the dataset's spatial extent fits — bumping image size past 65 535 in any axis silently widens the saved dtype.
 - **Low-memory mode rebuilds the second tree only after freeing the first** (and frees the GPU pool between forward/backward passes), trading speed for headroom; it also caps `max_query_points` at 2e5 and `max_bruteforce_pairs` at 2e6.


### PR DESCRIPTION
## Summary

- Deletes dead `_get_t` method and its caller, dead init-block state (`self.shape`/`spatial_shape`/`match_coord_dtype`/`debug = None` from both main and `no_t` paths), and the no-op `__main__` block
- Drops `self._cp` attribute (~12 callsites) — when on GPU, `self._cp == self.xp`, so `self.xp` is now the single source. `_resolve_backend` return tuple shrunk from 4-element to 3-element
- Wiki: `wiki/tracking/voxel-reassignment.md` — "Half-hoisted backend code" gotcha now flags the backend hoist as queued for Slice 3 (#101); cross-frame state-mutation gotcha stays (Slice 3 territory)
- Net diff: −27 lines on `voxel_reassignment.py` plus a small follow-up commit duck-typing `_free_gpu_memory`'s cupy-pool accessor (pyright doesn't know `numpy.get_default_memory_pool` doesn't exist when `self.xp == cupy`; `getattr` avoids the complaint, mirrors `adaptive_run.free_gpu_memory`'s pattern, and Slice 3 deletes this method anyway)

## Test plan

- [x] `pytest tests/test_voxel_reassignment.py -v` — 27/27 passing (Slice 1 baseline preserved)
- [x] `pytest tests/ -v` — 112/112 passing, no regressions in Filter #51, Label #70, Network #77, Markers #84, Hu #91
- [x] `grep -n "self\._cp" nellie/tracking/voxel_reassignment.py` → 0 matches
- [x] `grep -n "_get_t\|__main__" nellie/tracking/voxel_reassignment.py` → 0 matches
- [x] Pre-existing pyright noise (Optional type narrowing across `self.xp` / cupy imports / FlowInterpolator) accepted as-is — Slice 3 will largely eliminate it by deleting `_resolve_backend` and routing through `adaptive_run`

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)