### PR TITLE
verifier: validation split (Slice 5 of #127)

### DIFF
--- a/nellie/im_info/verifier.py
+++ b/nellie/im_info/verifier.py
@@ -511,22 +511,6 @@ class FileInfo:
             self._get_tif_tags_metadata(self.metadata, self.axes)
         self._validate()
 
-    def _check_axes(self):
-        """
-        Validates the axes metadata and ensures the required axes (X, Y) are present.
-        """
-        errors = self._axis_errors()
-        self.good_axes = not errors
-        return errors
-
-    def _check_dim_res(self):
-        """
-        Validates the dimensional resolution metadata, ensuring that X, Y, Z, and T dimensions have valid resolutions.
-        """
-        errors = self._dim_errors()
-        self.good_dims = not errors
-        return errors
-
     def _axis_errors(self):
         errors = []
         if self.axes is None or self.shape is None:
@@ -572,8 +556,40 @@ class FileInfo:
             errors.append('Temporal range out of bounds')
         return errors
 
-    def get_validation_errors(self):
+    def compute_errors(self):
+        """
+        Aggregate axis, dim, and time-range errors. Pure read.
+
+        Returns
+        -------
+        list[str]
+            Empty if all three error sources are clean. Otherwise the
+            concatenation of ``_axis_errors`` + ``_dim_errors`` +
+            ``_time_range_errors`` results.
+        """
         return self._axis_errors() + self._dim_errors() + self._time_range_errors()
+
+    def apply_defaults(self):
+        """
+        Fill ``t_start``/``t_end`` defaults when axes are valid and T present.
+
+        No-op when ``good_axes`` is False, when ``T`` is absent from
+        ``self.axes``, or when ``self.shape`` is None. Otherwise:
+        ``t_start`` defaults to 0 (when None); ``t_end`` defaults to
+        ``shape[axes.index('T')] - 1`` (when None).
+        """
+        if not self.good_axes:
+            return
+        if self.axes is None or 'T' not in self.axes:
+            return
+        if self.shape is None:
+            return
+        if self.t_start is None:
+            self.t_start = 0
+        t_index = self.axes.index('T')
+        max_t = self.shape[t_index] - 1
+        if self.t_end is None:
+            self.t_end = max_t
 
     def change_axes(self, new_axes):
         """
@@ -721,35 +737,26 @@ class FileInfo:
 
     def _validate(self):
         """
-        Validates the current state of the axes and dimensional metadata, then updates output paths.
+        Recompute validation flags + ``validation_errors`` and update output paths.
 
-        This method performs several validation steps:
-        1. Calls `_check_axes()` to ensure the axes are valid.
-        2. Calls `_check_dim_res()` to ensure that the dimensional resolutions are valid.
-        3. Calls `select_temporal_range()` to set or update the time range if applicable.
-        4. Calls `_get_output_path()` to update the output paths based on the current metadata.
+        Thin orchestrator that:
+        1. Sets ``good_axes`` and ``good_dims`` from the pure
+           ``_axis_errors`` / ``_dim_errors`` results.
+        2. Calls ``apply_defaults`` to fill ``t_start``/``t_end`` when
+           the axes are valid and T is present.
+        3. Sets ``validation_errors`` to ``compute_errors()``.
+        4. Calls ``_get_output_path`` to refresh output filename strings.
 
-        The method ensures that all aspects of the metadata (axes, dimensional resolutions, and temporal range)
-        are consistent and correctly applied before further processing.
-
-        Raises
-        ------
-        ValueError
-            If any aspect of the metadata is invalid or inconsistent.
+        Never raises. Slice 5 made validation symmetric — failures are
+        always surfaced via ``validation_errors`` and the boolean flags.
+        Programmer-error mutators (``select_temporal_range``,
+        ``change_axes``, ``change_dim_res``) still raise directly on
+        invalid input at the entry point.
         """
-        axis_errors = self._check_axes()
-        dim_errors = self._check_dim_res()
-        if self.good_axes and 'T' in self.axes and self.shape is not None:
-            if self.t_start is None:
-                self.t_start = 0
-            t_index = self.axes.index('T')
-            max_t = self.shape[t_index] - 1
-            if self.t_end is None:
-                self.t_end = max_t
-        time_errors = self._time_range_errors()
-        self.validation_errors = axis_errors + dim_errors + time_errors
-        if time_errors:
-            raise ValueError(time_errors[0])
+        self.good_axes = not self._axis_errors()
+        self.good_dims = not self._dim_errors()
+        self.apply_defaults()
+        self.validation_errors = self.compute_errors()
         self._get_output_path()
 
     def read_file(self):

--- a/nellie_napari/nellie_fileselect.py
+++ b/nellie_napari/nellie_fileselect.py
@@ -709,7 +709,7 @@ class NellieFileSelect(QWidget):
             self.preview_button.setEnabled(True)
             self.process_button.setEnabled(True)
 
-        errors = self.file_info.get_validation_errors()
+        errors = self.file_info.compute_errors()
         self._set_validation_messages(errors)
 
     def check_available_dims(self) -> None:

--- a/tests/test_verifier_fileinfo.py
+++ b/tests/test_verifier_fileinfo.py
@@ -466,7 +466,7 @@ def test_time_range_errors_out_of_bounds(tmp_path) -> None:
     assert "Temporal range out of bounds" in fi._time_range_errors()
 
 
-# ---- _validate: asymmetric raise (THE design quirk) ----
+# ---- _validate: symmetric (Slice 5 — never raises) ----
 
 def test_validate_implicit_after_load_metadata_3d(tmp_path) -> None:
     """``load_metadata`` runs ``_validate`` implicitly; on a clean fixture, no errors."""
@@ -476,54 +476,98 @@ def test_validate_implicit_after_load_metadata_3d(tmp_path) -> None:
     assert fi.good_dims is True
 
 
-def test_validate_raises_only_on_time_errors(tmp_path) -> None:
-    """``_validate`` raises ValueError only when ``_time_range_errors`` is non-empty."""
+def test_validate_does_not_raise_on_time_errors(tmp_path) -> None:
+    """Slice 5 made ``_validate`` symmetric — it never raises.
+
+    Slice 1 pinned the asymmetric raise (``_validate`` raised on
+    time-range errors but flagged axis/dim errors silently). Slice 5
+    removed the raise — all errors flow through ``validation_errors``
+    + ``good_axes``/``good_dims`` flags. Programmer errors still raise
+    from the user-facing mutators (``select_temporal_range``,
+    ``change_axes``, ``change_dim_res``); ``_validate`` is now a pure
+    flag-mutator + path-refresher. See dechaos report Pass 5.
+    """
     fi = _loaded_file_info(FIXTURE_3D_PATH, tmp_path)
     fi.t_end = 99  # past max_t
-    with pytest.raises(ValueError, match="Temporal range out of bounds"):
-        fi._validate()
+    fi._validate()  # would have raised ValueError before Slice 5
+    assert "Temporal range out of bounds" in fi.validation_errors
 
 
 def test_validate_does_not_raise_on_axis_or_dim_errors(tmp_path) -> None:
-    """Pins current intentional behavior: ``_validate`` raises only on time errors.
-
-    Axis and dim errors are flagged via ``good_axes``/``good_dims``
-    booleans for the napari widget to display, not raised as
-    exceptions. Time errors are raised because they represent
-    programmer-error in the temporal slicing pipeline (the napari
-    widget already validates the range before calling). See dechaos
-    report Pass 5 and Slice 5.
-    """
+    """``_validate`` never raises on axis/dim errors either; flags via booleans + validation_errors."""
     fi = _loaded_file_info(FIXTURE_3D_PATH, tmp_path)
     fi.axes = "XY"  # length mismatch, axis-error path
-    # Should NOT raise even though _check_axes will flag the error
-    fi._validate()
+    fi._validate()  # never raises
     assert fi.good_axes is False
     assert "Axes length does not match data shape" in fi.validation_errors
 
 
-# ---- get_validation_errors: concatenated report, no mutation ----
+# ---- apply_defaults: extracted t_start/t_end mutator ----
 
-def test_get_validation_errors_returns_concatenated(tmp_path) -> None:
+def test_apply_defaults_fills_t_start_and_t_end_when_unset(tmp_path) -> None:
+    """``apply_defaults`` fills t_start=0 and t_end=max_t when unset."""
+    fi = _loaded_file_info(FIXTURE_3D_PATH, tmp_path)
+    fi.t_start = None  # type: ignore[assignment]
+    fi.t_end = None
+    fi.apply_defaults()
+    assert fi.t_start == 0
+    assert fi.t_end == 1  # 3D fixture has T=2 → max_t=1
+
+
+def test_apply_defaults_no_op_when_t_start_already_set(tmp_path) -> None:
+    """``apply_defaults`` preserves caller-set t_start/t_end values."""
+    fi = _loaded_file_info(FIXTURE_3D_PATH, tmp_path)
+    fi.t_start = 0
+    fi.t_end = 1
+    fi.apply_defaults()
+    assert (fi.t_start, fi.t_end) == (0, 1)
+
+
+def test_apply_defaults_no_op_when_good_axes_false(tmp_path) -> None:
+    """``apply_defaults`` is a no-op when ``good_axes`` is False."""
+    fi = _loaded_file_info(FIXTURE_3D_PATH, tmp_path)
+    fi.good_axes = False
+    fi.t_start = None  # type: ignore[assignment]
+    fi.t_end = None
+    fi.apply_defaults()
+    assert fi.t_start is None
+    assert fi.t_end is None
+
+
+def test_apply_defaults_no_op_when_no_t_axis(tmp_path) -> None:
+    """``apply_defaults`` is a no-op when 'T' is not in axes."""
+    fi = _loaded_file_info(FIXTURE_IMAGEJ_WITH_PHYSICALSIZE_PATH, tmp_path)
+    # ImageJ fixture is 'YX' (no T)
+    assert fi.axes == "YX"
+    fi.t_start = None  # type: ignore[assignment]
+    fi.t_end = None
+    fi.apply_defaults()
+    assert fi.t_start is None
+    assert fi.t_end is None
+
+
+# ---- compute_errors: concatenated report, no mutation ----
+
+def test_compute_errors_returns_concatenated(tmp_path) -> None:
     fi = _loaded_file_info(FIXTURE_3D_PATH, tmp_path)
     assert fi.dim_res is not None
     fi.axes = "TZQX"  # invalid letter
     fi.dim_res["X"] = None
     fi.t_end = 99
     expected = fi._axis_errors() + fi._dim_errors() + fi._time_range_errors()
-    assert fi.get_validation_errors() == expected
+    assert fi.compute_errors() == expected
 
 
-def test_get_validation_errors_does_not_mutate_flags(tmp_path) -> None:
-    """Unlike ``_check_axes``/``_check_dim_res``, ``get_validation_errors`` is read-only."""
+def test_compute_errors_does_not_mutate_flags(tmp_path) -> None:
+    """``compute_errors`` is a pure read; ``_validate`` is the flag-mutator."""
     fi = _loaded_file_info(FIXTURE_3D_PATH, tmp_path)
     assert fi.dim_res is not None
     # Force good flags True, then introduce a hidden error
     fi.good_axes = True
     fi.good_dims = True
     fi.dim_res["X"] = None
-    _ = fi.get_validation_errors()
-    # Flags should be unchanged because get_validation_errors does not mutate
+    _ = fi.compute_errors()
+    # Flags should be unchanged because compute_errors does not mutate
     assert fi.good_axes is True
     assert fi.good_dims is True
 


### PR DESCRIPTION
## Summary

Slice 5 of the verifier dechaos refactor (issue #127). Untangles validation methods per dechaos report Pass 5 + Pass 8. ``_validate`` now never raises — failures uniformly surface through ``validation_errors`` and ``good_axes``/``good_dims`` flags.

**Method changes**:
- Deleted ``_check_axes`` and ``_check_dim_res`` (dual-write wrappers that overlapped with ``_axis_errors``/``_dim_errors``).
- Renamed ``get_validation_errors`` → ``compute_errors`` (more descriptive).
- Added ``apply_defaults()`` — extracted t_start/t_end default-fill from inline ``_validate`` logic.
- Rewrote ``_validate`` as a thin orchestrator: recompute flags from pure ``_*_errors``, ``apply_defaults()``, populate ``validation_errors`` via ``compute_errors()``, call ``_get_output_path``. **No raise.**

**Behavior change**: ``_validate`` no longer raises ``ValueError`` on time-range errors. Slice 1's ``test_validate_raises_only_on_time_errors`` flipped to ``test_validate_does_not_raise_on_time_errors``. ``select_temporal_range`` still raises directly on invalid input — ``_validate``'s raise was a redundant second guardrail. The napari fileselect widget already checks ``validation_errors`` after each mutation, so user-facing UX is unchanged.

**Test updates**:
- 1 Slice 1 raise pin flipped (asymmetric raise → symmetric no-raise)
- 2 ``get_validation_errors`` tests renamed to ``compute_errors``
- 4 new ``apply_defaults`` tests covering: fills when unset, no-op when set, no-op when ``good_axes=False``, no-op when no T axis
- 1 napari fileselect callsite updated

## Test plan

- [x] Pyright on ``verifier.py``: 85 → 83 errors (−2 net)
- [x] Pyright on test files: 0 errors
- [x] Verifier tests: 140 passed (136 baseline + 4 new)
- [x] Full test suite: 287 passed (283 baseline + 4 new)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)