### PR TITLE
config-extraction: tracking cluster + COST_CUTOFF lift (Slice 2 of #112)

### DIFF
--- a/nellie/run.py
+++ b/nellie/run.py
@@ -10,8 +10,8 @@ from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label, LabelConfig
 from nellie.segmentation.mocap_marking import Markers, MarkersConfig
 from nellie.segmentation.networking import Network, NetworkConfig
-from nellie.tracking.hu_tracking import HuMomentTracking
-from nellie.tracking.voxel_reassignment import VoxelReassigner
+from nellie.tracking.hu_tracking import HuMomentTracking, HuMomentTrackingConfig
+from nellie.tracking.voxel_reassignment import VoxelReassigner, VoxelReassignerConfig
 
 import time
 
@@ -96,7 +96,10 @@ def run(
 
     if timeit:
         start_time = time.perf_counter()
-    hu_tracking = HuMomentTracking(im_info, device=device, low_memory=low_memory)
+    hu_tracking = HuMomentTracking(
+        im_info,
+        HuMomentTrackingConfig(device=device, low_memory=low_memory),
+    )
     hu_tracking.run()
     if timeit:
         end_time = time.perf_counter()
@@ -104,7 +107,7 @@ def run(
 
     if timeit:
         start_time = time.perf_counter()
-    vox_reassign = VoxelReassigner(im_info, device=device)
+    vox_reassign = VoxelReassigner(im_info, VoxelReassignerConfig(device=device))
     vox_reassign.run()
     if timeit:
         end_time = time.perf_counter()

--- a/nellie/tracking/hu_tracking.py
+++ b/nellie/tracking/hu_tracking.py
@@ -15,13 +15,6 @@ from nellie.utils.base_logger import logger
 from nellie.im_info.verifier import ImInfo
 
 
-# Single source of truth for the match-acceptance cost cutoff used in BOTH the
-# dense (``_find_best_matches``) and sparse (``_match_frames_sparse``) paths.
-# Pinned by ``test_cost_cutoff_pinned_in_both_paths``; lifting to a constructor
-# arg is deferred to the cross-stage HuMomentTrackingConfig slice.
-_COST_CUTOFF = 1.0
-
-
 @dataclass
 class _FrameFeatures:
     """Internal container for per-frame features."""
@@ -29,6 +22,27 @@ class _FrameFeatures:
     coords_phys: np.ndarray   # (N, 2) or (N, 3) in micrometers
     stats: object             # xp.ndarray, shape (N, F_stats)
     hu: object                # xp.ndarray, shape (N, F_hu)
+
+
+@dataclass(frozen=True)
+class HuMomentTrackingConfig:
+    """Algorithm configuration for ``HuMomentTracking``.
+
+    Frozen — represents the user's intent at construction time.
+    HuMomentTracking copies these values into mutable instance attributes
+    that the OOM/availability cascade can update mid-run (``device``,
+    ``low_memory``). Inspect ``HuMomentTracking.config`` to see the
+    original intent regardless of any cascade-driven runtime fallbacks.
+    """
+
+    max_distance_um: float = 1.0
+    device: str = "auto"
+    mode: str = "auto"
+    max_dense_pairs: int = int(1e7)
+    max_dense_roi_voxels_cpu: int = int(5e7)
+    max_dense_roi_voxels_gpu: int = int(2e7)
+    low_memory: bool = False
+    cost_cutoff: float = 1.0
 
 
 class HuMomentTracking:
@@ -81,16 +95,27 @@ class HuMomentTracking:
         Rough upper bound on total ROI voxels for dense ROI extraction on GPU.
     """
 
-    def __init__(self, im_info: ImInfo, num_t=None,
-                 max_distance_um=1.0,
-                 viewer=None,
-                 device: str = "auto",
-                 mode: str = "auto",
-                 max_dense_pairs: int = int(1e7),
-                 max_dense_roi_voxels_cpu: int = int(5e7),
-                 max_dense_roi_voxels_gpu: int = int(2e7),
-                 low_memory: bool = False):
+    def __init__(
+        self,
+        im_info: ImInfo,
+        config: HuMomentTrackingConfig = HuMomentTrackingConfig(),
+        viewer=None,
+        num_t: int | None = None,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        im_info : ImInfo
+            Image metadata and memory-mapped image data.
+        config : HuMomentTrackingConfig
+            Algorithm configuration. Defaults to ``HuMomentTrackingConfig()``.
+        viewer : object or None, optional
+            Optional GUI viewer with a ``.status`` attribute.
+        num_t : int, optional
+            Number of timepoints to process. If None, inferred from image.
+        """
         self.im_info = im_info
+        self.config = config
 
         # If no time dimension, nothing to do.
         if self.im_info.no_t:
@@ -110,7 +135,7 @@ class HuMomentTracking:
         dt = self.im_info.dim_res.get('T') or 1.0
         if self.im_info.dim_res.get('T') is None:
             logger.warning("Time resolution missing; assuming 1.0s for max_distance_um scaling.")
-        self.max_distance_um = max(max_distance_um * dt, 0.5)
+        self.max_distance_um = max(config.max_distance_um * dt, 0.5)
 
         self.im_memmap = None
         self.im_frangi_memmap = None
@@ -120,17 +145,20 @@ class HuMomentTracking:
 
         self.viewer = viewer
 
+        # Cascade-mutable runtime state. Initial values come from config;
+        # ``_set_backend`` and ``_set_low_memory`` may update them on retry.
         # Backend / device info — normalize aliases ("cuda" → "gpu") at the
         # constructor edge so downstream code only sees "auto" | "cpu" | "gpu".
-        self.device = adaptive_run.normalize_device(device)
+        self.device = adaptive_run.normalize_device(config.device)
         self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(self.device)
+        self.low_memory = bool(config.low_memory)
 
-        # Matching / ROI mode tuning
-        self.mode = mode  # "auto", "dense", "sparse"
-        self.low_memory = bool(low_memory)
-        self.max_dense_pairs = int(max_dense_pairs)
-        self.max_dense_roi_voxels_cpu = int(max_dense_roi_voxels_cpu)
-        self.max_dense_roi_voxels_gpu = int(max_dense_roi_voxels_gpu)
+        # Aliases for hot path readability — config remains the source of truth.
+        self.mode = config.mode  # "auto", "dense", "sparse"
+        self.max_dense_pairs = int(config.max_dense_pairs)
+        self.max_dense_roi_voxels_cpu = int(config.max_dense_roi_voxels_cpu)
+        self.max_dense_roi_voxels_gpu = int(config.max_dense_roi_voxels_gpu)
+        self.cost_cutoff = float(config.cost_cutoff)
 
     # -------------------------------------------------------------------------
     # Backend helpers
@@ -834,7 +862,7 @@ class HuMomentTracking:
         # Row candidates
         for i, (r_idx, r_val) in enumerate(zip(row_min_idx, row_min_val)):
             val = float(r_val)
-            if val > _COST_CUTOFF:
+            if val > self.cost_cutoff:
                 continue
             row_matches.append(int(i))
             col_matches.append(int(r_idx))
@@ -843,7 +871,7 @@ class HuMomentTracking:
         # Column candidates
         for j, (c_idx, c_val) in enumerate(zip(col_min_idx, col_min_val)):
             val = float(c_val)
-            if val > _COST_CUTOFF:
+            if val > self.cost_cutoff:
                 continue
             row_matches.append(int(c_idx))
             col_matches.append(int(j))
@@ -960,7 +988,7 @@ class HuMomentTracking:
             z_hu = (hu_diff - mean_hu) / std_hu
 
             cost = z_dist + np.mean(z_stats, axis=1) + np.mean(z_hu, axis=1)
-            valid_mask = cost <= _COST_CUTOFF
+            valid_mask = cost <= self.cost_cutoff
             if not np.any(valid_mask):
                 continue
 
@@ -989,14 +1017,14 @@ class HuMomentTracking:
 
         # Row-based candidates
         for i_post, (j_pre, c) in enumerate(zip(row_min_idx, row_min_val)):
-            if j_pre >= 0 and c <= _COST_CUTOFF:
+            if j_pre >= 0 and c <= self.cost_cutoff:
                 row_matches.append(int(i_post))
                 col_matches.append(int(j_pre))
                 costs.append(float(c))
 
         # Column-based candidates
         for j_pre, (i_post, c) in enumerate(zip(col_min_idx, col_min_val)):
-            if i_post >= 0 and c <= _COST_CUTOFF:
+            if i_post >= 0 and c <= self.cost_cutoff:
                 row_matches.append(int(i_post))
                 col_matches.append(int(j_pre))
                 costs.append(float(c))

--- a/nellie/tracking/voxel_reassignment.py
+++ b/nellie/tracking/voxel_reassignment.py
@@ -23,6 +23,26 @@ class _TreeHandle:
     coords_real_scaled: Optional[np.ndarray] = None
 
 
+@dataclass(frozen=True)
+class VoxelReassignerConfig:
+    """Algorithm configuration for ``VoxelReassigner``.
+
+    Frozen — represents the user's intent at construction time.
+    VoxelReassigner copies these values into mutable instance attributes
+    that the OOM/availability cascade can update mid-run (``device``,
+    ``low_memory``, ``max_query_points``, ``max_bruteforce_pairs``).
+    Inspect ``VoxelReassigner.config`` to see the original intent
+    regardless of any cascade-driven runtime fallbacks.
+    """
+
+    store_running_matches: bool = True
+    max_refine_iterations: int = 3
+    device: str = "auto"
+    low_memory: bool = False
+    max_query_points: int = int(1e6)
+    max_bruteforce_pairs: int = int(1e7)
+
+
 class VoxelReassigner:
     """
     A class for voxel reassignment across time points using forward and backward flow interpolation.
@@ -36,50 +56,49 @@ class VoxelReassigner:
       - Assigns labels using weighted votes from forward/backward interpolations.
     """
 
-    def __init__(self, im_info: ImInfo, num_t=None, viewer=None,
-                 store_running_matches: bool = True,
-                 max_refine_iterations: int = 3,
-                 device: str = "auto",
-                 low_memory: bool = False,
-                 max_query_points: int = int(1e6),
-                 max_bruteforce_pairs: int = int(1e7)):
+    def __init__(
+        self,
+        im_info: ImInfo,
+        config: VoxelReassignerConfig = VoxelReassignerConfig(),
+        viewer=None,
+        num_t: int | None = None,
+    ) -> None:
         """
         Parameters
         ----------
         im_info : ImInfo
             Image metadata and memory-mapped data.
-        num_t : int, optional
-            Number of timepoints in the dataset. If None, it is inferred from the image metadata.
+        config : VoxelReassignerConfig
+            Algorithm configuration. Defaults to ``VoxelReassignerConfig()``.
         viewer : Any, optional
             Optional viewer for visualization / status updates.
-        store_running_matches : bool, optional
-            If True, store per-frame voxel matches (may be large for big datasets).
-            Matches are stored as one best source per target voxel.
-        max_refine_iterations : int, optional
-            Maximum number of vote iterations to assign labels at t+1 from t.
-            Set to 1 for a single pass.
-        device : {"auto", "cpu", "gpu"}, optional
-            Backend selection for nearest-neighbor matching.
-        low_memory : bool, optional
-            If True, prefer lower-memory matching strategies at the cost of speed.
-        max_query_points : int, optional
-            Maximum number of points per KDTree query chunk.
-        max_bruteforce_pairs : int, optional
-            Maximum number of pairwise distances to compute in GPU brute-force mode.
+        num_t : int, optional
+            Number of timepoints in the dataset. If None, it is inferred from the image metadata.
         """
         self.im_info = im_info
-        self.device = adaptive_run.normalize_device(device)
-        self._base_max_query_points = max(1, int(max_query_points))
-        self._base_max_bruteforce_pairs = max(1, int(max_bruteforce_pairs))
+        self.config = config
+
+        # Cascade-mutable runtime state. Initial values come from config;
+        # ``_set_backend`` and ``_set_low_memory`` may update them on retry.
+        self.device = adaptive_run.normalize_device(config.device)
+        # ``_base_max_*`` shadow attributes preserve the user's intent across
+        # ``_set_low_memory`` recomputes (which clamp ``self.max_*`` based on
+        # ``self.low_memory``).
+        self._base_max_query_points = max(1, int(config.max_query_points))
+        self._base_max_bruteforce_pairs = max(1, int(config.max_bruteforce_pairs))
         self.max_query_points = self._base_max_query_points
         self.max_bruteforce_pairs = self._base_max_bruteforce_pairs
-        self.low_memory = bool(low_memory)
+        self.low_memory = bool(config.low_memory)
         if self.low_memory:
             self.max_query_points = min(self.max_query_points, int(2e5))
             self.max_bruteforce_pairs = min(self.max_bruteforce_pairs, int(2e6))
         self.xp, _ndi, self.device_type = adaptive_run.resolve_backend(self.device)
         self._gpu_kdtree_cls = self._get_gpu_kdtree_cls() if self.device_type == "cuda" else None
         self._warned_gpu_fallback = False
+
+        # Aliases for hot path readability — config remains the source of truth.
+        self.store_running_matches = config.store_running_matches
+        self.max_refine_iterations = config.max_refine_iterations
 
         # handle single-timepoint data early
         if self.im_info.no_t:
@@ -93,8 +112,6 @@ class VoxelReassigner:
             self.reassigned_branch_memmap = None
             self.reassigned_obj_memmap = None
             self.viewer = viewer
-            self.store_running_matches = store_running_matches
-            self.max_refine_iterations = max_refine_iterations
             return
 
         self.num_t = num_t
@@ -115,10 +132,6 @@ class VoxelReassigner:
         self.reassigned_obj_memmap = None
 
         self.viewer = viewer
-
-        # optimization / behavior controls
-        self.store_running_matches = store_running_matches
-        self.max_refine_iterations = max_refine_iterations
 
     # -------------------------------------------------------------------------
     # Backend helpers

--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -12,8 +12,8 @@ from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label, LabelConfig
 from nellie.segmentation.mocap_marking import Markers, MarkersConfig
 from nellie.segmentation.networking import Network, NetworkConfig
-from nellie.tracking.hu_tracking import HuMomentTracking
-from nellie.tracking.voxel_reassignment import VoxelReassigner
+from nellie.tracking.hu_tracking import HuMomentTracking, HuMomentTrackingConfig
+from nellie.tracking.voxel_reassignment import VoxelReassigner, VoxelReassignerConfig
 from napari.qt.threading import thread_worker
 
 
@@ -448,11 +448,14 @@ class NellieProcessor(QWidget):
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Tracking file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            base_kwargs = {
-                "im_info": self.current_im_info,
-                "viewer": self.viewer,
-            }
-            hu_tracking = HuMomentTracking(**base_kwargs, **step_kwargs)
+            config_kwargs = dict(step_kwargs)
+            num_t = config_kwargs.pop("num_t", None)
+            hu_tracking = HuMomentTracking(
+                im_info=self.current_im_info,
+                config=HuMomentTrackingConfig(**config_kwargs),
+                viewer=self.viewer,
+                num_t=num_t,
+            )
             hu_tracking.run()
 
     def run_tracking(self):
@@ -487,11 +490,14 @@ class NellieProcessor(QWidget):
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Voxel Reassignment file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            base_kwargs = {
-                "im_info": self.current_im_info,
-                "viewer": self.viewer,
-            }
-            vox_reassign = VoxelReassigner(**base_kwargs, **step_kwargs)
+            config_kwargs = dict(step_kwargs)
+            num_t = config_kwargs.pop("num_t", None)
+            vox_reassign = VoxelReassigner(
+                im_info=self.current_im_info,
+                config=VoxelReassignerConfig(**config_kwargs),
+                viewer=self.viewer,
+                num_t=num_t,
+            )
             vox_reassign.run()
 
     def run_reassign(self):

--- a/scripts/voxel_reassignment_demo.py
+++ b/scripts/voxel_reassignment_demo.py
@@ -9,7 +9,7 @@ import pickle
 import numpy as np
 
 from nellie.im_info.verifier import FileInfo, ImInfo
-from nellie.tracking.voxel_reassignment import VoxelReassigner
+from nellie.tracking.voxel_reassignment import VoxelReassigner, VoxelReassignerConfig
 
 
 def accumulate_pair_counts(src_ids, dst_ids, n_src, n_dst, use_gpu=True):
@@ -55,7 +55,7 @@ def main():
     file_info.load_metadata()
     im_info = ImInfo(file_info)
 
-    run_obj = VoxelReassigner(im_info, num_t=3)
+    run_obj = VoxelReassigner(im_info, VoxelReassignerConfig(), num_t=3)
     run_obj.run()
 
     edges_loaded = pickle.load(open(im_info.pipeline_paths["adjacency_maps"], "rb"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,8 +79,8 @@ from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label, LabelConfig
 from nellie.segmentation.mocap_marking import Markers, MarkersConfig
 from nellie.segmentation.networking import Network, NetworkConfig
-from nellie.tracking.hu_tracking import HuMomentTracking
-from nellie.tracking.voxel_reassignment import VoxelReassigner
+from nellie.tracking.hu_tracking import HuMomentTracking, HuMomentTrackingConfig
+from nellie.tracking.voxel_reassignment import VoxelReassigner, VoxelReassignerConfig
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_3D_PATH = REPO_ROOT / "tests" / "fixtures" / "yeast_3d_t0_to_1.ome.tif"
@@ -817,7 +817,7 @@ def _run_hu_to_disk(im_info: ImInfo) -> Path:
     The upstream Markers/Label/Frangi memmap handles must still be
     released so Windows lets us read/copy them later.
     """
-    h = HuMomentTracking(im_info, num_t=2, device="cpu")
+    h = HuMomentTracking(im_info, HuMomentTrackingConfig(device="cpu"), num_t=2)
     h.run()
     h.label_memmap = None
     h.im_memmap = None
@@ -1053,7 +1053,7 @@ def _run_voxel_reassign_to_disk(im_info: ImInfo) -> dict[str, Path]:
     Drops VoxelReassigner's memmap handles so Windows lets us read/copy
     the files later (mirrors ``_run_filter_to_disk`` / ``_run_label_to_disk``).
     """
-    v = VoxelReassigner(im_info, num_t=2, device="cpu")
+    v = VoxelReassigner(im_info, VoxelReassignerConfig(device="cpu"), num_t=2)
     v.run()
     v.branch_label_memmap = None
     v.obj_label_memmap = None

--- a/tests/test_hu_tracking.py
+++ b/tests/test_hu_tracking.py
@@ -85,6 +85,7 @@ from nellie.segmentation.labelling import Label, LabelConfig
 from nellie.segmentation.mocap_marking import Markers, MarkersConfig
 from nellie.tracking.hu_tracking import (
     HuMomentTracking,
+    HuMomentTrackingConfig,
     _FrameFeatures,
 )
 
@@ -117,7 +118,7 @@ def _run_hu(info: ImInfo, **kwargs) -> HuMomentTracking:
     ``flow_vector_array`` on disk.
     """
     kwargs.setdefault("device", "cpu")
-    h = HuMomentTracking(info, num_t=2, **kwargs)
+    h = HuMomentTracking(info, HuMomentTrackingConfig(**kwargs), num_t=2)
     h.run()
     return h
 
@@ -411,7 +412,7 @@ def test_no_t_axis_early_return(tmp_path: Path) -> None:
     this dataset.
     """
     info = _build_single_frame_iminfo(tmp_path / "single_frame")
-    h = HuMomentTracking(info, num_t=1, device="cpu")
+    h = HuMomentTracking(info, HuMomentTrackingConfig(device="cpu"), num_t=1)
     h.run()  # must not raise
     fva_path = Path(info.pipeline_paths["flow_vector_array"])
     assert not fva_path.exists(), (
@@ -452,7 +453,9 @@ def test_mode_sparse_does_not_mutate_device_type(make_hu_imageinfo_3d) -> None:
     path.
     """
     info = make_hu_imageinfo_3d()
-    h = HuMomentTracking(info, num_t=2, device="cpu", mode="sparse")
+    h = HuMomentTracking(
+        info, HuMomentTrackingConfig(device="cpu", mode="sparse"), num_t=2
+    )
     h.run()
     arr = _load_flow_vector_array(info)
     assert h.device_type == "cpu", (
@@ -472,7 +475,9 @@ def test_mode_auto_switches_on_max_dense_pairs(make_hu_imageinfo_3d) -> None:
     """
     info_sparse = make_hu_imageinfo_3d()
     h_sparse = HuMomentTracking(
-        info_sparse, num_t=2, device="cpu", mode="auto", max_dense_pairs=1
+        info_sparse,
+        HuMomentTrackingConfig(device="cpu", mode="auto", max_dense_pairs=1),
+        num_t=2,
     )
     h_sparse.run()
     arr_sparse = _load_flow_vector_array(info_sparse)
@@ -481,10 +486,10 @@ def test_mode_auto_switches_on_max_dense_pairs(make_hu_imageinfo_3d) -> None:
     info_dense = make_hu_imageinfo_3d()
     h_dense = HuMomentTracking(
         info_dense,
+        HuMomentTrackingConfig(
+            device="cpu", mode="auto", max_dense_pairs=int(1e12)
+        ),
         num_t=2,
-        device="cpu",
-        mode="auto",
-        max_dense_pairs=int(1e12),
     )
     h_dense.run()
     arr_dense = _load_flow_vector_array(info_dense)
@@ -508,7 +513,9 @@ def test_low_memory_forces_streaming_roi(
     production code.
     """
     info = make_hu_imageinfo_3d()
-    h = HuMomentTracking(info, num_t=2, device="cpu", low_memory=True)
+    h = HuMomentTracking(
+        info, HuMomentTrackingConfig(device="cpu", low_memory=True), num_t=2
+    )
 
     calls = {"n": 0}
     real_streaming = HuMomentTracking._compute_features_streaming
@@ -598,6 +605,9 @@ def test_dense_vs_sparse_match_set_equivalence(tmp_path: Path) -> None:
     h.max_dense_roi_voxels_cpu = int(1e12)
     h.max_dense_roi_voxels_gpu = int(1e12)
     h.low_memory = False
+    # Slice 2 of #112 lifted ``_COST_CUTOFF`` to ``self.cost_cutoff``.
+    # ``__new__`` bypasses ``__init__`` so we have to set it explicitly.
+    h.cost_cutoff = HuMomentTrackingConfig().cost_cutoff
 
     # Three markers in pre-frame, three in post-frame; nearly 1:1.
     coords_pre = np.array([[0.0, 0.0], [0.0, 4.0], [4.0, 0.0]], dtype=float)
@@ -782,14 +792,18 @@ def test_viewer_status_callback(make_hu_imageinfo_2d) -> None:
     """
     # No-op arm: viewer=None.
     info_none = make_hu_imageinfo_2d()
-    h_none = HuMomentTracking(info_none, num_t=2, device="cpu", viewer=None)
+    h_none = HuMomentTracking(
+        info_none, HuMomentTrackingConfig(device="cpu"), viewer=None, num_t=2
+    )
     h_none.run()  # must not raise
     _release_hu(h_none)
 
     # Stub-viewer arm: assert per-frame writes.
     info_stub = make_hu_imageinfo_2d()
     stub = _StubViewer()
-    h_stub = HuMomentTracking(info_stub, num_t=2, device="cpu", viewer=stub)
+    h_stub = HuMomentTracking(
+        info_stub, HuMomentTrackingConfig(device="cpu"), viewer=stub, num_t=2
+    )
     h_stub.run()
     assert len(stub.status_writes) == 2, (
         f"Expected viewer.status set once per frame (2 writes); "
@@ -833,7 +847,9 @@ def test_cascade_b_dense_match_oom_does_not_mutate_device_type(
     ``self.xp`` / ``self.ndi`` / ``self.device_type``.
     """
     info = make_hu_imageinfo_3d()
-    h = HuMomentTracking(info, num_t=2, device="cpu", mode="dense")
+    h = HuMomentTracking(
+        info, HuMomentTrackingConfig(device="cpu", mode="dense"), num_t=2
+    )
 
     real_get_cost = HuMomentTracking._get_cost_matrix
     state: dict[str, object] = {"raised": False, "device_type_at_raise": None}

--- a/tests/test_voxel_reassignment.py
+++ b/tests/test_voxel_reassignment.py
@@ -92,7 +92,11 @@ import pytest
 
 import nellie.tracking.voxel_reassignment as vr_module
 from nellie.im_info.verifier import ImInfo
-from nellie.tracking.voxel_reassignment import VoxelReassigner, _TreeHandle
+from nellie.tracking.voxel_reassignment import (
+    VoxelReassigner,
+    VoxelReassignerConfig,
+    _TreeHandle,
+)
 
 
 # -------------------------------------------------------------------------
@@ -124,7 +128,7 @@ def _run_voxel_reassign(info: ImInfo, **kwargs) -> VoxelReassigner:
     inspecting the on-disk outputs.
     """
     kwargs.setdefault("device", "cpu")
-    v = VoxelReassigner(info, num_t=2, **kwargs)
+    v = VoxelReassigner(info, VoxelReassignerConfig(**kwargs), num_t=2)
     v.run()
     return v
 
@@ -367,7 +371,7 @@ def test_match_coord_dtype_synthetic_widens_to_uint32(
     pin without building a multi-GB synthetic fixture.
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
     v._allocate_memory()
     v.spatial_shape = (65_537, 8, 8)
     assert v._select_match_coord_dtype() == np.uint32
@@ -518,7 +522,7 @@ def test_build_tree_empty_input_returns_cpu_none_handle(
     the documented empty arrays (lines 271-272 + 275-276).
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
     handle = v._build_tree(np.empty((0, 3), dtype=np.float32))
     assert isinstance(handle, _TreeHandle)
     assert handle.backend == "cpu"
@@ -540,7 +544,7 @@ def test_build_tree_default_cpu_path_returns_cpu_with_tree(
 ) -> None:
     """Default CPU path: ``backend="cpu"`` with populated ``tree``; ``_query_tree`` works."""
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
     coords = np.array(
         [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], dtype=np.float32
     )
@@ -572,7 +576,7 @@ def test_cpu_bruteforce_fallback_on_ckdtree_memory_error(
     ``_query_bruteforce_cpu`` at line 314-315).
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
 
     real_ckdtree = vr_module.cKDTree
     state = {"raised": False}
@@ -626,7 +630,7 @@ def test_empty_master_mask_breaks_loop(
     before any t=1 writes).
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
 
     def empty_mask(_self, _t):
         return np.zeros(_self.spatial_shape, dtype=bool)
@@ -662,7 +666,7 @@ def test_match_voxels_empty_inputs_returns_empty_pair(
     branch which returns 3. We pin the actual returned shape contract.
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
     v._allocate_memory()  # populate spatial_shape
     vox_prev = np.empty((0, 3), dtype=int)
     vox_next = np.array([[1, 2, 3], [4, 5, 6]], dtype=int)
@@ -696,7 +700,7 @@ def test_distance_threshold_drops_above_max_distance(
     ``voxel_reassignment.py:744-745``.
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
     # Don't need _allocate_memory for _distance_threshold; it uses
     # flow_interpolator_fw.scaling and .max_distance_um directly.
     assert v.flow_interpolator_fw is not None
@@ -750,7 +754,7 @@ def test_vote_targets_inverse_distance_weighted(
     (lines 429-467).
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
     v._allocate_memory()  # populate spatial_shape
 
     # All three sources point at the same target voxel.
@@ -788,7 +792,7 @@ def test_select_best_pairs_returns_one_best_per_target(
     1 (distance 1.0).
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
     v._allocate_memory()
 
     sources = np.array(
@@ -829,7 +833,7 @@ def test_no_t_short_circuit(make_voxel_reassign_imageinfo_3d) -> None:
     """
     info = make_voxel_reassign_imageinfo_3d()
     info.no_t = True
-    v = VoxelReassigner(info, num_t=1, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=1)
     v.run()  # must not raise
     branch_path = Path(info.pipeline_paths["im_branch_label_reassigned"])
     obj_path = Path(info.pipeline_paths["im_obj_label_reassigned"])
@@ -921,14 +925,18 @@ def test_viewer_status_callback(make_voxel_reassign_imageinfo_2d) -> None:
     """
     # No-op arm: viewer=None.
     info_none = make_voxel_reassign_imageinfo_2d()
-    v_none = VoxelReassigner(info_none, num_t=2, device="cpu", viewer=None)
+    v_none = VoxelReassigner(
+        info_none, VoxelReassignerConfig(device="cpu"), viewer=None, num_t=2
+    )
     v_none.run()  # must not raise
     _release_voxel_reassigner(v_none)
 
     # Stub-viewer arm: assert per-frame writes.
     info_stub = make_voxel_reassign_imageinfo_2d()
     stub = _StubViewer()
-    v_stub = VoxelReassigner(info_stub, num_t=2, device="cpu", viewer=stub)
+    v_stub = VoxelReassigner(
+        info_stub, VoxelReassignerConfig(device="cpu"), viewer=stub, num_t=2
+    )
     v_stub.run()
     # The loop iterates from t=0 to t < num_t-1, so for num_t=2 there
     # is exactly one iteration. The status string is
@@ -1013,7 +1021,7 @@ def test_build_tree_gpu_oom_does_not_mutate_device_type(
     + ``_warn_gpu_fallback`` block).
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
     _simulate_gpu_state(v, kdtree_cls=_FakeGpuKDTreeOOM)
 
     coords = np.array(
@@ -1056,7 +1064,7 @@ def test_query_tree_gpu_oom_does_not_mutate_device_type(
     ``_query_tree`` directly.
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
     _simulate_gpu_state(v, kdtree_cls=None)
 
     coords_real = np.array(
@@ -1105,7 +1113,7 @@ def test_query_tree_gpu_non_oom_exception_propagates(
     ``ValueError`` instead of ``MemoryError``.
     """
     info = make_voxel_reassign_imageinfo_3d()
-    v = VoxelReassigner(info, num_t=2, device="cpu")
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
     _simulate_gpu_state(v, kdtree_cls=None)
 
     coords_real = np.array(

--- a/wiki/tracking/hu-tracking.md
+++ b/wiki/tracking/hu-tracking.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-06
-modified: 2026-05-08
+modified: 2026-05-09
 ---
 
 # Hu-moment tracking
@@ -18,6 +18,7 @@ Match [[mocap-marking|mocap markers]] across consecutive frames and write a `flo
 - Inputs: `im_marker`, `im_instance_label`, `im_distance`, `im_preprocessed`, raw — all [[segmentation/index|segmentation]] outputs.
 - Output: `flow_vector_array` consumed by [[flow-interpolation]] and [[voxel-reassignment]].
 - Backend: [[gpu-runtime|adaptive_run]] cascade.
+- Algorithm config is bundled in a `HuMomentTrackingConfig` frozen dataclass colocated in `hu_tracking.py`. `HuMomentTracking(im_info, HuMomentTrackingConfig(max_distance_um=1.0, ..., cost_cutoff=1.0), viewer=None, num_t=None)` is the construction shape. The cascade may mutate `HuMomentTracking.device` / `HuMomentTracking.low_memory` runtime state; `HuMomentTracking.config` preserves the original intent.
 
 ## Gotchas
 
@@ -30,7 +31,7 @@ Match [[mocap-marking|mocap markers]] across consecutive frames and write a `flo
   - The dense-ROI → streaming-ROI fallback inside `_get_frame_features` survives — it only flips a local `use_dense = False` and never touches `self.*`.
   - All three surviving inner cascades log a warning, free GPU memory, and continue without mutating backend attributes. Only the outer `mode_candidates` cascade ever flips `self.xp` / `self.ndi` / `self.device_type`.
 - **`low_memory` may be auto-enabled** by `adaptive_run.should_use_low_memory(im_info)` based on estimated memory usage — the constructor default is `False` but the actual run may force streaming ROI extraction anyway.
-- **Match-acceptance cost cutoff is a single module constant `_COST_CUTOFF = 1.0`** at the top of `hu_tracking.py`. Both `_find_best_matches` (dense) and `_match_frames_sparse` (sparse) reference the same constant, so the dense/sparse acceptance rates can no longer drift apart. `test_cost_cutoff_pinned_in_both_paths` is the authoritative spec — bumping the constant flips both paths atomically. Lifting to a constructor arg is deferred to the cross-stage `HuMomentTrackingConfig` slice; there is no documented tuning use case today.
+- **Match-acceptance cost cutoff is the single field `HuMomentTrackingConfig.cost_cutoff` (default `1.0`)**, hot-path-aliased onto `self.cost_cutoff`. Both `_find_best_matches` (dense) and `_match_frames_sparse` (sparse) reference the same attribute, so the dense/sparse acceptance rates can no longer drift apart. `test_cost_cutoff_pinned_in_both_paths` is the authoritative spec — bumping the field flips both paths atomically. Lifted to `HuMomentTrackingConfig.cost_cutoff` in PRD #112 Slice 2 (issue #114). The module constant `_COST_CUTOFF` is gone.
 - **`_find_best_matches` returns the union of row-min and col-min candidates** (not Hungarian), so a target can appear in multiple pairs and downstream code sees duplicates.
 - **Hu moment 7 (mirror invariance) is intentionally omitted.**
 - **3D ROIs are reduced via 3-axis max projection then stacked into 18 features** (not a true 3D moment).

--- a/wiki/tracking/voxel-reassignment.md
+++ b/wiki/tracking/voxel-reassignment.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-06
-modified: 2026-05-08
+modified: 2026-05-09
 ---
 
 # Voxel reassignment
@@ -37,6 +37,7 @@ OOM at any tier triggers `adaptive_run.free_gpu_memory(self.xp)` + a **local-onl
 - Inputs: [[hu-tracking|`flow_vector_array`]] (via `FlowInterpolator`), [[labelling|`im_instance_label`]], [[networking|`im_skel_relabelled`]].
 - Outputs feed [[feature-extraction]] (label identity at the components level via `reassigned_label`) and the [[visualizer|napari visualizer]] (`Reassigned px:` layers).
 - Backend orchestration via [[gpu-runtime|`adaptive_run`]] (`normalize_device`, `gpu_available`, `should_use_low_memory`, `mode_candidates`, `is_oom_error`, `is_gpu_unavailable_error`).
+- Algorithm config is bundled in a `VoxelReassignerConfig` frozen dataclass colocated in `voxel_reassignment.py`. `VoxelReassigner(im_info, VoxelReassignerConfig(store_running_matches=True, ...), viewer=None, num_t=None)` is the construction shape. The cascade may mutate `VoxelReassigner.device` / `VoxelReassigner.low_memory` / `VoxelReassigner.max_query_points` / `VoxelReassigner.max_bruteforce_pairs` runtime state (the `_base_max_*` shadow attributes preserve the user's intent across `_set_low_memory` recomputes); `VoxelReassigner.config` preserves the original intent.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Add `HuMomentTrackingConfig` (with the lifted `cost_cutoff: float = 1.0` field) and `VoxelReassignerConfig` frozen dataclasses, mirroring the FrangiConfig pattern. Migrate the 2 stage constructors to `Stage(im_info, config: StageConfig = StageConfig(), viewer=None, num_t=None)`. **Lift `_COST_CUTOFF`** from a module constant at `hu_tracking.py:22` to `HuMomentTrackingConfig.cost_cutoff`; the 5 in-tree references switch to `self.cost_cutoff`. Update run.py, processor, 2 test files, conftest.py, scripts/voxel_reassignment_demo.py, and 2 wiki articles.

**The wiki's "lift `_COST_CUTOFF` to a constructor arg" instruction (`wiki/tracking/hu-tracking.md:33`) is now resolved.**

**7 PRD-spec default values caught and corrected by the agent's verification step:**
- `HuMomentTrackingConfig`: `max_dense_pairs=int(1e7)`, `max_dense_roi_voxels_cpu=int(5e7)`, `max_dense_roi_voxels_gpu=int(2e7)` (PRD listed `25M/600K/4M` from a quick grep)
- `VoxelReassignerConfig`: `store_running_matches=True`, `max_query_points=int(1e6)`, `max_bruteforce_pairs=int(1e7)` (PRD listed `False/4M/50M`)

Real defaults preserved → behavior parity. The `test_dense_vs_sparse_match_set_equivalence` test bypasses `__init__` via `__new__` and needs `h.cost_cutoff` set explicitly post-construction; agent added an inline assignment with comment.

Closes #114.

## Test plan

- [x] `pytest tests/test_hu_tracking.py tests/test_voxel_reassignment.py -v` — 52/52 green; `test_cost_cutoff_pinned_in_both_paths` still green.
- [x] `pytest tests/ -v` — 147 passed, 88 warnings, 34.45s.
- [x] Pyright: 79 → 80 errors (+1; the new diagnostic is a pre-existing site that got a sharper `int` in its `Unknown | Any | None` union after typing improvements). All other "new" diagnostics in the system-reminder are pre-existing diagnostics shifted by line number — same pattern as Slice 1 and Hierarchy Slice 2/3.
- [x] Verification greps: zero `_COST_CUTOFF` in nellie/, 6 `self.cost_cutoff` references in hu_tracking.py (1 init + 5 sites), `_base_max_*` shadow attributes preserved in voxel_reassignment.py.
- [ ] Manual napari smoke check (Tracking tab still launches and runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)