### PR TITLE
hierarchical: structural cleanups + drop use_gpu (Slice 2 of #105)

### DIFF
--- a/nellie/feature_extraction/hierarchical.py
+++ b/nellie/feature_extraction/hierarchical.py
@@ -60,7 +60,6 @@ class Hierarchy:
         im_info: ImInfo,
         skip_nodes: bool = True,
         viewer=None,
-        use_gpu: bool = True,
         low_memory: bool = False,
         enable_motility: bool = True,
         enable_adjacency: bool = True,
@@ -77,9 +76,6 @@ class Hierarchy:
             If True, node-level features are skipped.
         viewer : optional
             Viewer object with `.status` attribute for status updates.
-        use_gpu : bool
-            If True and CuPy is available, some computations will attempt to use GPU.
-            Ignored when device is set to "cpu" or "gpu".
         low_memory : bool
             If True, use low-memory (slower) aggregation strategies where possible.
         enable_motility : bool
@@ -94,7 +90,6 @@ class Hierarchy:
             Upper bound on the size of the node/voxel mask (num_nodes * chunk_size).
         """
         self.im_info = im_info
-        # This may be overwritten in _get_t, but is a good default
         self.num_t = self.im_info.shape[0]
 
         if self.im_info.no_z:
@@ -113,20 +108,11 @@ class Hierarchy:
         self.enable_motility = enable_motility
         self.enable_adjacency = enable_adjacency
         self.device = (device or "auto").lower()
-        self._prefer_gpu = bool(use_gpu)
-        self.use_gpu = self._resolve_device(self.device, self._prefer_gpu)
+        self.use_gpu = self._resolve_device(self.device)
         self.node_chunk_size = node_chunk_size
         self.max_node_mask_elems = int(max_node_mask_elems)
 
         # Memory-mapped images
-        self.im_raw = None
-        self.im_struct = None
-        self.im_distance = None
-        self.im_skel = None
-        self.im_pixel_class = None
-        self.label_components = None
-        self.label_branches = None
-        self.im_border_mask = None
         self.im_obj_reassigned = None
         self.im_branch_reassigned = None
 
@@ -149,7 +135,7 @@ class Hierarchy:
         except Exception:
             return False
 
-    def _resolve_device(self, device: str, use_gpu: bool) -> bool:
+    def _resolve_device(self, device: str) -> bool:
         if device not in ("auto", "cpu", "gpu", "cuda"):
             raise ValueError(f"Unsupported device '{device}'. Use 'auto', 'cpu', or 'gpu'.")
         if device in ("gpu", "cuda"):
@@ -158,12 +144,12 @@ class Hierarchy:
             return True
         if device == "cpu":
             return False
-        return bool(use_gpu and self._cupy_available())
+        return self._cupy_available()
 
     def _set_backend(self, device: str):
         device = adaptive_run.normalize_device(device)
         self.device = device
-        self.use_gpu = self._resolve_device(device, self._prefer_gpu)
+        self.use_gpu = self._resolve_device(device)
 
     def _set_low_memory(self, low_memory):
         self.low_memory = bool(low_memory)
@@ -178,14 +164,6 @@ class Hierarchy:
         if num_nodes > 0 and num_nodes * base_chunk > max_mask_elems:
             base_chunk = max(1, max_mask_elems // num_nodes)
         return int(max(1, min(base_chunk, num_voxels)))
-
-    def _get_t(self) -> int:
-        """
-        Determine number of time frames.
-        """
-        if self.num_t is None and not self.im_info.no_t:
-            self.num_t = self.im_info.shape[self.im_info.axes.index("T")]
-        return self.num_t
 
     def _allocate_memory(self):
         """
@@ -536,8 +514,6 @@ class Hierarchy:
             pickle.dump(edges, f)
 
     def _run_hierarchy(self):
-        self._get_t()
-
         # Lazily initialize flow interpolators only if needed
         if (
             self.enable_motility
@@ -572,9 +548,7 @@ class Hierarchy:
         gpu_ok = adaptive_run.gpu_available()
         if device == "gpu" and not gpu_ok:
             logger.warning("Hierarchy: GPU requested but not available; falling back to CPU.")
-        if device == "auto" and not self._prefer_gpu:
-            device_order = ["cpu"]
-        elif device == "cpu" or not gpu_ok:
+        if device == "cpu" or not gpu_ok:
             device_order = ["cpu"]
         else:
             device_order = ["gpu", "cpu"]
@@ -623,61 +597,6 @@ def append_to_array(to_append):
             new_array.append(vals)
             new_headers.append(f"{feature}_{stat}")
     return new_array, new_headers
-
-
-def create_feature_array(level, labels=None):
-    """
-    Original non-streaming implementation kept for backwards compatibility.
-    Not used inside Hierarchy anymore (which streams to CSV directly).
-    """
-    full_array = None
-    headers = None
-    all_attr = []
-    attr_dict = []
-
-    if node_attr := getattr(level, "aggregate_node_metrics", None):
-        all_attr.append(node_attr)
-    if voxel_attr := getattr(level, "aggregate_voxel_metrics", None):
-        all_attr.append(voxel_attr)
-    if branch_attr := getattr(level, "aggregate_branch_metrics", None):
-        all_attr.append(branch_attr)
-    if component_attr := getattr(level, "aggregate_component_metrics", None):
-        all_attr.append(component_attr)
-
-    inherent_features = getattr(level, "features_to_save", [])
-    for feature in inherent_features:
-        if feature_vals := getattr(level, feature, None):
-            all_attr.append([{feature: feature_vals[t]} for t in range(len(feature_vals))])
-
-    if not all_attr:
-        return np.zeros((0, 0)), []
-
-    for t in range(len(all_attr[0])):
-        time_dict = {}
-        for attr in all_attr:
-            time_dict.update(attr[t])
-        attr_dict.append(time_dict)
-
-    for t in range(len(attr_dict)):
-        to_append = attr_dict[t]
-        time_array, new_headers = append_to_array(to_append)
-        if labels is None:
-            labels_t = np.array(range(len(time_array[0])), dtype=np.int64)
-        else:
-            labels_t = labels[t]
-        time_array.insert(0, labels_t)
-        time_array.insert(0, np.array([t] * len(time_array[0]), dtype=np.int64))
-        if headers is None:
-            headers = new_headers
-        if full_array is None:
-            full_array = np.array(time_array).T
-        else:
-            time_array = np.array(time_array).T
-            full_array = np.vstack([full_array, time_array])
-
-    headers.insert(0, "label")
-    headers.insert(0, "t")
-    return full_array, headers
 
 
 class Voxels:
@@ -2114,18 +2033,3 @@ class Image:
                     f"Extracting image features. Frame: {t + 1} of {self.hierarchy.num_t}."
                 )
             self._run_frame(t)
-
-
-if __name__ == "__main__":
-    im_path = r"F:\60x_568mito_488phal_dapi_siDRP12_w1iSIM-561_s1 - Stage1 _1_-1.tif"
-    im_info = ImInfo(im_path)
-
-    hierarchy = Hierarchy(
-        im_info,
-        skip_nodes=True,
-        use_gpu=True,
-        low_memory=False,
-        enable_motility=True,
-        enable_adjacency=True,
-    )
-    hierarchy.run()

--- a/nellie_napari/nellie_settings.py
+++ b/nellie_napari/nellie_settings.py
@@ -89,7 +89,6 @@ class SettingsConfig:
     reassign_max_bruteforce_pairs: int
 
     feature_skip_nodes: Optional[bool]
-    feature_use_gpu: bool
     feature_low_memory: bool
     feature_enable_motility: bool
     feature_enable_adjacency: bool
@@ -318,8 +317,6 @@ class Settings(QWidget):
             self._make_optional_checkbox(self.feature_skip_nodes)
         )
 
