### PR TITLE
config-extraction: segmentation cluster (Slice 1 of #112)

### DIFF
--- a/nellie/run.py
+++ b/nellie/run.py
@@ -7,9 +7,9 @@ including filtering, segmentation, tracking, and feature extraction.
 from nellie.feature_extraction.hierarchical import Hierarchy
 from nellie.im_info.verifier import FileInfo, ImInfo
 from nellie.segmentation.filtering import Filter, FrangiConfig
-from nellie.segmentation.labelling import Label
-from nellie.segmentation.mocap_marking import Markers
-from nellie.segmentation.networking import Network
+from nellie.segmentation.labelling import Label, LabelConfig
+from nellie.segmentation.mocap_marking import Markers, MarkersConfig
+from nellie.segmentation.networking import Network, NetworkConfig
 from nellie.tracking.hu_tracking import HuMomentTracking
 from nellie.tracking.voxel_reassignment import VoxelReassigner
 
@@ -66,10 +66,12 @@ def run(
         start_time = time.perf_counter()
     segmenting = Label(
         im_info,
-        otsu_thresh_intensity=otsu_thresh_intensity,
-        threshold=threshold,
-        device=device,
-        low_memory=low_memory,
+        LabelConfig(
+            threshold=threshold,
+            otsu_thresh_intensity=otsu_thresh_intensity,
+            device=device,
+            low_memory=low_memory,
+        ),
     )
     segmenting.run()
     if timeit:
@@ -78,7 +80,7 @@ def run(
 
     if timeit:
         start_time = time.perf_counter()
-    networking = Network(im_info, device=device)
+    networking = Network(im_info, NetworkConfig(device=device))
     networking.run()
     if timeit:
         end_time = time.perf_counter()
@@ -86,7 +88,7 @@ def run(
 
     if timeit:
         start_time = time.perf_counter()
-    mocap_marking = Markers(im_info, device=device)
+    mocap_marking = Markers(im_info, MarkersConfig(device=device))
     mocap_marking.run()
     if timeit:
         end_time = time.perf_counter()

--- a/nellie/segmentation/labelling.py
+++ b/nellie/segmentation/labelling.py
@@ -4,6 +4,8 @@ Semantic and instance segmentation for microscopy images.
 This module provides the Label class for thresholding-based segmentation with
 optimizations for large volumes and optional GPU acceleration.
 """
+from dataclasses import dataclass
+
 import numpy as np
 
 from nellie.utils import adaptive_run
@@ -14,68 +16,70 @@ from nellie.utils.gpu_functions import otsu_threshold, triangle_threshold
 _UNSET = object()
 
 
+@dataclass(frozen=True)
+class LabelConfig:
+    """Algorithm configuration for ``Label``.
+
+    Frozen — represents the user's intent at construction time. Label
+    copies these values into mutable instance attributes that the
+    OOM/availability cascade can update mid-run (``device``, ``low_memory``).
+    Inspect ``Label.config`` to see the original intent regardless of any
+    cascade-driven runtime fallbacks.
+    """
+
+    threshold: float | None = None
+    otsu_thresh_intensity: bool = False
+    chunk_z: int | None = None
+    flush_interval: int = 1
+    min_radius_um: float = 0.25
+    threshold_sampling_pixels: int = 1_000_000
+    histogram_nbins: int = 256
+    device: str = "auto"
+    low_memory: bool = False
+    max_chunk_voxels: int = int(1e6)
+
+
 class Label:
     """
     A class for semantic and instance segmentation of microscopy images using
     thresholding techniques, optimized for large volumes and optional GPU acceleration.
     """
 
-    def __init__(self, im_info: ImInfo,
-                 num_t=None,
-                 threshold=None,
-                 otsu_thresh_intensity=False,
-                 viewer=None,
-                 chunk_z=None,
-                 flush_interval=1,
-                 min_radius_um=0.25,
-                 threshold_sampling_pixels=1_000_000,
-                 histogram_nbins=256,
-                 device="auto",
-                 low_memory: bool = False,
-                 max_chunk_voxels: int = int(1e6)):
+    def __init__(
+        self,
+        im_info: ImInfo,
+        config: LabelConfig = LabelConfig(),
+        viewer=None,
+        num_t: int | None = None,
+    ) -> None:
         """
         Parameters
         ----------
         im_info : ImInfo
             Image metadata and paths.
-        num_t : int, optional
-            Number of timepoints to process.
-        threshold : float or None, optional
-            Fixed intensity threshold for segmentation (if not using Otsu).
-        otsu_thresh_intensity : bool, optional
-            Whether to apply Otsu's method for intensity thresholding.
+        config : LabelConfig
+            Algorithm configuration. Defaults to ``LabelConfig()``.
         viewer : object or None, optional
             Viewer object for displaying status.
-        chunk_z : int or None, optional
-            If not None and image has Z, process each timepoint in Z-chunks of
-            this size instead of the full volume. If None and
-            low_memory is True, a chunk size is inferred from max_chunk_voxels.
-        flush_interval : int, optional
-            How often (in frames) to flush the output memmap to disk.
-        min_radius_um : float, optional
-            Minimum expected object radius in micrometers. Labels smaller than
-            the area/volume of a circle/sphere with this radius are removed.
-        threshold_sampling_pixels : int, optional
-            Maximum number of pixels sampled when computing global thresholds
-            to reduce histogram cost for very large volumes.
-        histogram_nbins : int, optional
-            Number of bins to use in histogram-based thresholding.
-        device : {"auto", "cpu", "gpu"}, optional
-            Backend selection. "auto" uses GPU if available, otherwise CPU.
-        low_memory : bool, optional
-            If True, prefer chunked Z processing to reduce peak memory usage.
-        max_chunk_voxels : int, optional
-            Target maximum number of voxels per Z-chunk when low_memory is True
-            and chunk_z is not specified.
+        num_t : int, optional
+            Number of timepoints to process.
         """
         self.im_info = im_info
-        self.device = device
-        self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(device)
+        self.config = config
+
+        # Cascade-mutable runtime state. Initial values come from config;
+        # ``_set_backend`` and ``_set_low_memory`` may update them on retry.
+        self.device = config.device
+        self.low_memory = bool(config.low_memory)
+
+        self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(self.device)
         self.num_t = num_t
         if num_t is None and not self.im_info.no_t:
             self.num_t = im_info.shape[im_info.axes.index('T')]
-        self.threshold = threshold
-        self.otsu_thresh_intensity = otsu_thresh_intensity
+
+        # Aliases for hot path readability — config remains the source of truth.
+        self.threshold = config.threshold
+        self.otsu_thresh_intensity = config.otsu_thresh_intensity
 
         self.im_memmap = None
         self.frangi_memmap = None
@@ -87,20 +91,19 @@ class Label:
         self.viewer = viewer
 
         # Optimization / configuration parameters
-        self.chunk_z = chunk_z if (not self.im_info.no_z and chunk_z is not None) else None
+        self.chunk_z = config.chunk_z if (not self.im_info.no_z and config.chunk_z is not None) else None
         # Stash the *coerced* value (None for 2D), not the raw user input —
         # ``chunk_z`` has no meaning without a Z axis, so passing
         # ``chunk_z=...`` against a 2D image is intentionally a no-op.
         self._user_chunk_z = self.chunk_z
-        self.flush_interval = max(1, int(flush_interval))
-        min_radius_um = float(min_radius_um)
+        self.flush_interval = max(1, int(config.flush_interval))
+        min_radius_um = float(config.min_radius_um)
         x_res = self.im_info.dim_res.get("X") or 1.0
         self.min_radius_um = max(min_radius_um, float(x_res))
-        self.threshold_sampling_pixels = int(threshold_sampling_pixels)
-        self.histogram_nbins = int(histogram_nbins)
+        self.threshold_sampling_pixels = int(config.threshold_sampling_pixels)
+        self.histogram_nbins = int(config.histogram_nbins)
         self.eps = 1e-8
-        self.low_memory = bool(low_memory)
-        self.max_chunk_voxels = int(max_chunk_voxels)
+        self.max_chunk_voxels = int(config.max_chunk_voxels)
 
         if self.low_memory and self.chunk_z is None and not self.im_info.no_z:
             inferred_chunk = self._infer_chunk_z()

--- a/nellie/segmentation/mocap_marking.py
+++ b/nellie/segmentation/mocap_marking.py
@@ -10,11 +10,34 @@ Notes
 - The border mask is the outside shell, computed as dilation(mask) XOR mask.
 """
 import itertools
+from dataclasses import dataclass
+
 import numpy as np
 
 from nellie.utils import adaptive_run
 from nellie.utils.base_logger import logger
 from nellie.im_info.verifier import ImInfo
+
+
+@dataclass(frozen=True)
+class MarkersConfig:
+    """Algorithm configuration for ``Markers``.
+
+    Frozen — represents the user's intent at construction time. Markers
+    copies these values into mutable instance attributes that the
+    OOM/availability cascade can update mid-run (``device``, ``low_memory``).
+    Inspect ``Markers.config`` to see the original intent regardless of any
+    cascade-driven runtime fallbacks.
+    """
+
+    min_radius_um: float = 0.20
+    max_radius_um: float = 1
+    use_im: str = "distance"
+    num_sigma: int = 5
+    peak_min_distance: int = 2
+    device: str = "auto"
+    low_memory: bool = False
+    max_chunk_voxels: int = int(1e6)
 
 
 class Markers:
@@ -70,10 +93,13 @@ class Markers:
         Minimum separation (in pixels) between peaks in morphological NMS.
     """
 
-    def __init__(self, im_info: ImInfo, num_t=None,
-                 min_radius_um=0.20, max_radius_um=1, use_im='distance', num_sigma=5,
-                 viewer=None, peak_min_distance=2,
-                 device="auto", low_memory=False, max_chunk_voxels=int(1e6)):
+    def __init__(
+        self,
+        im_info: ImInfo,
+        config: MarkersConfig = MarkersConfig(),
+        viewer=None,
+        num_t: int | None = None,
+    ) -> None:
         """
         Initializes the Markers object with image metadata and marking parameters.
 
@@ -81,28 +107,15 @@ class Markers:
         ----------
         im_info : ImInfo
             An instance of the ImInfo class, containing metadata and paths for the image file.
-        num_t : int, optional
-            Number of timepoints to process. If None, defaults to the number of timepoints in the image.
-        min_radius_um : float, optional
-            Minimum radius of detected objects in micrometers (default is 0.20).
-        max_radius_um : float, optional
-            Maximum radius of detected objects in micrometers (default is 1).
-        use_im : str, optional
-            Specifies which image to use for peak detection ('distance' or 'frangi', default is 'distance').
-        num_sigma : int, optional
-            Number of sigma steps for multi-scale filtering (default is 5).
+        config : MarkersConfig
+            Algorithm configuration. Defaults to ``MarkersConfig()``.
         viewer : object or None, optional
             Viewer object for displaying status during processing (default is None).
-        peak_min_distance : int, optional
-            Minimum distance (in pixels) between peaks for NMS (default is 2).
-        device : {"auto", "cpu", "gpu"}, optional
-            Backend selection. "auto" uses GPU if available, otherwise CPU.
-        low_memory : bool, optional
-            If True, prefer chunked LoG and NMS to reduce memory at the cost of speed.
-        max_chunk_voxels : int, optional
-            Maximum number of voxels per chunk for low-memory processing.
+        num_t : int, optional
+            Number of timepoints to process. If None, defaults to the number of timepoints in the image.
         """
         self.im_info = im_info
+        self.config = config
 
         self.num_t = num_t
         if self.im_info.no_t:
@@ -115,14 +128,15 @@ class Markers:
         else:
             self.z_ratio = 1.0
 
-        self.min_radius_um = max(min_radius_um, self.im_info.dim_res['X'])
-        self.max_radius_um = max_radius_um
+        # Aliases for hot path readability — config remains the source of truth.
+        self.min_radius_um = max(config.min_radius_um, self.im_info.dim_res['X'])
+        self.max_radius_um = config.max_radius_um
 
         self.min_radius_px = self.min_radius_um / self.im_info.dim_res['X']
         self.max_radius_px = self.max_radius_um / self.im_info.dim_res['X']
 
-        self.use_im = use_im
-        self.num_sigma = num_sigma
+        self.use_im = config.use_im
+        self.num_sigma = config.num_sigma
 
         self.im_memmap = None
         self.im_frangi_memmap = None
@@ -133,15 +147,17 @@ class Markers:
 
         self.viewer = viewer
 
-        self.device = adaptive_run.normalize_device(device)
+        # Cascade-mutable runtime state. Initial values come from config;
+        # ``_set_backend`` and ``_set_low_memory`` may update them on retry.
+        self.device = adaptive_run.normalize_device(config.device)
         self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(self.device)
 
         # Morphological NMS radius
-        self.peak_min_distance = peak_min_distance
+        self.peak_min_distance = config.peak_min_distance
 
         # Optional low-memory chunking
-        self.low_memory = bool(low_memory)
-        self.max_chunk_voxels = int(max_chunk_voxels)
+        self.low_memory = bool(config.low_memory)
+        self.max_chunk_voxels = int(config.max_chunk_voxels)
         self.truncate = 4.0
 
     # -------------------------------------------------------------------------

--- a/nellie/segmentation/networking.py
+++ b/nellie/segmentation/networking.py
@@ -5,6 +5,8 @@ This module provides the Network class for skeletonizing network-like structures
 and analyzing their topology with optimized CPU/GPU processing.
 """
 import itertools
+from dataclasses import dataclass
+
 import numpy as np
 import skimage.morphology as morph
 from scipy import ndimage as ndi_cpu
@@ -12,6 +14,24 @@ from scipy import ndimage as ndi_cpu
 from nellie.utils import adaptive_run
 from nellie.utils.base_logger import logger
 from nellie.im_info.verifier import ImInfo
+
+
+@dataclass(frozen=True)
+class NetworkConfig:
+    """Algorithm configuration for ``Network``.
+
+    Frozen — represents the user's intent at construction time. Network
+    copies these values into mutable instance attributes that the
+    OOM/availability cascade can update mid-run (``device``, ``low_memory``).
+    Inspect ``Network.config`` to see the original intent regardless of any
+    cascade-driven runtime fallbacks.
+    """
+
+    min_radius_um: float = 0.20
+    max_radius_um: float = 1
+    device: str = "auto"
+    low_memory: bool = False
+    max_chunk_voxels: int = int(1e6)
 
 
 class Network:
@@ -24,45 +44,38 @@ class Network:
       - More memory-friendly local-max detection.
       - More efficient branch relabeling using distance transforms on per-object crops.
       - Graceful degradation when GPU memory is insufficient (CPU/chunked fallback).
-
-    Parameters
-    ----------
-    im_info : ImInfo
-        Image metadata and paths.
-    num_t : int, optional
-        Number of timepoints to process. Defaults to all timepoints.
-    min_radius_um : float, optional
-        Minimum radius of detected objects in micrometers.
-    max_radius_um : float, optional
-        Maximum radius of detected objects in micrometers.
-    viewer : object or None, optional
-        Viewer object for status reporting.
-    device : {"auto", "cpu", "gpu"}, optional
-        Backend selection for connectivity computations.
-    low_memory : bool, optional
-        If True, use chunked CPU fallbacks for local neighborhood operations.
-    max_chunk_voxels : int, optional
-        Maximum voxels per chunk for low-memory paths.
     """
 
     def __init__(
         self,
         im_info: ImInfo,
-        num_t=None,
-        min_radius_um=0.20,
-        max_radius_um=1,
+        config: NetworkConfig = NetworkConfig(),
         viewer=None,
-        device="auto",
-        low_memory: bool = False,
-        max_chunk_voxels: int = int(1e6),
-    ):
-
+        num_t: int | None = None,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        im_info : ImInfo
+            Image metadata and paths.
+        config : NetworkConfig
+            Algorithm configuration. Defaults to ``NetworkConfig()``.
+        viewer : object or None, optional
+            Viewer object for status reporting.
+        num_t : int, optional
+            Number of timepoints to process. Defaults to all timepoints.
+        """
         self.im_info = im_info
-        self.device = device
-        self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(device)
-        self.force_device = device is not None and device.lower() in ("cpu", "gpu", "cuda")
-        self.low_memory = low_memory
-        self.max_chunk_voxels = int(max_chunk_voxels)
+        self.config = config
+
+        # Cascade-mutable runtime state. Initial values come from config;
+        # ``_set_backend`` and ``_set_low_memory`` may update them on retry.
+        self.device = config.device
+        self.low_memory = bool(config.low_memory)
+
+        self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(self.device)
+        self.force_device = config.device.lower() in ("cpu", "gpu", "cuda")
+        self.max_chunk_voxels = int(config.max_chunk_voxels)
         self.num_t = num_t
         if num_t is None and not self.im_info.no_t:
             self.num_t = im_info.shape[im_info.axes.index('T')]
@@ -71,8 +84,8 @@ class Network:
             self.z_ratio = self.im_info.dim_res['Z'] / self.im_info.dim_res['X']
 
         # either (roughly) diffraction limit, or pixel size, whichever is larger
-        self.min_radius_um = max(min_radius_um, self.im_info.dim_res['X'])
-        self.max_radius_um = max_radius_um
+        self.min_radius_um = max(config.min_radius_um, self.im_info.dim_res['X'])
+        self.max_radius_um = config.max_radius_um
 
         self.min_radius_px = self.min_radius_um / self.im_info.dim_res['X']
         self.max_radius_px = self.max_radius_um / self.im_info.dim_res['X']

--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -9,9 +9,9 @@ from qtpy.QtCore import Qt, QTimer
 
 from nellie.feature_extraction.hierarchical import Hierarchy
 from nellie.segmentation.filtering import Filter, FrangiConfig
-from nellie.segmentation.labelling import Label
-from nellie.segmentation.mocap_marking import Markers
-from nellie.segmentation.networking import Network
+from nellie.segmentation.labelling import Label, LabelConfig
+from nellie.segmentation.mocap_marking import Markers, MarkersConfig
+from nellie.segmentation.networking import Network, NetworkConfig
 from nellie.tracking.hu_tracking import HuMomentTracking
 from nellie.tracking.voxel_reassignment import VoxelReassigner
 from napari.qt.threading import thread_worker
@@ -364,17 +364,23 @@ class NellieProcessor(QWidget):
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Segmentation file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            label_base_kwargs = {
-                "im_info": self.current_im_info,
-                "viewer": self.viewer,
-            }
-            segmenting = Label(**label_base_kwargs, **label_kwargs)
+            label_config_kwargs = dict(label_kwargs)
+            label_num_t = label_config_kwargs.pop("num_t", None)
+            segmenting = Label(
+                im_info=self.current_im_info,
+                config=LabelConfig(**label_config_kwargs),
+                viewer=self.viewer,
+                num_t=label_num_t,
+            )
             segmenting.run()
-            network_base_kwargs = {
-                "im_info": self.current_im_info,
-                "viewer": self.viewer,
-            }
-            networking = Network(**network_base_kwargs, **network_kwargs)
+            network_config_kwargs = dict(network_kwargs)
+            network_num_t = network_config_kwargs.pop("num_t", None)
+            networking = Network(
+                im_info=self.current_im_info,
+                config=NetworkConfig(**network_config_kwargs),
+                viewer=self.viewer,
+                num_t=network_num_t,
+            )
             networking.run()
 
     def run_segmentation(self):
@@ -405,11 +411,14 @@ class NellieProcessor(QWidget):
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Mocap Marking file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            base_kwargs = {
-                "im_info": self.current_im_info,
-                "viewer": self.viewer,
-            }
-            mocap_marking = Markers(**base_kwargs, **step_kwargs)
+            config_kwargs = dict(step_kwargs)
+            num_t = config_kwargs.pop("num_t", None)
+            mocap_marking = Markers(
+                im_info=self.current_im_info,
+                config=MarkersConfig(**config_kwargs),
+                viewer=self.viewer,
+                num_t=num_t,
+            )
             mocap_marking.run()
 
     def run_mocap(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,9 +76,9 @@ import pytest
 
 from nellie.im_info.verifier import FileInfo, ImInfo
 from nellie.segmentation.filtering import Filter, FrangiConfig
-from nellie.segmentation.labelling import Label
-from nellie.segmentation.mocap_marking import Markers
-from nellie.segmentation.networking import Network
+from nellie.segmentation.labelling import Label, LabelConfig
+from nellie.segmentation.mocap_marking import Markers, MarkersConfig
+from nellie.segmentation.networking import Network, NetworkConfig
 from nellie.tracking.hu_tracking import HuMomentTracking
 from nellie.tracking.voxel_reassignment import VoxelReassigner
 
@@ -257,7 +257,7 @@ def _run_label_to_disk(im_info: ImInfo) -> Path:
     ``im_info``'s pipeline tree (pre-populated by ``_run_filter_to_disk``
     or by copying a session-cached Frangi).
     """
-    lbl = Label(im_info, num_t=2, device="cpu")
+    lbl = Label(im_info, LabelConfig(device="cpu"), num_t=2)
     lbl.run()
     # Drop memmap handles so Windows lets us read/copy the file later.
     lbl.instance_label_memmap = None
@@ -523,7 +523,7 @@ def _run_markers_to_disk(im_info: ImInfo) -> dict[str, Path]:
     (mirrors ``_run_filter_to_disk`` / ``_run_label_to_disk``). ``im_border``
     is intentionally not exposed — HuMomentTracking does not consume it.
     """
-    m = Markers(im_info, num_t=2, device="cpu")
+    m = Markers(im_info, MarkersConfig(device="cpu"), num_t=2)
     m.run()
     m.im_marker_memmap = None
     m.im_distance_memmap = None
@@ -731,7 +731,7 @@ def _run_network_to_disk(im_info: ImInfo) -> dict[str, Path]:
     they need; VoxelReassigner only consumes ``im_skel_relabelled`` while
     Hierarchy consumes all three.
     """
-    net = Network(im_info, num_t=2, device="cpu")
+    net = Network(im_info, NetworkConfig(device="cpu"), num_t=2)
     net.run()
     # Drop memmap handles so Windows lets us read/copy the file later.
     net.skel_relabelled_memmap = None

--- a/tests/test_hu_tracking.py
+++ b/tests/test_hu_tracking.py
@@ -81,8 +81,8 @@ import tifffile
 
 from nellie.im_info.verifier import FileInfo, ImInfo
 from nellie.segmentation.filtering import Filter, FrangiConfig
-from nellie.segmentation.labelling import Label
-from nellie.segmentation.mocap_marking import Markers
+from nellie.segmentation.labelling import Label, LabelConfig
+from nellie.segmentation.mocap_marking import Markers, MarkersConfig
 from nellie.tracking.hu_tracking import (
     HuMomentTracking,
     _FrameFeatures,
@@ -396,8 +396,8 @@ def _build_single_frame_iminfo(workdir: Path) -> ImInfo:
     file_info.load_metadata()
     info = ImInfo(file_info)
     Filter(info, FrangiConfig(device="cpu"), num_t=1).run()
-    Label(info, num_t=1, device="cpu").run()
-    Markers(info, num_t=1, device="cpu").run()
+    Label(info, LabelConfig(device="cpu"), num_t=1).run()
+    Markers(info, MarkersConfig(device="cpu"), num_t=1).run()
     gc.collect()
     return info
 

--- a/tests/test_labelling.py
+++ b/tests/test_labelling.py
@@ -27,7 +27,7 @@ import pytest
 import tifffile
 
 from nellie.im_info.verifier import FileInfo, ImInfo
-from nellie.segmentation.labelling import Label
+from nellie.segmentation.labelling import Label, LabelConfig
 
 
 # Bar-shaped 3D fixture: a 5×5 cross at (Y=6..10, X=6..10) extruded along
@@ -56,7 +56,7 @@ def _release_label(lbl: Label) -> None:
 
 def _run_label(info: ImInfo, **kwargs) -> np.ndarray:
     """Run ``Label`` on ``info`` and return a copy of the on-disk labels."""
-    lbl = Label(info, num_t=2, device="cpu", **kwargs)
+    lbl = Label(info, LabelConfig(device="cpu", **kwargs), num_t=2)
     lbl.run()
     out = np.asarray(lbl.instance_label_memmap).copy()
     _release_label(lbl)
@@ -189,7 +189,7 @@ def test_anisotropic_min_area_pixel_volume(make_label_imageinfo_3d) -> None:
     as isotropic to X (0.0655), the same formula would give ~233 voxels.
     """
     info = make_label_imageinfo_3d()
-    lbl = Label(info, num_t=2, device="cpu", min_radius_um=0.25)
+    lbl = Label(info, LabelConfig(device="cpu", min_radius_um=0.25), num_t=2)
     x_res = info.dim_res["X"]
     y_res = info.dim_res["Y"]
     z_res = info.dim_res["Z"]
@@ -205,7 +205,7 @@ def test_min_radius_um_floored_at_x_res(imageinfo_3d) -> None:
     """``min_radius_um`` smaller than ``x_res`` is silently floored at ``x_res``."""
     x_res = float(imageinfo_3d.dim_res["X"])
     sub_pixel = x_res / 1000.0
-    lbl = Label(imageinfo_3d, num_t=2, device="cpu", min_radius_um=sub_pixel)
+    lbl = Label(imageinfo_3d, LabelConfig(device="cpu", min_radius_um=sub_pixel), num_t=2)
     assert lbl.min_radius_um == pytest.approx(x_res)
 
 

--- a/tests/test_mocap_marking.py
+++ b/tests/test_mocap_marking.py
@@ -55,8 +55,8 @@ import tifffile
 
 from nellie.im_info.verifier import FileInfo, ImInfo
 from nellie.segmentation.filtering import Filter, FrangiConfig
-from nellie.segmentation.labelling import Label
-from nellie.segmentation.mocap_marking import Markers
+from nellie.segmentation.labelling import Label, LabelConfig
+from nellie.segmentation.mocap_marking import Markers, MarkersConfig
 
 
 def _release_markers(m: Markers) -> None:
@@ -78,7 +78,7 @@ def _release_markers(m: Markers) -> None:
 def _run_markers(info: ImInfo, **kwargs) -> dict[str, np.ndarray]:
     """Run ``Markers`` on ``info`` and return copies of the on-disk outputs."""
     kwargs.setdefault("device", "cpu")
-    m = Markers(info, num_t=2, **kwargs)
+    m = Markers(info, MarkersConfig(**kwargs), num_t=2)
     m.run()
     out = {
         "marker": np.asarray(m.im_marker_memmap).copy(),
@@ -323,7 +323,7 @@ def test_use_im_frangi_raises_when_frangi_absent(make_imageinfo_3d, label_3d_pat
     # Markers' run() catches OOM/GPU-unavailable errors and continues
     # the cascade, but a missing-file error should propagate cleanly.
     with pytest.raises(Exception) as exc_info:
-        Markers(info, num_t=2, device="cpu", use_im="frangi").run()
+        Markers(info, MarkersConfig(device="cpu", use_im="frangi"), num_t=2).run()
 
     # The actual error type is FileNotFoundError from tifffile.memmap
     # (or RuntimeError if the inner check at line 678 is reached on a
@@ -423,14 +423,14 @@ def test_viewer_status_callback(make_markers_imageinfo_2d) -> None:
     """
     # No-op arm: viewer=None.
     info_none = make_markers_imageinfo_2d()
-    m_none = Markers(info_none, num_t=2, device="cpu", viewer=None)
+    m_none = Markers(info_none, MarkersConfig(device="cpu"), viewer=None, num_t=2)
     m_none.run()  # must not raise
     _release_markers(m_none)
 
     # Stub-viewer arm: assert per-frame writes.
     info_stub = make_markers_imageinfo_2d()
     stub = _StubViewer()
-    m_stub = Markers(info_stub, num_t=2, device="cpu", viewer=stub)
+    m_stub = Markers(info_stub, MarkersConfig(device="cpu"), viewer=stub, num_t=2)
     m_stub.run()
     assert len(stub.status_writes) == 2, (
         f"Expected viewer.status set once per frame (2 writes); "
@@ -498,7 +498,7 @@ def _build_single_frame_iminfo(workdir: Path) -> ImInfo:
     file_info.load_metadata()
     info = ImInfo(file_info)
     Filter(info, FrangiConfig(device="cpu"), num_t=1).run()
-    Label(info, num_t=1, device="cpu").run()
+    Label(info, LabelConfig(device="cpu"), num_t=1).run()
     gc.collect()
     return info
 
@@ -527,7 +527,7 @@ def test_single_frame_shape_branch_both_paths(tmp_path: Path) -> None:
     """
     # ----- [:] arm -----
     info = _build_single_frame_iminfo(tmp_path / "splat_branch")
-    m_splat = Markers(info, num_t=1, device="cpu")
+    m_splat = Markers(info, MarkersConfig(device="cpu"), num_t=1)
     m_splat._set_backend("cpu")
     m_splat._set_low_memory(False)
     m_splat._allocate_memory()
@@ -556,7 +556,7 @@ def test_single_frame_shape_branch_both_paths(tmp_path: Path) -> None:
 
     # ----- [t] arm -----
     info_t = _build_single_frame_iminfo(tmp_path / "frame_branch")
-    m_t = Markers(info_t, num_t=1, device="cpu")
+    m_t = Markers(info_t, MarkersConfig(device="cpu"), num_t=1)
     m_t._set_backend("cpu")
     m_t._set_low_memory(False)
     m_t._allocate_memory()

--- a/tests/test_networking.py
+++ b/tests/test_networking.py
@@ -39,7 +39,7 @@ import pytest
 from scipy import ndimage as ndi_cpu
 
 from nellie.im_info.verifier import ImInfo
-from nellie.segmentation.networking import Network
+from nellie.segmentation.networking import Network, NetworkConfig
 
 
 def _release_network(net: Network) -> None:
@@ -61,7 +61,7 @@ def _release_network(net: Network) -> None:
 def _run_network(info: ImInfo, **kwargs) -> dict[str, np.ndarray]:
     """Run ``Network`` on ``info`` and return copies of the on-disk outputs."""
     kwargs.setdefault("device", "cpu")
-    net = Network(info, num_t=2, **kwargs)
+    net = Network(info, NetworkConfig(**kwargs), num_t=2)
     net.run()
     out = {
         "skel": np.asarray(net.skel_memmap).copy(),
@@ -81,7 +81,7 @@ def _build_cpu_network(info: ImInfo, **kwargs) -> Network:
     Always pinned to CPU for deterministic behavior.
     """
     kwargs.setdefault("device", "cpu")
-    net = Network(info, num_t=2, **kwargs)
+    net = Network(info, NetworkConfig(**kwargs), num_t=2)
     net._set_backend("cpu")
     net._set_low_memory(kwargs.get("low_memory", False))
     net._allocate_memory()

--- a/wiki/segmentation/labelling.md
+++ b/wiki/segmentation/labelling.md
@@ -17,6 +17,7 @@ Frangi response is continuous; tracking and features need discrete object IDs. C
 - Output `im_instance_label` consumed by [[networking]], [[mocap-marking]], [[tracking/index|tracking]], and [[feature-extraction]].
 - Threshold helpers from [[gpu-runtime|gpu_functions]].
 - Backend selection and OOM cascade go through [[gpu-runtime|`adaptive_run`]].
+- Algorithm config is bundled in a `LabelConfig` frozen dataclass colocated in `labelling.py`. `Label(im_info, LabelConfig(threshold=..., ...), viewer=None, num_t=None)` is the construction shape. The cascade may mutate `Label.device` / `Label.low_memory` runtime state; `Label.config` preserves the original intent.
 
 ## Adaptive backend & low-memory mode
 

--- a/wiki/segmentation/mocap-marking.md
+++ b/wiki/segmentation/mocap-marking.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-06
-modified: 2026-05-09
+modified: 2026-05-08
 ---
 
 # Mocap marking
@@ -15,6 +15,7 @@ Detect motion-tracking anchor points (multi-scale LoG peaks) inside each label, 
 
 - Inputs: [[labelling|`im_instance_label`]] + raw intensity (+ [[filtering|Frangi]] if `use_im='frangi'`).
 - Outputs feed [[hu-tracking|Hu-moment tracking]] (markers, distance), [[voxel-reassignment]] (markers indirectly via the flow array), and [[feature-extraction]] (distance, border).
+- Algorithm config is bundled in a `MarkersConfig` frozen dataclass colocated in `mocap_marking.py`. `Markers(im_info, MarkersConfig(use_im=..., ...), viewer=None, num_t=None)` is the construction shape. The cascade may mutate `Markers.device` / `Markers.low_memory` runtime state; `Markers.config` preserves the original intent.
 
 ## Gotchas
 

--- a/wiki/segmentation/networking.md
+++ b/wiki/segmentation/networking.md
@@ -28,6 +28,7 @@ Topology — branches, junctions, tips — is what enables network metrics (leng
 - Inputs: [[labelling|`im_instance_label`]], raw, [[filtering|`im_preprocessed`]].
 - Outputs consumed by [[feature-extraction]] (branches/components level), [[voxel-reassignment]] (branch labels), and the [[visualizer|napari visualizer]] (label layers).
 - Plugs into the [[gpu-runtime|adaptive_run cascade]]: `run()` iterates `mode_candidates` over `(device, low_memory)` pairs, retrying the whole pipeline if a stage raises an OOM or GPU-unavailable error.
+- Algorithm config is bundled in a `NetworkConfig` frozen dataclass colocated in `networking.py`. `Network(im_info, NetworkConfig(min_radius_um=..., ...), viewer=None, num_t=None)` is the construction shape. The cascade may mutate `Network.device` / `Network.low_memory` runtime state; `Network.config` preserves the original intent.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Add `LabelConfig`, `NetworkConfig`, `MarkersConfig` frozen dataclasses colocated above their respective classes, mirroring the `FrangiConfig` pattern from PRD #66. Migrate the 3 stage constructors to `Stage(im_info, config: StageConfig = StageConfig(), viewer=None, num_t=None)`. Update `nellie/run.py` (3 call sites), `nellie_napari/nellie_processor.py` (3 `_run_*` methods), 3 test files, and 3 wiki articles. Pure mechanical refactor — no behavior changes.

**Deviations worth noting (verified by agent during implementation):**
- `MarkersConfig.peak_min_distance` defaults to `2` (matches current constructor default, not `1` as PRD #112 spec listed from a quick grep).
- `tests/conftest.py` and `tests/test_hu_tracking.py` also touched — inline `Label/Network/Markers(im_info, num_t=2, device="cpu")` calls cascade through the fixture chain and need the same wrap.

Net: +215/-169 across 13 files (3 stage files, run.py, processor, 5 test files, 3 wiki articles).

Closes #113.

## Test plan

- [x] `pytest tests/ -v` — 147 passed, 88 warnings, 33.74s. All Filter/Label/Network/Markers/Hu/VoxelReassigner/Hierarchy suites still green.
- [x] Pyright: 72 → 72 errors on the 3 stage source files. **No new diagnostics introduced**; the system-reminder line-number-shift "new" flags are pre-existing diagnostics surfacing at new offsets (same pattern as Hierarchy Slice 2/3 #110/#111).
- [ ] Manual napari smoke check (segmentation tabs still launch and run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)