### PR TITLE
verifier: unified axes normalizer (Slice 4 of #125)

### DIFF
--- a/nellie/im_info/verifier.py
+++ b/nellie/im_info/verifier.py
@@ -29,6 +29,144 @@ class DimRes(TypedDict):
     T: float | None
 
 
+def infer_t_axis(
+    source_axes: str | None,
+    source_shape: tuple[int, ...] | None,
+) -> str | None:
+    """
+    Infer a leading T axis when the source library stripped it.
+
+    Some readers (notably tifffile on certain inputs) return an axes
+    string that omits a leading singleton T dim while keeping it in the
+    shape — e.g. axes='ZYX' but shape=(1, 16, 512, 512). This helper
+    detects that pattern and returns the prepended axes string.
+
+    Parameters
+    ----------
+    source_axes : str or None
+        Axes string from the source reader (e.g. 'ZYX', 'TZYX').
+    source_shape : tuple of int or None
+        Shape from the source reader.
+
+    Returns
+    -------
+    str or None
+        ``source_axes`` with 'T' prepended when the leading-singleton
+        heuristic fires; otherwise ``source_axes`` unchanged. Returns
+        ``None`` when either input is ``None``.
+    """
+    if source_axes is None or source_shape is None:
+        return source_axes
+    if 'T' in source_axes:
+        return source_axes
+    if len(source_shape) == len(source_axes) + 1 and source_shape[0] == 1:
+        return 'T' + source_axes
+    return source_axes
+
+
+def transform_to_axes(
+    data: np.ndarray,
+    source_axes: str | None,
+    target_axes: str | None = None,
+) -> tuple[np.ndarray, str]:
+    """
+    Transform a data array so its axes match a target layout.
+
+    Two modes:
+
+    - **Canonical mode** (``target_axes=None``): derive a canonical
+      ``T[Z]YX`` target — T is prepended if absent (or moved to index 0
+      if present elsewhere); singleton Z is always squeezed; the result
+      must contain Y and X and use only ``{T, Z, Y, X}``.
+    - **Match mode** (``target_axes`` is a string): rearrange to match
+      the supplied target. T is prepended if source lacks T; Z is
+      squeezed only when the target lacks Z (raises if Z>1 in source
+      but missing in target). Source axes set must equal target axes
+      set after T-handling and the conditional Z-squeeze.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Data array to transform.
+    source_axes : str
+        Axes string describing ``data``'s current layout.
+    target_axes : str or None, optional
+        Desired axes layout. ``None`` triggers canonical mode.
+
+    Returns
+    -------
+    (np.ndarray, str)
+        Transformed array and its final axes string.
+
+    Raises
+    ------
+    ValueError
+        If ``source_axes`` is ``None``, validation fails, or
+        dimensions become inconsistent with the resulting axes.
+    """
+    if source_axes is None:
+        raise ValueError("Axes metadata is not initialized")
+
+    axes_list = list(source_axes)
+
+    # Step 1: ensure T is at index 0 (prepend or moveaxis).
+    if 'T' not in axes_list:
+        data = data[np.newaxis, ...]
+        axes_list = ['T'] + axes_list
+    else:
+        t_index = axes_list.index('T')
+        if t_index != 0:
+            data = np.moveaxis(data, t_index, 0)
+            axes_list = ['T'] + [ax for i, ax in enumerate(axes_list) if i != t_index]
+
+    target_list = list(target_axes) if target_axes is not None else None
+
+    # Step 2: Z handling. Canonical mode always squeezes singleton Z;
+    # match mode squeezes only when target lacks Z (and raises on Z>1).
+    if 'Z' in axes_list:
+        z_index = axes_list.index('Z')
+        if target_list is None:
+            if data.shape[z_index] == 1:
+                data = np.squeeze(data, axis=z_index)
+                axes_list.pop(z_index)
+        elif 'Z' not in target_list:
+            if data.shape[z_index] == 1:
+                data = np.squeeze(data, axis=z_index)
+                axes_list.pop(z_index)
+            else:
+                raise ValueError(
+                    "Z axis present with size > 1, but target axes lacks Z"
+                )
+
+    # Step 3: validate and pick the final ordering.
+    if target_list is None:
+        allowed_axes = {'T', 'Z', 'Y', 'X'}
+        extra_axes = [ax for ax in axes_list if ax not in allowed_axes]
+        if extra_axes:
+            raise ValueError(f"Unsupported axes found: {extra_axes}")
+        if 'Y' not in axes_list or 'X' not in axes_list:
+            raise ValueError("Axes must include both Y and X")
+        final_axes = ['T']
+        if 'Z' in axes_list:
+            final_axes.append('Z')
+        final_axes.extend(['Y', 'X'])
+    else:
+        if set(axes_list) != set(target_list):
+            extra = sorted(set(axes_list) - set(target_list))
+            missing = sorted(set(target_list) - set(axes_list))
+            raise ValueError(f"Axes mismatch. Extra: {extra}, missing: {missing}")
+        final_axes = target_list
+
+    if axes_list != final_axes:
+        order = [axes_list.index(ax) for ax in final_axes]
+        data = np.transpose(data, order)
+
+    if data.ndim != len(final_axes):
+        raise ValueError("Data dimensions do not match normalized axes")
+
+    return data, ''.join(final_axes)
+
+
 class FileInfo:
     """
     A class to handle file information, metadata extraction, and basic file operations for microscopy image files.
@@ -196,7 +334,7 @@ class FileInfo:
             self.metadata_type = metadata_type
             self.axes = tif.series[0].axes
             self.shape = tif.series[0].shape
-            self._normalize_time_axis()
+            self.axes = infer_t_axis(self.axes, self.shape)
 
         return metadata, metadata_type
 
@@ -213,7 +351,7 @@ class FileInfo:
             self.metadata_type = 'nd2'
             self.axes = ''.join(nd2_file.sizes.keys())
             self.shape = tuple(nd2_file.sizes.values())
-            self._normalize_time_axis()
+            self.axes = infer_t_axis(self.axes, self.shape)
 
     def find_metadata(self):
         """
@@ -235,14 +373,6 @@ class FileInfo:
             self._find_nd2_metadata()
         else:
             raise ValueError('File type not supported')
-
-    def _normalize_time_axis(self):
-        if self.axes is None or self.shape is None:
-            return
-        if 'T' in self.axes:
-            return
-        if len(self.shape) == len(self.axes) + 1 and self.shape[0] == 1:
-            self.axes = 'T' + self.axes
 
     def _get_imagej_metadata(self, metadata):
         """
@@ -1001,7 +1131,7 @@ class ImInfo:
         with tifffile.TiffFile(self.im_path) as tif:
             self.file_axes = tif.series[0].axes
             self.file_shape = tif.series[0].shape
-        self.im, self.axes = self._normalize_axes(self.im, self.file_axes)
+        self.im, self.axes = transform_to_axes(self.im, self.file_axes)
         self.new_axes = self.axes
         self.shape = self.im.shape
         self.ome_metadata = ome_types.from_xml(tifffile.tiffcomment(self.im_path))
@@ -1009,84 +1139,6 @@ class ImInfo:
         self.dim_res['Y'] = self.ome_metadata.images[0].pixels.physical_size_y
         self.dim_res['Z'] = self.ome_metadata.images[0].pixels.physical_size_z
         self.dim_res['T'] = self.ome_metadata.images[0].pixels.time_increment
-
-    def _normalize_axes(self, data, axes):
-        """
-        Normalize axes to a canonical order (T, Z, Y, X) and squeeze singleton Z.
-        """
-        if axes is None:
-            raise ValueError("Axes metadata is not initialized")
-        axes_list = list(axes)
-        # Ensure T exists and is first.
-        if 'T' not in axes_list:
-            data = data[np.newaxis, ...]
-            axes_list = ['T'] + axes_list
-        else:
-            t_index = axes_list.index('T')
-            if t_index != 0:
-                data = np.moveaxis(data, t_index, 0)
-                axes_list = ['T'] + [ax for i, ax in enumerate(axes_list) if i != t_index]
-        # Squeeze singleton Z if present.
-        if 'Z' in axes_list:
-            z_index = axes_list.index('Z')
-            if data.shape[z_index] == 1:
-                data = np.squeeze(data, axis=z_index)
-                axes_list.pop(z_index)
-        # Validate axes
-        allowed_axes = {'T', 'Z', 'Y', 'X'}
-        extra_axes = [ax for ax in axes_list if ax not in allowed_axes]
-        if extra_axes:
-            raise ValueError(f"Unsupported axes found: {extra_axes}")
-        if 'Y' not in axes_list or 'X' not in axes_list:
-            raise ValueError("Axes must include both Y and X")
-        # Canonical order: T, Z (if present), Y, X
-        target_axes = ['T']
-        if 'Z' in axes_list:
-            target_axes.append('Z')
-        target_axes.extend(['Y', 'X'])
-        if axes_list != target_axes:
-            order = [axes_list.index(ax) for ax in target_axes]
-            data = np.transpose(data, order)
-            axes_list = target_axes
-        if data.ndim != len(axes_list):
-            raise ValueError("Data dimensions do not match normalized axes")
-        return data, ''.join(axes_list)
-
-    def _normalize_memmap(self, memmap, file_axes):
-        """
-        Normalize a memmap to the canonical axes used by this ImInfo instance.
-        """
-        if file_axes is None:
-            return memmap
-        data = memmap
-        axes_list = list(file_axes)
-        # Ensure T exists and is first.
-        if 'T' not in axes_list:
-            data = data[np.newaxis, ...]
-            axes_list = ['T'] + axes_list
-        else:
-            t_index = axes_list.index('T')
-            if t_index != 0:
-                data = np.moveaxis(data, t_index, 0)
-                axes_list = ['T'] + [ax for i, ax in enumerate(axes_list) if i != t_index]
-        # Squeeze singleton Z if this ImInfo treats Z as absent.
-        if 'Z' in axes_list and 'Z' not in self.axes:
-            z_index = axes_list.index('Z')
-            if data.shape[z_index] == 1:
-                data = np.squeeze(data, axis=z_index)
-                axes_list.pop(z_index)
-            else:
-                raise ValueError("Z axis present with size > 1, but ImInfo expects no Z axis")
-        # Validate axes match target
-        target_axes = list(self.axes)
-        if set(axes_list) != set(target_axes):
-            extra = sorted(set(axes_list) - set(target_axes))
-            missing = sorted(set(target_axes) - set(axes_list))
-            raise ValueError(f"Axes mismatch. Extra: {extra}, missing: {missing}")
-        if axes_list != target_axes:
-            order = [axes_list.index(ax) for ax in target_axes]
-            data = np.transpose(data, order)
-        return data
 
     def get_memmap(self, file_path, read_mode='r+'):
         """
@@ -1111,7 +1163,9 @@ class ImInfo:
                 file_axes = tif.series[0].axes
         except Exception:
             file_axes = None
-        return self._normalize_memmap(memmap, file_axes)
+        if file_axes is None:
+            return memmap
+        return transform_to_axes(memmap, file_axes, target_axes=self.axes)[0]
 
     def allocate_memory(self, output_path, dtype='float', data=None, description='No description.',
                         return_memmap=False, read_mode='r+'):

--- a/tests/test_verifier_fileinfo.py
+++ b/tests/test_verifier_fileinfo.py
@@ -30,7 +30,7 @@ import ome_types
 import pytest
 import tifffile
 
-from nellie.im_info.verifier import FileInfo
+from nellie.im_info.verifier import FileInfo, infer_t_axis
 
 # Fixture paths are derived once at import time from the same on-disk
 # locations the conftest constants point at. (The ``tests/`` directory
@@ -231,7 +231,32 @@ def test_unsupported_extension_raises(tmp_path) -> None:
 
 
 # ============================================================
-# B. Axes normalization (_normalize_time_axis)
+# A1. infer_t_axis (pure-logic)
+# ============================================================
+#
+# Slice 4 extracted ``_normalize_time_axis`` (a side-effect-on-self
+# method) into ``infer_t_axis``, a pure module-level function. These
+# tests exercise the function directly with edge inputs that wouldn't
+# fire through the FileInfo integration paths below.
+
+
+def test_infer_t_axis_returns_unchanged_for_none_inputs() -> None:
+    """Both ``source_axes`` and ``source_shape`` ``None`` → return ``None``."""
+    assert infer_t_axis(None, None) is None
+
+
+def test_infer_t_axis_no_op_when_shape_extra_singleton_at_non_zero_position() -> None:
+    """Shape has an extra dim but NOT at position 0 → no T prepend.
+
+    ``axes='ZYX'`` + ``shape=(16, 1, 512, 512)`` exposes the
+    leading-singleton heuristic's narrow gate: only a leading singleton
+    triggers T-prepend; a singleton at any other position does not.
+    """
+    assert infer_t_axis('ZYX', (16, 1, 512, 512)) == 'ZYX'
+
+
+# ============================================================
+# B. Axes normalization (infer_t_axis)
 # ============================================================
 
 def test_normalize_time_axis_imagej_with_physicalsize_stays_yx(tmp_path) -> None:
@@ -240,8 +265,8 @@ def test_normalize_time_axis_imagej_with_physicalsize_stays_yx(tmp_path) -> None
     assert fi.axes == "YX"
 
 
-def test_normalize_time_axis_prepends_t_when_leading_singleton(tmp_path) -> None:
-    """``_normalize_time_axis``: axes='ZYX' + shape=(1,16,512,512) → axes='TZYX'.
+def test_infer_t_axis_prepends_t_when_leading_singleton(tmp_path) -> None:
+    """``infer_t_axis``: axes='ZYX' + shape=(1,16,512,512) → axes='TZYX'.
 
     Driven by direct state manipulation: tifffile won't let us write a
     file whose axes string disagrees with the data shape, so the
@@ -252,35 +277,35 @@ def test_normalize_time_axis_prepends_t_when_leading_singleton(tmp_path) -> None
     fi = FileInfo(str(dst))
     fi.axes = "ZYX"
     fi.shape = (1, 16, 512, 512)
-    fi._normalize_time_axis()
+    fi.axes = infer_t_axis(fi.axes, fi.shape)
     assert fi.axes == "TZYX"
 
 
-def test_normalize_time_axis_noop_when_t_already_present(tmp_path) -> None:
+def test_infer_t_axis_noop_when_t_already_present(tmp_path) -> None:
     dst = _copy_fixture_to_tmp(FIXTURE_3D_PATH, tmp_path)
     fi = FileInfo(str(dst))
     fi.axes = "TZYX"
     fi.shape = (2, 17, 192, 279)
-    fi._normalize_time_axis()
+    fi.axes = infer_t_axis(fi.axes, fi.shape)
     assert fi.axes == "TZYX"
 
 
-def test_normalize_time_axis_noop_when_axes_none(tmp_path) -> None:
+def test_infer_t_axis_noop_when_axes_none(tmp_path) -> None:
     dst = _copy_fixture_to_tmp(FIXTURE_3D_PATH, tmp_path)
     fi = FileInfo(str(dst))
     fi.axes = None
     fi.shape = (16, 512, 512)
-    fi._normalize_time_axis()
+    fi.axes = infer_t_axis(fi.axes, fi.shape)
     assert fi.axes is None
 
 
-def test_normalize_time_axis_noop_when_lengths_match(tmp_path) -> None:
+def test_infer_t_axis_noop_when_lengths_match(tmp_path) -> None:
     """Lengths match (no leading singleton): leave axes alone."""
     dst = _copy_fixture_to_tmp(FIXTURE_3D_PATH, tmp_path)
     fi = FileInfo(str(dst))
     fi.axes = "ZYX"
     fi.shape = (16, 512, 512)
-    fi._normalize_time_axis()
+    fi.axes = infer_t_axis(fi.axes, fi.shape)
     assert fi.axes == "ZYX"
 
 

--- a/tests/test_verifier_iminfo.py
+++ b/tests/test_verifier_iminfo.py
@@ -12,13 +12,16 @@ dechaos report calls out — the ``_normalize_axes`` allowed-set divergence
 from ``FileInfo._axis_errors`` (C-axis), the auto-regen on T-axis stale,
 and the partial-flag semantics of ``_check_axes_exist``.
 
-The tests intentionally exercise some private ``ImInfo`` methods
-directly (``_normalize_axes`` / ``_normalize_memmap``). Those normalizer
-paths are awkward to drive end-to-end because synthesizing a
-non-canonical OME-TIFF that survives ``ImInfo``'s constructor without
-being re-saved by ``save_ome_tiff`` is impractical. Calling the methods
-directly with synthetic numpy arrays is the cheapest way to pin the
-specific paths that Slice 4's normalizer unification will touch.
+The tests intentionally exercise the module-level normalizer
+``transform_to_axes`` directly with synthetic numpy arrays. End-to-end
+testing through the constructor would re-write the synthetic file via
+``save_ome_tiff`` (which has its own normalization), so direct calls
+are the cheapest way to pin each branch. Slice 4 of the dechaos refactor
+collapsed the three normalizer copies (``_normalize_time_axis``,
+``_normalize_axes``, ``_normalize_memmap``) into two pure functions
+(``infer_t_axis``, ``transform_to_axes``); the canonical-mode tests
+exercise ``transform_to_axes(data, axes)`` and the match-mode tests
+exercise ``transform_to_axes(data, file_axes, target_axes=info.axes)``.
 
 See ``wiki/outputs/dechaos-verifier.md`` for the full structural review
 and refactor plan.
@@ -36,7 +39,7 @@ import ome_types
 import pytest
 import tifffile
 
-from nellie.im_info.verifier import FileInfo, ImInfo
+from nellie.im_info.verifier import FileInfo, ImInfo, transform_to_axes
 
 
 def _release_iminfo_memmap(info: ImInfo) -> None:
@@ -380,155 +383,264 @@ def test_pipeline_paths_nellie_necessities_routing(imageinfo_3d: ImInfo) -> None
 
 
 # ============================================================================
-# C. ``_normalize_axes`` (called from ``_get_ome_metadata``)
+# C0. transform_to_axes (pure-logic)
 # ============================================================================
 #
-# These tests call the private ``_normalize_axes`` method directly with
-# synthetic numpy arrays. End-to-end testing through the constructor
+# Slice 4 promoted ``_normalize_axes`` / ``_normalize_memmap`` into the
+# module-level ``transform_to_axes`` function with two modes (canonical
+# when ``target_axes=None``; match when a target string is supplied).
+# These pure-logic tests exercise edge cases that wouldn't fire through
+# the existing integration paths below.
+
+
+def test_transform_to_axes_canonical_t_in_middle_position() -> None:
+    """``axes='ZTYX'`` with T at position 1 reorders to canonical ``'TZYX'``.
+
+    Distinct from ``test_transform_to_axes_moves_t_to_position_zero``
+    in that no ImInfo state is needed — pure module-level call.
+    """
+    data = np.zeros((16, 2, 512, 512), dtype=np.uint16)
+    out, axes = transform_to_axes(data, 'ZTYX')
+    assert axes == 'TZYX'
+    assert out.shape == (2, 16, 512, 512)
+
+
+def test_transform_to_axes_match_z_in_target_but_not_source_raises() -> None:
+    """Target has Z but source lacks Z → set-equality check raises ``ValueError``.
+
+    This path was un-exercised before Slice 4 because ``_normalize_memmap``'s
+    caller always passed ``self.axes`` as target. In any realistic workflow
+    the target axes set is a subset of (or equal to) the source axes set;
+    Slice 4's set-equality check now also detects the inverse mismatch.
+    """
+    data = np.zeros((2, 16, 16), dtype=np.uint16)
+    with pytest.raises(ValueError, match="Axes mismatch"):
+        transform_to_axes(data, 'TYX', target_axes='TZYX')
+
+
+def test_transform_to_axes_canonical_raises_on_none_source_axes() -> None:
+    """``source_axes=None`` raises ``ValueError`` — the new contract.
+
+    Slice 3's ``_normalize_axes`` raised the same message; Slice 4's
+    ``transform_to_axes`` re-pins it as the function's first guard.
+    The ``get_memmap`` caller short-circuits on ``file_axes is None``
+    BEFORE calling ``transform_to_axes`` (verifier.py: ``if file_axes
+    is None: return memmap``), so this guard only fires for direct
+    callers.
+    """
+    data = np.zeros((2, 16, 16), dtype=np.uint16)
+    with pytest.raises(ValueError, match="Axes metadata is not initialized"):
+        transform_to_axes(data, None)
+
+
+def test_transform_to_axes_canonical_rejects_c_in_source() -> None:
+    """``axes='TCYX'`` raises ``ValueError("Unsupported axes found: ['C']")``.
+
+    Pins the canonical-mode allowed-set check (``{'T','Z','Y','X'}``).
+    Distinct from ``test_transform_to_axes_rejects_c_axis`` below in
+    that the data here is 4D-with-T-already-present; the older test
+    drives the T-prepend path.
+    """
+    data = np.zeros((2, 3, 16, 16), dtype=np.uint16)
+    with pytest.raises(ValueError, match=r"Unsupported axes found: \['C'\]"):
+        transform_to_axes(data, 'TCYX')
+
+
+# ============================================================================
+# C. ``transform_to_axes`` (canonical mode, called from ``_get_ome_metadata``)
+# ============================================================================
+#
+# These tests call the module-level ``transform_to_axes`` function directly
+# with synthetic numpy arrays. End-to-end testing through the constructor
 # would re-write the synthetic file via ``save_ome_tiff`` (which has its
-# own normalization), so the only practical way to characterize each
-# branch is the direct call. Slice 4 of the dechaos refactor unifies the
-# three normalizer copies into one — these tests pin the surface that
-# the unified normalizer must reproduce.
+# own normalization), so the only practical way to characterize each branch
+# is the direct call. Slice 4 of the dechaos refactor unified the three
+# normalizer copies into one — these tests pin the canonical-mode surface
+# (no ``target_axes``) that the unified normalizer must reproduce.
 
 
-def test_normalize_axes_prepends_t_when_missing(make_imageinfo_3d) -> None:
-    """``axes='ZYX'`` with non-singleton Z gets a T prepended (verifier.py:897-899)."""
-    info = make_imageinfo_3d()
+def test_transform_to_axes_prepends_t_when_missing() -> None:
+    """``axes='ZYX'`` with non-singleton Z gets a T prepended."""
     data = np.zeros((4, 16, 16), dtype=np.uint16)
-    norm_data, norm_axes = info._normalize_axes(data, 'ZYX')
+    norm_data, norm_axes = transform_to_axes(data, 'ZYX')
     assert norm_axes == 'TZYX'
     assert norm_data.shape == (1, 4, 16, 16)
 
 
-def test_normalize_axes_moves_t_to_position_zero(make_imageinfo_3d) -> None:
-    """``axes='ZTYX'`` with T at position 1 gets reordered to ``'TZYX'`` (verifier.py:901-904)."""
-    info = make_imageinfo_3d()
+def test_transform_to_axes_moves_t_to_position_zero() -> None:
+    """``axes='ZTYX'`` with T at position 1 gets reordered to ``'TZYX'``."""
     data = np.zeros((16, 2, 16, 16), dtype=np.uint16)
-    norm_data, norm_axes = info._normalize_axes(data, 'ZTYX')
+    norm_data, norm_axes = transform_to_axes(data, 'ZTYX')
     assert norm_axes == 'TZYX'
     assert norm_data.shape == (2, 16, 16, 16)
 
 
-def test_normalize_axes_squeezes_singleton_z(make_imageinfo_3d) -> None:
+def test_transform_to_axes_squeezes_singleton_z() -> None:
     """``axes='ZYX'`` with ``Z=1`` collapses to ``'TYX'`` after T-prepend + Z-squeeze."""
-    info = make_imageinfo_3d()
     data = np.zeros((1, 16, 16), dtype=np.uint16)
-    norm_data, norm_axes = info._normalize_axes(data, 'ZYX')
+    norm_data, norm_axes = transform_to_axes(data, 'ZYX')
     assert norm_axes == 'TYX'
     assert norm_data.shape == (1, 16, 16)
 
 
-def test_normalize_axes_preserves_z_when_not_singleton(make_imageinfo_3d) -> None:
+def test_transform_to_axes_preserves_z_when_not_singleton() -> None:
     """``axes='ZYX'`` with ``Z>1`` preserves Z in the canonical ``'TZYX'`` order."""
-    info = make_imageinfo_3d()
     data = np.zeros((16, 16, 16), dtype=np.uint16)
-    norm_data, norm_axes = info._normalize_axes(data, 'ZYX')
+    norm_data, norm_axes = transform_to_axes(data, 'ZYX')
     assert norm_axes == 'TZYX'
     assert norm_data.shape == (1, 16, 16, 16)
 
 
-def test_normalize_axes_2d_yx_gets_t_prepended(make_imageinfo_3d) -> None:
+def test_transform_to_axes_2d_yx_gets_t_prepended() -> None:
     """Pure ``'YX'`` data gains a single-timepoint T prefix → ``'TYX'``."""
-    info = make_imageinfo_3d()
     data = np.zeros((16, 16), dtype=np.uint16)
-    norm_data, norm_axes = info._normalize_axes(data, 'YX')
+    norm_data, norm_axes = transform_to_axes(data, 'YX')
     assert norm_axes == 'TYX'
     assert norm_data.shape == (1, 16, 16)
 
 
-def test_normalize_axes_missing_yx_raises(make_imageinfo_3d) -> None:
-    """Axes lacking Y or X raise ``ValueError`` (verifier.py:916-917)."""
-    info = make_imageinfo_3d()
+def test_transform_to_axes_missing_yx_raises() -> None:
+    """Axes lacking Y or X raise ``ValueError``."""
     data = np.zeros((4, 16), dtype=np.uint16)
     with pytest.raises(ValueError, match="Axes must include both Y and X"):
-        info._normalize_axes(data, 'ZX')
+        transform_to_axes(data, 'ZX')
 
 
-def test_normalize_axes_rejects_c_axis(make_imageinfo_3d) -> None:
+def test_transform_to_axes_rejects_c_axis() -> None:
     """Axes containing C raise ``ValueError("Unsupported axes found: ['C']")``.
 
-    Pins current intentional behavior: ``ImInfo._normalize_axes`` excludes
-    ``C`` from its allowed set (verifier.py:912 — ``{'T', 'Z', 'Y', 'X'}``).
+    Pins current intentional behavior: ``transform_to_axes`` (canonical
+    mode) excludes ``C`` from its allowed set (``{'T', 'Z', 'Y', 'X'}``).
     ``FileInfo._axis_errors`` accepts multichannel input via its allowed
     set (verifier.py:373 — ``{'T', 'Z', 'Y', 'X', 'C'}``); ``save_ome_tiff``
     collapses ``C`` via channel-take before writing the canonical
     OME-TIFF, so ``ImInfo`` should only ever read post-collapse files.
     The two allowed sets diverge intentionally — see dechaos report
-    Pass 5 ("``_normalize_axes`` excludes C; ``_axis_errors`` includes C
-    in allowed set") and ``test_verifier_fileinfo.py``.
+    Pass 5 ("normalizer excludes C; ``_axis_errors`` includes C in
+    allowed set") and ``test_verifier_fileinfo.py``.
     """
-    info = make_imageinfo_3d()
     data = np.zeros((1, 4, 16, 16), dtype=np.uint16)
     with pytest.raises(ValueError, match=r"Unsupported axes found: \['C'\]"):
-        info._normalize_axes(data, 'CZYX')
+        transform_to_axes(data, 'CZYX')
 
 
-def test_normalize_axes_returns_string_in_canonical_order(make_imageinfo_3d) -> None:
+def test_transform_to_axes_returns_string_in_canonical_order() -> None:
     """Returned axes is a string with T first, Z (if present) second, then YX."""
-    info = make_imageinfo_3d()
     # Already-canonical input — output should equal input.
     data = np.zeros((2, 4, 16, 16), dtype=np.uint16)
-    _, norm_axes = info._normalize_axes(data, 'TZYX')
+    _, norm_axes = transform_to_axes(data, 'TZYX')
     assert isinstance(norm_axes, str)
     assert norm_axes == 'TZYX'
 
     # Reordered input — output must still be canonical.
     data = np.zeros((4, 2, 16, 16), dtype=np.uint16)
-    _, norm_axes = info._normalize_axes(data, 'ZTYX')
+    _, norm_axes = transform_to_axes(data, 'ZTYX')
     assert norm_axes == 'TZYX'
 
 
 # ============================================================================
-# D. ``_normalize_memmap`` (called from ``get_memmap``)
+# D. ``transform_to_axes`` (match mode, called from ``get_memmap``)
 # ============================================================================
 #
 # The 3D ``imageinfo_3d`` has self.axes='TZYX'; the 2D variant has
-# self.axes='TYX'. ``_normalize_memmap`` reads ``self.axes`` to decide
-# whether to squeeze Z. Use whichever fixture matches the test's intent.
+# self.axes='TYX'. ``transform_to_axes`` (with ``target_axes=info.axes``)
+# uses the target string to decide whether to squeeze Z. Use whichever
+# fixture matches the test's intent.
 
 
-def test_normalize_memmap_no_op_when_axes_match(imageinfo_3d: ImInfo) -> None:
+def test_transform_to_axes_match_no_op_when_axes_match(imageinfo_3d: ImInfo) -> None:
     """When ``file_axes == self.axes``, the memmap shape passes through."""
     data = np.zeros((2, 17, 192, 279), dtype=np.uint16)
-    out = imageinfo_3d._normalize_memmap(data, 'TZYX')
+    out, _ = transform_to_axes(data, 'TZYX', target_axes=imageinfo_3d.axes)
     assert out.shape == (2, 17, 192, 279)
 
 
-def test_normalize_memmap_prepends_t_when_missing(imageinfo_3d: ImInfo) -> None:
+def test_transform_to_axes_match_prepends_t_when_missing(imageinfo_3d: ImInfo) -> None:
     """``file_axes='ZYX'`` against ``self.axes='TZYX'`` gains a T prefix."""
     data = np.zeros((17, 192, 279), dtype=np.uint16)
-    out = imageinfo_3d._normalize_memmap(data, 'ZYX')
+    out, _ = transform_to_axes(data, 'ZYX', target_axes=imageinfo_3d.axes)
     assert out.shape == (1, 17, 192, 279)
 
 
-def test_normalize_memmap_squeezes_singleton_z(imageinfo_2d: ImInfo) -> None:
+def test_transform_to_axes_match_squeezes_singleton_z(imageinfo_2d: ImInfo) -> None:
     """When ``self.axes`` lacks Z but the memmap has ``Z=1``, Z is squeezed."""
     # 2D ImInfo has self.axes='TYX' — so a TZYX memmap with Z=1 must squeeze.
     data = np.zeros((2, 1, 192, 279), dtype=np.uint16)
-    out = imageinfo_2d._normalize_memmap(data, 'TZYX')
+    out, _ = transform_to_axes(data, 'TZYX', target_axes=imageinfo_2d.axes)
     assert out.shape == (2, 192, 279)
 
 
-def test_normalize_memmap_z_gt_1_when_target_lacks_z_raises(
+def test_transform_to_axes_match_z_gt_1_when_target_lacks_z_raises(
     imageinfo_2d: ImInfo,
 ) -> None:
-    """``Z>1`` against a target that lacks Z is unrecoverable — raises (verifier.py:954-955)."""
+    """``Z>1`` against a target that lacks Z is unrecoverable — raises ``ValueError``."""
     data = np.zeros((2, 5, 192, 279), dtype=np.uint16)
     with pytest.raises(
         ValueError,
-        match="Z axis present with size > 1, but ImInfo expects no Z axis",
+        match="Z axis present with size > 1, but target axes lacks Z",
     ):
-        imageinfo_2d._normalize_memmap(data, 'TZYX')
+        transform_to_axes(data, 'TZYX', target_axes=imageinfo_2d.axes)
 
 
-def test_normalize_memmap_returns_memmap_unchanged_when_file_axes_none(
-    imageinfo_3d: ImInfo,
+def test_get_memmap_returns_memmap_unchanged_when_axes_lookup_fails(
+    imageinfo_3d: ImInfo, tmp_path: Path, monkeypatch,
 ) -> None:
-    """``file_axes=None`` is the early-return path (verifier.py:935-936)."""
+    """``get_memmap`` returns the raw memmap when the axes-lookup branch raises.
+
+    Slice 4 moved the ``file_axes is None`` early-return out of the
+    normalizer (which now raises ``ValueError`` on ``None``) and into
+    the ``get_memmap`` caller. We let ``tifffile.memmap`` succeed
+    normally, then swap ``TiffFile`` to a raising stub for the
+    axes-lookup that follows — the ``except`` branch fires, ``file_axes``
+    stays ``None``, and ``get_memmap`` returns the raw memmap
+    untransformed. (The old ``_normalize_memmap`` had this early-return
+    baked into the normalizer itself; the new contract cleanly separates
+    the data-shape transform from the missing-axes fallback.)
+    """
+    # Build a synthetic TIFF the memmap call can succeed against.
+    p = tmp_path / "synthetic.tif"
+    arr = np.zeros((2, 17, 192, 279), dtype=np.uint16)
+    tifffile.imwrite(str(p), arr, metadata={'axes': 'TZYX'},
+                     photometric='minisblack')
+
+    from nellie.im_info import verifier as verifier_module
+
+    # Pre-build the memmap so tifffile.memmap inside get_memmap can
+    # succeed without invoking the raising TiffFile we're about to
+    # install. We monkeypatch ``tifffile.memmap`` in the verifier module
+    # to return our pre-built memmap, then replace ``TiffFile`` with a
+    # stub that always raises so the axes-lookup ``except`` branch fires.
+    real_memmap = verifier_module.tifffile.memmap(str(p), mode='r+')
+
+    def _stub_memmap(*_args, **_kwargs):
+        return real_memmap
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("synthetic axes lookup failure")
+
+    monkeypatch.setattr(verifier_module.tifffile, 'memmap', _stub_memmap)
+    monkeypatch.setattr(verifier_module.tifffile, 'TiffFile', _raise)
+
+    out = imageinfo_3d.get_memmap(str(p))
+
+    # Memmap returned unchanged (no transform).
+    assert out is real_memmap
+    assert out.shape == (2, 17, 192, 279)
+
+
+def test_transform_to_axes_match_raises_on_none_source_axes() -> None:
+    """Pin the new contract: ``transform_to_axes`` raises on ``None`` source axes.
+
+    The old ``_normalize_memmap`` short-circuited on
+    ``file_axes is None`` (returned the raw memmap unchanged). Slice 4
+    moved that early-return into the ``get_memmap`` caller; the
+    normalizer itself now raises ``ValueError`` so direct callers that
+    forget to pre-validate their axes string fail loudly instead of
+    silently bypassing the transform.
+    """
     data = np.zeros((2, 17, 192, 279), dtype=np.uint16)
-    out = imageinfo_3d._normalize_memmap(data, None)
-    assert out is data
+    with pytest.raises(ValueError, match="Axes metadata is not initialized"):
+        transform_to_axes(data, None, target_axes='TZYX')
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Slice 4 of the verifier dechaos refactor (issue #125). Consolidates the 3 near-duplicate axes-normalization implementations into 2 module-level pure functions in ``verifier.py``.

**New functions** (after ``DimRes``, before ``FileInfo``):

- ``infer_t_axis(source_axes, source_shape) -> str | None`` — pure axes-string heuristic. Replaces ``FileInfo._normalize_time_axis``.
- ``transform_to_axes(data, source_axes, target_axes=None) -> (data, axes)`` — data-shape transformation. Two modes:
  - ``target_axes=None`` → canonical mode: T-prepend or T-move-to-0, **always** squeeze singleton Z, validate axes ⊆ {T,Z,Y,X}, require Y+X, transpose to T[Z]YX. Replaces ``ImInfo._normalize_axes``.
  - ``target_axes='...'`` → match mode: T-prepend or T-move-to-0, squeeze Z **only if target lacks Z** (raise on Z>1), validate set-equality, transpose to match target. Replaces ``ImInfo._normalize_memmap``.

**Method deletions**: ``_normalize_time_axis``, ``_normalize_axes``, ``_normalize_memmap``.

**Call site updates**: 4 sites now use the new functions directly.

**Test updates**:
- 17 existing direct-method tests renamed/migrated to call the new functions.
- 7 new pure-logic tests including a previously un-exercised "Z in target but not source" path that wasn't reachable through the old methods (because their callers always passed compatible targets).

**Behavior preservation**: the new functions are behavior-preserving extractions. One error-message wording change: ``"Z axis present with size > 1, but ImInfo expects no Z axis"`` → ``"Z axis present with size > 1, but target axes lacks Z"`` (the unified function isn't ImInfo-aware).

## Test plan

- [x] Pyright on ``verifier.py``: 85 errors (was 86 baseline; −1 net)
- [x] Pyright on test files: 0 errors
- [x] Verifier tests: 136 passed (122 from Slice 1 + 7 from Slice 3 + 7 new from Slice 4)
- [x] Full test suite: 283 passed (276 baseline + 7 new)

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)