-        self.feature_use_gpu = QCheckBox("Use GPU")
-        self.feature_use_gpu.setChecked(True)
         self.feature_low_memory = QCheckBox("Low memory")
         self.feature_low_memory.setChecked(False)
         self.feature_enable_motility = QCheckBox("Enable motility")
@@ -591,7 +588,6 @@ class Settings(QWidget):
 
         form = QFormLayout()
         form.addRow("Skip node-level features", self.feature_skip_nodes_row)
-        form.addRow("Use GPU", self.feature_use_gpu)
         form.addRow("Low memory", self.feature_low_memory)
         form.addRow("Enable motility", self.feature_enable_motility)
         form.addRow("Enable adjacency", self.feature_enable_adjacency)
@@ -722,7 +718,6 @@ class Settings(QWidget):
                 if self.feature_skip_nodes_override.isChecked()
                 else None
             ),
-            feature_use_gpu=self.feature_use_gpu.isChecked(),
             feature_low_memory=self.feature_low_memory.isChecked(),
             feature_enable_motility=self.feature_enable_motility.isChecked(),
             feature_enable_adjacency=self.feature_enable_adjacency.isChecked(),
@@ -831,7 +826,6 @@ class Settings(QWidget):
         self.feature_skip_nodes_override.setChecked(config.feature_skip_nodes is not None)
         if config.feature_skip_nodes is not None:
             self.feature_skip_nodes.setChecked(config.feature_skip_nodes)
-        self.feature_use_gpu.setChecked(config.feature_use_gpu)
         self.feature_low_memory.setChecked(config.feature_low_memory)
         self.feature_enable_motility.setChecked(config.feature_enable_motility)
         self.feature_enable_adjacency.setChecked(config.feature_enable_adjacency)
