### PR TITLE
verifier: constructor I/O extraction (Slice 3 of #123)

### DIFF
--- a/nellie/im_info/verifier.py
+++ b/nellie/im_info/verifier.py
@@ -117,7 +117,11 @@ class FileInfo:
     """
     def __init__(self, filepath, output_dir=None, output_naming="detailed"):
         """
-        Initializes the FileInfo object and creates directories for outputs if they do not exist.
+        Initializes the FileInfo object — pure-data, no I/O.
+
+        Output directories are created lazily by ``prepare_output_dirs``,
+        which is called automatically from ``find_metadata``. Construction
+        itself does not touch the filesystem.
 
         Parameters
         ----------
@@ -141,12 +145,7 @@ class FileInfo:
         self.extension = os.path.splitext(filepath)[1].lower()
         self.output_naming = output_naming
         self.output_dir = output_dir or os.path.join(self.input_dir, 'nellie_output')
-        if not os.path.exists(self.output_dir):
-            os.makedirs(self.output_dir)
-
         self.nellie_necessities_dir = os.path.join(self.output_dir, 'nellie_necessities')
-        if not os.path.exists(self.nellie_necessities_dir):
-            os.makedirs(self.nellie_necessities_dir)
 
         self.ome_output_path = None
         self.good_dims = False
@@ -157,6 +156,17 @@ class FileInfo:
         self.t_start = 0
         self.t_end = None
         self.dtype = None
+
+    def prepare_output_dirs(self):
+        """
+        Create ``output_dir`` and ``nellie_necessities_dir`` if missing.
+
+        Idempotent (uses ``exist_ok=True``). Called automatically from
+        ``find_metadata``; can be invoked explicitly by callers that
+        want directories created without metadata extraction.
+        """
+        os.makedirs(self.output_dir, exist_ok=True)
+        os.makedirs(self.nellie_necessities_dir, exist_ok=True)
 
     def _find_tif_metadata(self):
         """
@@ -209,11 +219,16 @@ class FileInfo:
         """
         Detects file type (e.g., TIFF or ND2) and calls the appropriate metadata extraction method.
 
+        Also calls ``prepare_output_dirs`` so output directories exist
+        before any subsequent ``save_ome_tiff`` call. Construction
+        itself does not touch the filesystem; this method does.
+
         Raises
         ------
         ValueError
             If the file type is not supported.
         """
+        self.prepare_output_dirs()
         if self.extension in ('.tiff', '.tif'):
             self._find_tif_metadata()
         elif self.extension == '.nd2':
@@ -820,9 +835,16 @@ class ImInfo:
     """
     def __init__(self, file_info: FileInfo):
         """
-        Initializes the ImInfo object, loading image data and setting up directories for screenshots and graphs.
+        Thin constructor — pure-data, no I/O.
 
-        If the OME-TIFF file does not exist, it creates one by calling `save_ome_tiff()` from the FileInfo class.
+        Stores ``file_info`` and computes the path-derived attributes
+        (``im_path``, ``screenshot_dir``, ``graph_dir``). Initializes
+        all loaded-state attributes to None / empty defaults.
+
+        Use ``ImInfo.from_file_info(file_info)`` for the standard
+        construct-and-load entry point. Calling ``__init__`` alone
+        leaves ``self.im`` as None and ``pipeline_paths`` empty;
+        downstream stages will fail until ``load()`` runs.
 
         Parameters
         ----------
@@ -831,6 +853,45 @@ class ImInfo:
         """
         self.file_info = file_info
         self.im_path = file_info.ome_output_path
+        self.screenshot_dir = os.path.join(self.file_info.output_dir, 'screenshots')
+        self.graph_dir = os.path.join(self.file_info.output_dir, 'graphs')
+
+        self.im = None
+        self.dim_res: DimRes = {'X': None, 'Y': None, 'Z': None, 'T': None}
+        self.axes = None
+        self.new_axes = None
+        self.shape = None
+        self.ome_metadata = None
+        self.file_axes = None
+        self.file_shape = None
+        self.no_z = True
+        self.no_t = True
+        self.pipeline_paths = {}
+
+    @classmethod
+    def from_file_info(cls, file_info: FileInfo) -> "ImInfo":
+        """
+        Construct an ``ImInfo`` and load it in one step.
+
+        Equivalent to ``info = ImInfo(file_info); info.load()``.
+        This is the canonical entry point — every production caller
+        should use it. The thin ``__init__`` exists for tests that
+        want to inspect path computations without the I/O cost of a
+        full load.
+        """
+        instance = cls(file_info)
+        instance.load()
+        return instance
+
+    def load(self) -> None:
+        """
+        Perform the I/O sequence: regen-on-stale, memmap, metadata, paths.
+
+        Idempotent — calling ``load()`` twice re-loads the memmap and
+        re-derives axes/shape/dim_res. Used by ``from_file_info`` and
+        by tests that want to load explicitly after a thin construction.
+        """
+        file_info = self.file_info
         needs_regen = not os.path.exists(self.im_path)
         if not needs_regen:
             with tifffile.TiffFile(self.im_path) as tif:
@@ -841,20 +902,7 @@ class ImInfo:
             file_info.save_ome_tiff()
         self.im = tifffile.memmap(self.im_path)
 
-        self.screenshot_dir = os.path.join(self.file_info.output_dir, 'screenshots')
-        self.graph_dir = os.path.join(self.file_info.output_dir, 'graphs')
-
-        self.dim_res: DimRes = {'X': None, 'Y': None, 'Z': None, 'T': None}
-        self.axes = None
-        self.new_axes = None
-        self.shape = None
-        self.ome_metadata = None
-        self.file_axes = None
-        self.file_shape = None
         self._get_ome_metadata()
-
-        self.no_z = True
-        self.no_t = True
         self._check_axes_exist()
 
         self.pipeline_paths = {}

--- a/nellie/run.py
+++ b/nellie/run.py
@@ -49,7 +49,7 @@ def run(
     ImInfo
         ImInfo object containing processed image data and paths.
     """
-    im_info = ImInfo(file_info)
+    im_info = ImInfo.from_file_info(file_info)
 
     if timeit:
         start_time = time.perf_counter()

--- a/nellie/tracking/flow_vector_viz.py
+++ b/nellie/tracking/flow_vector_viz.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     file_info.find_metadata()
     file_info.load_metadata()
 
-    im_info = ImInfo(file_info)
+    im_info = ImInfo.from_file_info(file_info)
 
     tracks, props = load_flow_vectors_as_tracks(im_info, cost_threshold=None, stride=1)
     markers = load_mocap_markers_as_points(im_info, point_stride=1)

--- a/nellie_napari/nellie_fileselect.py
+++ b/nellie_napari/nellie_fileselect.py
@@ -368,7 +368,7 @@ class NellieFileSelect(QWidget):
         file_infos = self._each_file_info()
         if not file_infos:
             raise RuntimeError("No file(s) selected.")
-        im_infos = [ImInfo(fi) for fi in file_infos]
+        im_infos = [ImInfo.from_file_info(fi) for fi in file_infos]
         return im_infos[0] if len(im_infos) == 1 else im_infos
 
     # -------------------------------------------------------------------------

--- a/scripts/voxel_reassignment_demo.py
+++ b/scripts/voxel_reassignment_demo.py
@@ -53,7 +53,7 @@ def main():
     file_info = FileInfo(im_path)
     file_info.find_metadata()
     file_info.load_metadata()
-    im_info = ImInfo(file_info)
+    im_info = ImInfo.from_file_info(file_info)
 
     run_obj = VoxelReassigner(im_info, VoxelReassignerConfig(), num_t=3)
     run_obj.run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ def _build_iminfo(source: Path, workdir: Path) -> ImInfo:
     file_info = FileInfo(str(dst))
     file_info.find_metadata()
     file_info.load_metadata()
-    return ImInfo(file_info)
+    return ImInfo.from_file_info(file_info)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_hu_tracking.py
+++ b/tests/test_hu_tracking.py
@@ -395,7 +395,7 @@ def _build_single_frame_iminfo(workdir: Path) -> ImInfo:
     file_info = FileInfo(str(raw_path))
     file_info.find_metadata()
     file_info.load_metadata()
-    info = ImInfo(file_info)
+    info = ImInfo.from_file_info(file_info)
     Filter(info, FrangiConfig(device="cpu"), num_t=1).run()
     Label(info, LabelConfig(device="cpu"), num_t=1).run()
     Markers(info, MarkersConfig(device="cpu"), num_t=1).run()

--- a/tests/test_labelling.py
+++ b/tests/test_labelling.py
@@ -103,7 +103,7 @@ def _build_synthetic_label_iminfo(workdir: Path) -> ImInfo:
     file_info = FileInfo(str(raw_path))
     file_info.find_metadata()
     file_info.load_metadata()
-    info = ImInfo(file_info)
+    info = ImInfo.from_file_info(file_info)
 
     rng = np.random.default_rng(42)
     frangi = rng.uniform(0.005, 0.05, size=_SYNTHETIC_SHAPE).astype(np.float32)

--- a/tests/test_mocap_marking.py
+++ b/tests/test_mocap_marking.py
@@ -496,7 +496,7 @@ def _build_single_frame_iminfo(workdir: Path) -> ImInfo:
     file_info = FileInfo(str(raw_path))
     file_info.find_metadata()
     file_info.load_metadata()
-    info = ImInfo(file_info)
+    info = ImInfo.from_file_info(file_info)
     Filter(info, FrangiConfig(device="cpu"), num_t=1).run()
     Label(info, LabelConfig(device="cpu"), num_t=1).run()
     gc.collect()

--- a/tests/test_verifier_fileinfo.py
+++ b/tests/test_verifier_fileinfo.py
@@ -65,6 +65,66 @@ def _loaded_file_info(source, workdir) -> FileInfo:
 
 
 # ============================================================
+# A0. Constructor purity + prepare_output_dirs (Slice 3 boundary)
+# ============================================================
+
+
+def test_thin_constructor_does_no_io(tmp_path) -> None:
+    """``FileInfo(filepath)`` is a thin constructor — no filesystem I/O.
+
+    Slice 3 moved ``os.makedirs`` out of ``__init__`` into
+    ``prepare_output_dirs``, called automatically from ``find_metadata``.
+    The bare constructor only stores path-derived strings.
+
+    Pinned so tests can construct ``FileInfo`` to inspect path
+    computations without creating output directories on disk.
+    """
+    workdir = tmp_path / 'wd'
+    workdir.mkdir()
+    src = workdir / 'tiny.tif'
+    src.write_bytes(b'')  # empty placeholder; constructor doesn't read it
+    output_dir = workdir / 'custom_out'
+    fi = FileInfo(str(src), output_dir=str(output_dir))
+    # Constructor stored the path but did NOT create the directory.
+    assert fi.output_dir == str(output_dir)
+    assert not output_dir.exists()
+    assert not (output_dir / 'nellie_necessities').exists()
+
+
+def test_prepare_output_dirs_creates_both_dirs(tmp_path) -> None:
+    """Explicit ``prepare_output_dirs`` creates both output directories."""
+    src = tmp_path / 'tiny.tif'
+    src.write_bytes(b'')
+    output_dir = tmp_path / 'out'
+    fi = FileInfo(str(src), output_dir=str(output_dir))
+    fi.prepare_output_dirs()
+    assert output_dir.exists()
+    assert (output_dir / 'nellie_necessities').exists()
+
+
+def test_prepare_output_dirs_is_idempotent(tmp_path) -> None:
+    """Re-calling ``prepare_output_dirs`` is safe (uses ``exist_ok=True``)."""
+    src = tmp_path / 'tiny.tif'
+    src.write_bytes(b'')
+    fi = FileInfo(str(src), output_dir=str(tmp_path / 'out'))
+    fi.prepare_output_dirs()
+    fi.prepare_output_dirs()  # would raise without exist_ok=True
+    assert (tmp_path / 'out').exists()
+
+
+def test_find_metadata_creates_output_dirs(tmp_path) -> None:
+    """``find_metadata`` calls ``prepare_output_dirs`` before extraction.
+
+    Pins the auto-call wiring so production callers (run.py, napari
+    fileselect) don't need to call prepare_output_dirs explicitly.
+    """
+    fi = _loaded_file_info(FIXTURE_3D_PATH, tmp_path / 'fixture_workdir')
+    # _loaded_file_info calls find_metadata; output dirs must exist now.
+    assert os.path.isdir(fi.output_dir)
+    assert os.path.isdir(fi.nellie_necessities_dir)
+
+
+# ============================================================
 # A. Per-format dim_res extraction (metadata_type branches)
 # ============================================================
 

--- a/tests/test_verifier_iminfo.py
+++ b/tests/test_verifier_iminfo.py
@@ -188,6 +188,79 @@ def test_canonical_ome_tiff_exists_after_construction(imageinfo_3d: ImInfo) -> N
     assert os.path.exists(imageinfo_3d.im_path)
 
 
+# ------ Thin constructor (Slice 3 boundary) ------
+
+
+def test_thin_constructor_does_no_io(tmp_path: Path) -> None:
+    """``ImInfo(file_info)`` is a thin constructor — no filesystem I/O.
+
+    Slice 3 split ``ImInfo``'s I/O into ``load()``. The bare
+    constructor stores ``file_info`` and computes path-derived
+    attributes only; it does NOT call ``save_ome_tiff``, does NOT
+    open the canonical OME-TIFF, and does NOT memmap. ``info.im``
+    is None until ``load()`` (or ``from_file_info``) runs.
+
+    Pinned so that pure-logic tests in subsequent slices can construct
+    an ImInfo to inspect path computations without triggering OME-TIFF
+    regen or memmap allocation.
+    """
+    workdir = tmp_path / 'wd'
+    workdir.mkdir()
+    src = copy_fixture_to_tmp(FIXTURE_3D_PATH, workdir)
+    fi = FileInfo(str(src))
+    fi.find_metadata()
+    fi.load_metadata()
+
+    # Construct without load — no I/O should fire.
+    info = ImInfo(fi)
+    assert info.im is None
+    assert info.axes is None
+    assert info.shape is None
+    assert info.ome_metadata is None
+    assert info.pipeline_paths == {}
+    # Path-derived attrs ARE populated (they're pure-string ops)
+    assert info.im_path == fi.ome_output_path
+    assert info.screenshot_dir == os.path.join(fi.output_dir, 'screenshots')
+
+
+def test_load_is_idempotent(tmp_path: Path) -> None:
+    """Calling ``load()`` twice is safe — re-loads memmap + paths."""
+    workdir = tmp_path / 'wd'
+    workdir.mkdir()
+    src = copy_fixture_to_tmp(FIXTURE_3D_PATH, workdir)
+    fi = FileInfo(str(src))
+    fi.find_metadata()
+    fi.load_metadata()
+    info = ImInfo(fi)
+    info.load()
+    first_axes = info.axes
+    first_pipeline_paths = dict(info.pipeline_paths)
+    info.load()  # second call should re-load without error
+    assert info.axes == first_axes
+    assert info.pipeline_paths == first_pipeline_paths
+
+
+def test_from_file_info_equivalent_to_explicit_load(tmp_path: Path) -> None:
+    """``ImInfo.from_file_info(fi)`` == ``ImInfo(fi); info.load()``."""
+    workdir = tmp_path / 'wd'
+    workdir.mkdir()
+    src = copy_fixture_to_tmp(FIXTURE_3D_PATH, workdir)
+    fi = FileInfo(str(src))
+    fi.find_metadata()
+    fi.load_metadata()
+
+    via_classmethod = ImInfo.from_file_info(fi)
+    via_explicit = ImInfo(fi)
+    via_explicit.load()
+
+    assert via_classmethod.axes == via_explicit.axes
+    assert via_classmethod.shape == via_explicit.shape
+    assert via_classmethod.dim_res == via_explicit.dim_res
+    assert via_classmethod.no_z == via_explicit.no_z
+    assert via_classmethod.no_t == via_explicit.no_t
+    assert set(via_classmethod.pipeline_paths.keys()) == set(via_explicit.pipeline_paths.keys())
+
+
 # ------ Auto-regen path (verifier.py:765-772) ------
 
 
@@ -206,13 +279,13 @@ def test_construction_skips_regen_when_ome_exists(tmp_path: Path) -> None:
     fi.find_metadata()
     fi.load_metadata()
 
-    info_first = ImInfo(fi)
+    info_first = ImInfo.from_file_info(fi)
     assert info_first.im_path is not None
     mtime_after_first = os.path.getmtime(info_first.im_path)
     # Sleep across the filesystem mtime resolution boundary so a
     # spurious regen would actually shift the mtime.
     time.sleep(1.1)
-    info_second = ImInfo(fi)
+    info_second = ImInfo.from_file_info(fi)
     assert info_second.im_path is not None
     mtime_after_second = os.path.getmtime(info_second.im_path)
     assert mtime_after_second == mtime_after_first
@@ -247,7 +320,7 @@ def test_construction_regens_when_t_axis_missing(tmp_path: Path) -> None:
     # file_info.axes='TZYX' — mismatch should trigger regen.
     assert fi.axes is not None
     assert 'T' in fi.axes
-    info = ImInfo(fi)
+    info = ImInfo.from_file_info(fi)
     assert info.im_path is not None
     mtime_after = os.path.getmtime(info.im_path)
     assert mtime_after > mtime_before
@@ -486,7 +559,7 @@ def test_check_axes_exist_single_timepoint_2d(tmp_path: Path) -> None:
     workdir = tmp_path / 'wd'
     workdir.mkdir()
     fi = _make_minimal_file_info(workdir, source_axes='YX')
-    info = ImInfo(fi)
+    info = ImInfo.from_file_info(fi)
     assert info.axes == 'TYX'
     assert info.shape == (1, 16, 16)
     assert info.no_z is True


### PR DESCRIPTION
## Summary

Slice 3 of the verifier dechaos refactor (issue #123). First slice with real architectural change — moves I/O out of constructors so subsequent slices (4 unified normalizer, 5 validation split, 6 extractor strategy, etc.) can refactor pure logic without filesystem dependencies.

**FileInfo**:
- New ``prepare_output_dirs()`` method creates ``output_dir`` + ``nellie_necessities_dir`` with ``exist_ok=True``.
- ``find_metadata()`` auto-calls ``prepare_output_dirs()`` so production callers see no behavior change.
- ``FileInfo.__init__`` no longer touches the filesystem.

**ImInfo**:
- Thin ``__init__``: stores ``file_info`` + path-derived attrs only. Zero filesystem I/O. Loaded-state attrs initialize to ``None`` / empty defaults.
- New ``load()`` method: regen-on-stale check, ``tifffile.memmap``, ``_get_ome_metadata``, ``_check_axes_exist``, ``_create_output_paths``. Idempotent.
- New ``from_file_info()`` classmethod: construct + load in one step. **The canonical entry point.**

**Callsite updates** (12 total): ``nellie/run.py``, ``nellie_napari/nellie_fileselect.py``, ``nellie/tracking/flow_vector_viz.py``, ``scripts/voxel_reassignment_demo.py``, ``tests/conftest.py``, ``tests/test_hu_tracking.py``, ``tests/test_labelling.py``, ``tests/test_mocap_marking.py``, ``tests/test_verifier_iminfo.py`` (4 callsites). All ``ImInfo(fi)`` → ``ImInfo.from_file_info(fi)``.

**New tests** (7):
- ``test_verifier_fileinfo.py``: 4 tests pinning FileInfo constructor purity, ``prepare_output_dirs`` idempotency, ``find_metadata`` auto-call wiring.
- ``test_verifier_iminfo.py``: 3 tests pinning ImInfo thin-constructor purity, ``load()`` idempotency, ``from_file_info`` equivalence to explicit construct+load.

## Test plan

- [x] Pyright on ``verifier.py``: 86 errors (unchanged from Slice 2 baseline)
- [x] Pyright on test files: 0 errors
- [x] Verifier tests: 129 passed (122 from Slice 1 + 7 new)
- [x] Full test suite: 276 passed (269 baseline + 7 new)

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)