@@ -943,7 +937,6 @@ class Settings(QWidget):
 
     def get_feature_params(self) -> dict:
         params = {
-            "use_gpu": self.feature_use_gpu.isChecked(),
             "low_memory": self.feature_low_memory.isChecked(),
             "enable_motility": self.feature_enable_motility.isChecked(),
             "enable_adjacency": self.feature_enable_adjacency.isChecked(),

--- a/wiki/feature-extraction.md
+++ b/wiki/feature-extraction.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-06
-modified: 2026-05-07
+modified: 2026-05-08
 ---
 
 # Feature extraction
@@ -42,10 +42,12 @@ Five per-level CSVs (`features_voxels` / `nodes` / `branches` / `organelles` / `
 - **`enable_motility=False` short-circuits all flow-derived voxel features to NaN** (and every `*_vel` / `*_acc` / `rel_*` aggregate above it inherits NaNs). `enable_adjacency=False` skips writing `adjacency_maps.pkl` entirely. Both default `True`; flipping them is the cheap way to skip whole feature families when you only need morphology.
 - **`FlowInterpolator` instances are built lazily** — only when `enable_motility and not no_t and num_t > 1`. Single-frame stacks skip flow loading even when motility is "enabled," and the per-voxel motility helper fills NaN in that branch.
 - **Per-branch reference voxel for `rel_*` motility is the one with minimum-magnitude flow vector in that branch** (`_get_min_euc_dist`). All `rel_linear_vel` / `rel_angular_vel` / `rel_directionality` are measured against that single representative — interpret accordingly.
+- **Backend selection is `device`-only** as of Slice 2 of #105 (PR follow-up to #109). The `use_gpu` constructor parameter was dropped (Option A, mirroring Markers PR #89); pass `device="cpu"` instead. The local `_cupy_available` and `_resolve_device` helpers still wrap `adaptive_run.gpu_available` and friends — they are queued for deletion in Slice 3 of #105 so the constructor + `_set_backend` call `adaptive_run.resolve_backend` directly. Until Slice 3, the `Branches._compute_branch_lengths_and_degrees` per-call OOM fallback still narrowly catches `cp.cuda.memory.OutOfMemoryError`; Slice 3 widens it through `adaptive_run.is_oom_error`.
 
 ## Invariants
 
 - `test_aggregate_stats_low_memory_parity` pins the core guarantee: the fast vectorized path and the low-memory path produce identical mean/std/min/max/sum (NaN-equal) for the same `(child_class, t, list_of_idxs)`, and identical column headers from `append_to_array`.
+- Slice 1 (#106 / PR #109) added `tests/test_hierarchical.py` (~25 characterization tests) pinning the contracts above and below — output schema (5 CSVs + adjacency pickle), aggregation parity, motility short-circuits (`enable_motility=False`, `vec01` at t=0 / `vec12` at t=num_t-1, single-frame stack), branch length tip-radius adjustment + length/thickness swap + tortuosity-from-first-two-tips, reassigned-label fallback to NaN, backend characterization, and per-call GPU OOM fallback on `Branches._compute_branch_lengths_and_degrees`.
 - NaNs in inputs propagate via `nan*` reductions rather than corrupting aggregates.
 - CSV header order is **stable across frames** (set on first frame, reused in append mode).
 - Adjacency edge lists are 0-indexed for level-internal indices but use raw label values for component columns, matching how the CSVs key their `label` field.


### PR DESCRIPTION
## Summary

- **Drop `use_gpu` from `Hierarchy.__init__`** (Option A, mirroring Markers' resolved overlap in PR #89). Constructor signature loses `use_gpu`; `self._prefer_gpu` removed; `_resolve_device(device, use_gpu)` → `_resolve_device(device)`; `run()` drops the `if device == "auto" and not self._prefer_gpu` branch (auto unconditionally tries GPU first when available). The `self.use_gpu` derived attribute is **kept** for now — Slice 3 deletes it along with `_resolve_device` itself.
- **Drop `feature_use_gpu` from `nellie_napari/nellie_settings.py`** — SettingsConfig field, UI checkbox, form row, config R/W, and `get_feature_params()` return. The "Use GPU" checkbox is removed from the Feature Export tab.
- **Delete dead code**: `_get_t` (unreachable guard), `create_feature_array` (legacy non-streaming, annotated as such in its docstring), `__main__` block (hardcoded `F:\` path), and 8 dead `self.X = None` init lines (122-129) overwritten unconditionally by `_allocate_memory`.
- **Wiki touch-ups**: `wiki/feature-extraction.md` updated to flag the backend hoist as queued for Slice 3 and add a Slice-1 invariant note.

Net delete: ~101 lines (somewhat above the PRD's ~30-40 estimate because deleting `create_feature_array` removed 53 lines).

Closes #107.

## Test plan

- [x] `pytest tests/ -v` — 146 passed, 155 warnings, 40.51s. Slice 1 (#106 / PR #109) tests still green; all Filter/Label/Network/Markers/Hu/VoxelReassigner suites still green.
- [x] Pyright diagnostics: 93 → 67 (-26). All eliminated errors were in deleted code; **no new diagnostics introduced** (the system-reminder line-number-shift "new" flags are pre-existing diagnostics surfacing at new offsets).
- [x] Verification greps: `use_gpu` / `_prefer_gpu` references in hierarchical.py limited to the kept `self.use_gpu` derivation + the `Branches._compute_branch_lengths_and_degrees` read site (Slice 3 deletes both); zero `feature_use_gpu` in nellie_settings.py; zero `_get_t` / `create_feature_array` / `__main__` in hierarchical.py.
- [ ] Manual napari widget smoke check (the "Use GPU" checkbox should be gone from the Feature Export tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)