### PR TITLE
verifier: extractor strategy + bioio prep (Slice 6 of #129)

### DIFF
--- a/nellie/im_info/extractors/__init__.py
+++ b/nellie/im_info/extractors/__init__.py
@@ -1,0 +1,33 @@
+"""
+Per-format metadata extractors for ``FileInfo``.
+
+Layout:
+
+- ``protocol.py`` defines the structural ``MetadataExtractor`` Protocol
+  that every concrete extractor satisfies.
+- One file per format: ``ome.py``, ``imagej.py``, ``imagej_tif_tags.py``,
+  ``nd2.py``, ``raw_tiff.py``.
+- ``factory.py`` exposes ``detect_extractor(path)``, the single
+  classifier+constructor entry point used by ``FileInfo.find_metadata``.
+- ``_tif_tags.py`` carries the shared TIFF-tag projection helper used
+  by ``RawTiffTagExtractor`` and ``ImageJTifTagExtractor`` (the
+  fallback case where the imagej dict lacks ``physicalsizex``).
+"""
+
+from nellie.im_info.extractors.factory import detect_extractor
+from nellie.im_info.extractors.imagej import ImageJExtractor
+from nellie.im_info.extractors.imagej_tif_tags import ImageJTifTagExtractor
+from nellie.im_info.extractors.nd2 import Nd2Extractor
+from nellie.im_info.extractors.ome import OmeExtractor
+from nellie.im_info.extractors.protocol import MetadataExtractor
+from nellie.im_info.extractors.raw_tiff import RawTiffTagExtractor
+
+__all__ = [
+    'MetadataExtractor',
+    'OmeExtractor',
+    'ImageJExtractor',
+    'ImageJTifTagExtractor',
+    'Nd2Extractor',
+    'RawTiffTagExtractor',
+    'detect_extractor',
+]

--- a/nellie/im_info/extractors/_tif_tags.py
+++ b/nellie/im_info/extractors/_tif_tags.py
@@ -1,0 +1,71 @@
+"""
+Private helper shared by ``RawTiffTagExtractor`` and
+``ImageJTifTagExtractor``: compute X/Y/Z/T entries from a raw TIFF
+``tags`` dict (the output of ``tif.pages[0].tags._dict``).
+
+Mirrors the legacy ``FileInfo._get_tif_tags_metadata`` logic exactly:
+
+- X/Y from XResolution/YResolution, scaled by ResolutionUnit
+  (CENTIMETER → ×1e4, INCH → ×25400, NONE/absent → no scale).
+- Z from ZResolution, but only when ``axes`` contains 'Z'.
+- T from FrameRate, but only when ``axes`` contains 'T'.
+
+The function MUTATES ``result`` in place rather than returning a new
+dict so it can be used both by ``RawTiffTagExtractor`` (which starts
+with an all-None ``DimRes``) and by ``ImageJTifTagExtractor`` (which
+starts with the imagej-derived dict and layers raw tags on top).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tifffile import tifffile
+
+if TYPE_CHECKING:
+    from nellie.im_info.types import DimRes
+
+
+def apply_tif_tags(
+    result: "DimRes",
+    tags: dict,
+    axes: str | None,
+) -> None:
+    """Mutate ``result`` with X/Y/Z/T values pulled from the TIFF tags dict.
+
+    Parameters
+    ----------
+    result : DimRes
+        Dict to mutate. Existing entries (e.g. populated by an earlier
+        imagej-meta pass) are overwritten when the corresponding tag is
+        present.
+    tags : dict
+        Raw TIFF tag dict — ``tif.pages[0].tags._dict``. Values are
+        ``TiffTag`` objects with ``.name`` and ``.value`` attributes.
+    axes : str | None
+        Axes string for the file (used to gate Z/T extraction). The
+        Z/T extraction only fires when the corresponding letter is in
+        this string.
+    """
+    tag_names = {tag_value.name: tag_code for tag_code, tag_value in tags.items()}
+
+    if 'XResolution' in tag_names:
+        result['X'] = tags[tag_names['XResolution']].value[1] \
+                       / tags[tag_names['XResolution']].value[0]
+    if 'YResolution' in tag_names:
+        result['Y'] = tags[tag_names['YResolution']].value[1] \
+                       / tags[tag_names['YResolution']].value[0]
+    if 'ResolutionUnit' in tag_names:
+        unit = tags[tag_names['ResolutionUnit']].value
+        if unit == tifffile.RESUNIT.CENTIMETER:
+            result['X'] *= 1E4  # type: ignore[operator]
+            result['Y'] *= 1E4  # type: ignore[operator]
+        elif unit == tifffile.RESUNIT.INCH:
+            result['X'] *= 25400  # type: ignore[operator]
+            result['Y'] *= 25400  # type: ignore[operator]
+    if axes is not None and 'Z' in axes:
+        if 'ZResolution' in tag_names:
+            result['Z'] = 1 / tags[tag_names['ZResolution']].value[0]
+    if axes is not None and 'T' in axes:
+        if 'FrameRate' in tag_names:
+            result['T'] = 1 / tags[tag_names['FrameRate']].value[0]

--- a/nellie/im_info/extractors/factory.py
+++ b/nellie/im_info/extractors/factory.py
@@ -1,0 +1,110 @@
+"""
+Factory for choosing the right ``MetadataExtractor`` for a given
+file path.
+
+Replaces the legacy two-stage dispatch in ``FileInfo`` (extension-based
+``find_metadata`` + string-tag ``load_metadata`` switch) with a single
+``detect_extractor(path)`` call. The file is opened ONCE for both
+classification and raw-metadata reads — subsequent
+``extractor.parse_dim_res()`` calls do not reopen the file.
+"""
+
+from __future__ import annotations
+
+import os
+
+import nd2
+import ome_types
+from tifffile import tifffile
+
+from nellie.im_info.extractors.imagej import ImageJExtractor
+from nellie.im_info.extractors.imagej_tif_tags import ImageJTifTagExtractor
+from nellie.im_info.extractors.nd2 import Nd2Extractor
+from nellie.im_info.extractors.ome import OmeExtractor
+from nellie.im_info.extractors.protocol import MetadataExtractor
+from nellie.im_info.extractors.raw_tiff import RawTiffTagExtractor
+from nellie.im_info.types import infer_t_axis
+
+
+def detect_extractor(filepath: str) -> MetadataExtractor:
+    """
+    Detect file format and return the appropriate ``MetadataExtractor``.
+
+    Opens the file once to classify and to extract format-specific raw
+    metadata + axes/shape. Subsequent calls to the returned extractor's
+    ``parse_dim_res()`` do not reopen the file.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to the input file. Extension is matched case-insensitively
+        against ``.nd2``, ``.tif``, and ``.tiff``.
+
+    Returns
+    -------
+    MetadataExtractor
+        One of ``Nd2Extractor``, ``OmeExtractor``, ``ImageJExtractor``,
+        ``ImageJTifTagExtractor``, or ``RawTiffTagExtractor``.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is not supported.
+    """
+    ext = os.path.splitext(filepath)[1].lower()
+    if ext == '.nd2':
+        with nd2.ND2File(filepath) as nd2_file:
+            source_axes = ''.join(nd2_file.sizes.keys())
+            shape = tuple(nd2_file.sizes.values())
+            # ``nd2_file.events(orient='list')`` returns a ``DictOfLists``
+            # that pyright treats as Mapping rather than dict; cast for
+            # the dataclass annotation.
+            return Nd2Extractor(
+                root_meta=nd2_file.metadata,
+                recorded_data=dict(nd2_file.events(orient='list')),
+                axes=infer_t_axis(source_axes, shape),
+                shape=shape,
+            )
+    elif ext in ('.tif', '.tiff'):
+        with tifffile.TiffFile(filepath) as tif:
+            source_axes = tif.series[0].axes
+            shape = tif.series[0].shape
+            axes = infer_t_axis(source_axes, shape)
+            if tif.is_ome or tif.ome_metadata is not None:
+                # ``tifffile.tiffcomment`` is typed as
+                # ``str | bytes | None``; ``from_xml`` requires non-None.
+                # In the ``is_ome``/``ome_metadata is not None`` branch
+                # the comment is always present — narrow with an assert.
+                ome_xml = tifffile.tiffcomment(filepath)
+                assert ome_xml is not None
+                return OmeExtractor(
+                    ome=ome_types.from_xml(ome_xml),
+                    axes=axes,
+                    shape=shape,
+                )
+            elif tif.is_imagej:
+                # ``tif.imagej_metadata`` is typed as ``dict | None``;
+                # in the ``is_imagej`` branch it is always a dict.
+                imagej_meta = tif.imagej_metadata
+                assert imagej_meta is not None
+                if 'physicalsizex' in imagej_meta:
+                    return ImageJExtractor(
+                        imagej_meta=imagej_meta,
+                        axes=axes,
+                        shape=shape,
+                    )
+                else:
+                    return ImageJTifTagExtractor(
+                        imagej_meta=imagej_meta,
+                        tif_tags=tif.pages[0].tags._dict,  # type: ignore[union-attr]
+                        axes=axes,
+                        shape=shape,
+                    )
+            else:
+                return RawTiffTagExtractor(
+                    tags=tif.pages[0].tags._dict,  # type: ignore[union-attr]
+                    axes=axes,
+                    shape=shape,
+                )
+    else:
+        raise ValueError('File type not supported')

--- a/nellie/im_info/extractors/imagej.py
+++ b/nellie/im_info/extractors/imagej.py
@@ -1,0 +1,39 @@
+"""
+``ImageJExtractor`` — ``MetadataExtractor`` for ImageJ-flavored TIFFs
+that carry the ``physicalsizex`` key.
+
+Mirrors the legacy ``FileInfo._get_imagej_metadata`` exactly: pulls
+``physicalsizex/y`` for X/Y, ``spacing`` for Z, ``finterval`` for T.
+Each key is independently optional; missing keys produce ``None``.
+
+For ImageJ TIFFs that LACK ``physicalsizex``, see
+``ImageJTifTagExtractor`` (which combines this extractor's logic with
+the raw-TIFF tag fallback).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nellie.im_info.types import DimRes
+
+
+@dataclass
+class ImageJExtractor:
+    """Per-format metadata extractor for ImageJ TIFFs with ``physicalsizex``."""
+    imagej_meta: dict
+    axes: str | None
+    shape: tuple[int, ...] | None
+    # Widened to ``str | None`` for Protocol invariance compatibility;
+    # default value is the discriminator ``'imagej'``.
+    metadata_type: str | None = 'imagej'
+
+    def parse_dim_res(self) -> DimRes:
+        """Pull X/Y from ``physicalsize{x,y}``, Z from ``spacing``, T from ``finterval``."""
+        m = self.imagej_meta
+        return {
+            'X': m.get('physicalsizex'),
+            'Y': m.get('physicalsizey'),
+            'Z': m.get('spacing'),
+            'T': m.get('finterval'),
+        }

--- a/nellie/im_info/extractors/imagej_tif_tags.py
+++ b/nellie/im_info/extractors/imagej_tif_tags.py
@@ -1,0 +1,47 @@
+"""
+``ImageJTifTagExtractor`` — ``MetadataExtractor`` for ImageJ TIFFs
+that LACK the ``physicalsizex`` key.
+
+Combines the imagej-meta extraction (same logic as
+``ImageJExtractor``) with the raw-TIFF tag fallback (same logic as
+``RawTiffTagExtractor``). The legacy code shoehorned both into a
+list-of-dicts (``self.metadata = [imagej_meta, tif_tags]``) and routed
+two extractor calls in ``load_metadata``; this dataclass carries both
+as proper named fields.
+
+The ordering is preserved from the legacy: imagej-meta values are
+written first (X/Y from ``physicalsizex/y``, Z from ``spacing``, T from
+``finterval``), then the raw TIFF tag fallback layers in non-None
+values for any axis the imagej dict didn't carry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nellie.im_info.extractors._tif_tags import apply_tif_tags
+from nellie.im_info.types import DimRes
+
+
+@dataclass
+class ImageJTifTagExtractor:
+    """Per-format extractor for ImageJ TIFFs without ``physicalsizex``."""
+    imagej_meta: dict
+    tif_tags: dict
+    axes: str | None
+    shape: tuple[int, ...] | None
+    # Widened to ``str | None`` for Protocol invariance compatibility;
+    # default value is the discriminator ``'imagej_tif_tags'``.
+    metadata_type: str | None = 'imagej_tif_tags'
+
+    def parse_dim_res(self) -> DimRes:
+        """Pull imagej-meta first, then layer in any TIFF-tag values via ``apply_tif_tags``."""
+        m = self.imagej_meta
+        result: DimRes = {
+            'X': m.get('physicalsizex'),
+            'Y': m.get('physicalsizey'),
+            'Z': m.get('spacing'),
+            'T': m.get('finterval'),
+        }
+        apply_tif_tags(result, self.tif_tags, self.axes)
+        return result

--- a/nellie/im_info/extractors/nd2.py
+++ b/nellie/im_info/extractors/nd2.py
@@ -1,0 +1,98 @@
+"""
+``Nd2Extractor`` — ``MetadataExtractor`` for Nikon ND2 files.
+
+Mirrors the legacy ``FileInfo._get_nd2_metadata`` exactly. ND2's
+metadata is split across two surfaces:
+
+- ``recorded_data`` — a dict-of-lists from ``nd2.events(orient='list')``
+  carrying per-frame timestamps. ``T`` is the **median** of timestamp
+  diffs (not first-diff or mean) to be robust against a single
+  long-tail outlier.
+- ``root_meta`` — the structured metadata object from
+  ``nd2.metadata``. X/Y/Z come from ``volume.axesCalibration`` (a
+  3-tuple of microns), with a fallback chain through
+  ``channels[0].volume.axesCalibration`` because some ND2s organize
+  the calibration under the channel rather than the file root.
+
+Both ``root_meta`` and (each entry it traverses) can be either a
+``dict`` or an attribute-bearing object — the legacy code used
+``isinstance``-aware getters that this extractor preserves verbatim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from nellie.im_info.types import DimRes
+
+
+@dataclass
+class Nd2Extractor:
+    """Per-format extractor for ND2.
+
+    Parameters
+    ----------
+    root_meta : Any
+        ``nd2.ND2File.metadata`` — either an attribute-bearing object
+        (typical) or a dict (legacy fallback). The legacy
+        ``_get_nd2_metadata`` accepted both shapes, so this extractor
+        does too.
+    recorded_data : dict
+        ``nd2.ND2File.events(orient='list')`` — dict of per-frame
+        recorded values. We read ``"Time [s]"``.
+    """
+    root_meta: Any
+    recorded_data: dict
+    axes: str | None
+    shape: tuple[int, ...] | None
+    # Widened to ``str | None`` for Protocol invariance compatibility;
+    # default value is the discriminator ``'nd2'``.
+    metadata_type: str | None = 'nd2'
+
+    def parse_dim_res(self) -> DimRes:
+        """Compute T from median frame-diff and X/Y/Z from axesCalibration with fallback."""
+        result: DimRes = {'X': None, 'Y': None, 'Z': None, 'T': None}
+
+        recorded_data = self.recorded_data or {}
+        timestamps = recorded_data.get("Time [s]")
+        if timestamps is not None:
+            if len(timestamps) >= 2:
+                diffs = np.diff(timestamps)
+                result['T'] = float(np.median(diffs))
+            else:
+                result['T'] = None
+
+        root_metadata = self.root_meta
+        axes_calibration = None
+        if root_metadata is not None:
+            if isinstance(root_metadata, dict):
+                volume = root_metadata.get("volume")
+            else:
+                volume = getattr(root_metadata, "volume", None)
+            axes_calibration = getattr(volume, "axesCalibration", None)
+
+        if axes_calibration is None and root_metadata is not None:
+            if isinstance(root_metadata, dict):
+                channels = root_metadata.get("channels")
+            else:
+                channels = getattr(root_metadata, "channels", None)
+            if channels:
+                channel = channels[0]
+                if isinstance(channel, dict):
+                    channel_volume = channel.get("volume")
+                else:
+                    channel_volume = getattr(channel, "volume", None)
+                axes_calibration = getattr(channel_volume, "axesCalibration", None)
+
+        if axes_calibration is not None:
+            if len(axes_calibration) > 0:
+                result['X'] = axes_calibration[0]
+            if len(axes_calibration) > 1:
+                result['Y'] = axes_calibration[1]
+            if len(axes_calibration) > 2:
+                result['Z'] = axes_calibration[2]
+
+        return result

--- a/nellie/im_info/extractors/ome.py
+++ b/nellie/im_info/extractors/ome.py
@@ -1,0 +1,40 @@
+"""
+``OmeExtractor`` — ``MetadataExtractor`` for OME-TIFF files.
+
+Reads X/Y/Z physical sizes and the time increment off the first image's
+pixels block in the OME-XML metadata tree (``ome.images[0].pixels``).
+Mirrors the legacy ``FileInfo._get_ome_metadata`` exactly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from nellie.im_info.types import DimRes
+
+
+@dataclass
+class OmeExtractor:
+    """Per-format metadata extractor for OME-TIFF.
+
+    Construct with the parsed ``ome_types.OME`` object plus the file's
+    axes/shape (already normalized via ``infer_t_axis`` by the factory).
+    """
+    ome: Any
+    axes: str | None
+    shape: tuple[int, ...] | None
+    # Typed as ``str | None`` (not just ``str``) for invariance
+    # compatibility with the Protocol's ``metadata_type: str | None``
+    # field. Default value is the discriminator ``'ome'``.
+    metadata_type: str | None = 'ome'
+
+    def parse_dim_res(self) -> DimRes:
+        """Return X/Y/Z in microns + T in seconds from ``ome.images[0].pixels``."""
+        pixels = self.ome.images[0].pixels
+        return {
+            'X': pixels.physical_size_x,
+            'Y': pixels.physical_size_y,
+            'Z': pixels.physical_size_z,
+            'T': pixels.time_increment,
+        }

--- a/nellie/im_info/extractors/protocol.py
+++ b/nellie/im_info/extractors/protocol.py
@@ -1,0 +1,52 @@
+"""
+``MetadataExtractor`` Protocol — the structural seam shared by every
+per-format extractor in this subpackage.
+
+Per PEP 544 (structural typing): any class whose attribute and method
+signatures match this Protocol is a valid ``MetadataExtractor`` without
+needing to inherit from it. The 5 concrete extractors
+(``OmeExtractor``, ``ImageJExtractor``, ``ImageJTifTagExtractor``,
+``Nd2Extractor``, ``RawTiffTagExtractor``) all satisfy this Protocol
+without an ``isinstance`` check or a base class.
+
+The Protocol fields ``axes`` / ``shape`` carry the source-reader's
+view of the file's axis layout; ``parse_dim_res`` projects the raw
+format-specific metadata into the canonical ``DimRes`` 4-key dict that
+``FileInfo`` consumes.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from nellie.im_info.types import DimRes
+
+
+class MetadataExtractor(Protocol):
+    """Structural type for per-format metadata extractors.
+
+    Attributes
+    ----------
+    axes : str | None
+        Axes string for the file (e.g. 'TZYX'), normalized via
+        ``infer_t_axis`` by the factory before construction.
+    shape : tuple[int, ...] | None
+        Shape of the file's primary series.
+    metadata_type : str | None
+        Extractor's discriminator string. One of
+        ``'ome'``, ``'imagej''``, ``'imagej_tif_tags'``, ``'nd2'``, or
+        ``None`` (raw TIFF, by existing FileInfo convention).
+
+    Methods
+    -------
+    parse_dim_res() -> DimRes
+        Project the per-format raw metadata into the canonical
+        ``DimRes`` 4-key dict (X/Y in microns, Z in microns, T in
+        seconds; any missing axis is ``None``).
+    """
+
+    axes: str | None
+    shape: tuple[int, ...] | None
+    metadata_type: str | None
+
+    def parse_dim_res(self) -> DimRes: ...

--- a/nellie/im_info/extractors/raw_tiff.py
+++ b/nellie/im_info/extractors/raw_tiff.py
@@ -1,0 +1,39 @@
+"""
+``RawTiffTagExtractor`` — ``MetadataExtractor`` for raw TIFFs that
+carry neither OME-XML nor ImageJ metadata.
+
+Mirrors the legacy ``FileInfo._get_tif_tags_metadata`` exactly when
+called from the ``metadata_type is None`` branch — starts with an
+all-None ``DimRes`` and overwrites entries from the TIFF tags.
+
+The ``metadata_type`` discriminator is ``None`` per the existing
+``FileInfo`` convention (the dispatcher's "raw TIFF" branch was keyed
+off ``metadata_type is None`` rather than a string tag).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nellie.im_info.extractors._tif_tags import apply_tif_tags
+from nellie.im_info.types import DimRes
+
+
+@dataclass
+class RawTiffTagExtractor:
+    """Per-format extractor for plain TIFFs (no OME, no ImageJ)."""
+    tags: dict
+    axes: str | None
+    shape: tuple[int, ...] | None
+    # Typed as ``str | None`` (not the literal ``None``) for invariance
+    # compatibility with the Protocol's ``metadata_type: str | None``
+    # field. The default value ``None`` preserves the legacy
+    # ``FileInfo`` convention (raw TIFF dispatch was keyed off
+    # ``metadata_type is None``).
+    metadata_type: str | None = None
+
+    def parse_dim_res(self) -> DimRes:
+        """Build an all-None ``DimRes`` then layer in TIFF-tag values via ``apply_tif_tags``."""
+        result: DimRes = {'X': None, 'Y': None, 'Z': None, 'T': None}
+        apply_tif_tags(result, self.tags, self.axes)
+        return result

--- a/nellie/im_info/types.py
+++ b/nellie/im_info/types.py
@@ -1,0 +1,64 @@
+"""
+Shared types and small helpers for the im_info subpackage.
+
+Lives at this seam to break the circular import between
+``nellie.im_info.verifier`` and ``nellie.im_info.extractors`` —
+verifier imports the extractor factory and Protocol, while extractors
+need ``DimRes`` (and the ``infer_t_axis`` helper that the factory uses
+to prepend a missing leading T axis).
+
+``verifier.py`` re-exports ``DimRes`` for backwards compat so existing
+``from nellie.im_info.verifier import DimRes`` imports keep working.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class DimRes(TypedDict):
+    """Per-axis physical resolution: X/Y/Z in micrometers, T in seconds.
+
+    All four keys are always present; values are ``None`` until populated
+    by ``FileInfo.load_metadata`` (per-format extractor) or until the
+    corresponding axis is determined to be absent from the file.
+    """
+    X: float | None
+    Y: float | None
+    Z: float | None
+    T: float | None
+
+
+def infer_t_axis(
+    source_axes: str | None,
+    source_shape: tuple[int, ...] | None,
+) -> str | None:
+    """
+    Infer a leading T axis when the source library stripped it.
+
+    Some readers (notably tifffile on certain inputs) return an axes
+    string that omits a leading singleton T dim while keeping it in the
+    shape — e.g. axes='ZYX' but shape=(1, 16, 512, 512). This helper
+    detects that pattern and returns the prepended axes string.
+
+    Parameters
+    ----------
+    source_axes : str or None
+        Axes string from the source reader (e.g. 'ZYX', 'TZYX').
+    source_shape : tuple of int or None
+        Shape from the source reader.
+
+    Returns
+    -------
+    str or None
+        ``source_axes`` with 'T' prepended when the leading-singleton
+        heuristic fires; otherwise ``source_axes`` unchanged. Returns
+        ``None`` when either input is ``None``.
+    """
+    if source_axes is None or source_shape is None:
+        return source_axes
+    if 'T' in source_axes:
+        return source_axes
+    if len(source_shape) == len(source_axes) + 1 and source_shape[0] == 1:
+        return 'T' + source_axes
+    return source_axes

--- a/nellie/im_info/verifier.py
+++ b/nellie/im_info/verifier.py
@@ -6,62 +6,21 @@ metadata from various microscopy file formats (TIFF, OME-TIFF, ND2).
 """
 import json
 import os
-from typing import TypedDict
 
 import nd2
 import numpy as np
 import ome_types
 from tifffile import tifffile
 
+from nellie.im_info.extractors import MetadataExtractor, detect_extractor
+from nellie.im_info.types import DimRes, infer_t_axis
 from nellie.utils.base_logger import logger
 
-
-class DimRes(TypedDict):
-    """Per-axis physical resolution: X/Y/Z in micrometers, T in seconds.
-
-    All four keys are always present; values are ``None`` until populated
-    by ``FileInfo.load_metadata`` (per-format extractor) or until the
-    corresponding axis is determined to be absent from the file.
-    """
-    X: float | None
-    Y: float | None
-    Z: float | None
-    T: float | None
-
-
-def infer_t_axis(
-    source_axes: str | None,
-    source_shape: tuple[int, ...] | None,
-) -> str | None:
-    """
-    Infer a leading T axis when the source library stripped it.
-
-    Some readers (notably tifffile on certain inputs) return an axes
-    string that omits a leading singleton T dim while keeping it in the
-    shape — e.g. axes='ZYX' but shape=(1, 16, 512, 512). This helper
-    detects that pattern and returns the prepended axes string.
-
-    Parameters
-    ----------
-    source_axes : str or None
-        Axes string from the source reader (e.g. 'ZYX', 'TZYX').
-    source_shape : tuple of int or None
-        Shape from the source reader.
-
-    Returns
-    -------
-    str or None
-        ``source_axes`` with 'T' prepended when the leading-singleton
-        heuristic fires; otherwise ``source_axes`` unchanged. Returns
-        ``None`` when either input is ``None``.
-    """
-    if source_axes is None or source_shape is None:
-        return source_axes
-    if 'T' in source_axes:
-        return source_axes
-    if len(source_shape) == len(source_axes) + 1 and source_shape[0] == 1:
-        return 'T' + source_axes
-    return source_axes
+# Backwards-compat re-exports: ``DimRes`` and ``infer_t_axis`` moved to
+# ``nellie.im_info.types`` in Slice 6 to break the verifier ↔ extractors
+# circular import. Existing ``from nellie.im_info.verifier import DimRes``
+# (or ``infer_t_axis``) imports keep working via the re-exports above.
+__all__ = ['FileInfo', 'ImInfo', 'DimRes', 'infer_t_axis', 'transform_to_axes']
 
 
 def transform_to_axes(
@@ -175,10 +134,12 @@ class FileInfo:
     ----------
     filepath : str
         Path to the input file.
-    metadata : dict or None
-        Stores the metadata extracted from the file.
     metadata_type : str or None
         Type of metadata detected (e.g., 'ome', 'imagej', 'nd2').
+        Slice 6: this is the only metadata-discriminator field on
+        ``FileInfo``; the polymorphic ``self.metadata`` field was
+        retired in favor of a stashed extractor instance
+        (``self._extractor``) consumed by ``load_metadata``.
     axes : str or None
         String representing the axes in the file (e.g., 'TZCYX').
     shape : tuple or None
@@ -216,22 +177,13 @@ class FileInfo:
 
     Methods
     -------
-    _find_tif_metadata()
-        Extract metadata from TIFF or OME-TIFF files.
-    _find_nd2_metadata()
-        Extract metadata from ND2 files.
     find_metadata()
-        Detect file type and extract corresponding metadata.
-    _get_imagej_metadata(metadata)
-        Extract dimensional resolution from ImageJ metadata.
-    _get_ome_metadata(metadata)
-        Extract dimensional resolution from OME metadata.
-    _get_tif_tags_metadata(metadata)
-        Extract dimensional resolution from generic TIFF tags.
-    _get_nd2_metadata(metadata)
-        Extract dimensional resolution from ND2 metadata.
+        Detect file type via the extractor factory and stash the
+        extractor instance, plus axes / shape / metadata_type. Calls
+        ``prepare_output_dirs`` first.
     load_metadata()
-        Load and validate dimensional metadata based on the file type.
+        Project the stashed extractor into ``self.dim_res`` via
+        ``parse_dim_res()``, then runs ``_validate``.
     _check_axes()
         Validate the axes metadata for correctness.
     _check_dim_res()
@@ -271,11 +223,16 @@ class FileInfo:
             Output naming strategy ("detailed" or "stable"). Defaults to "detailed".
         """
         self.filepath = filepath
-        self.metadata = None
-        self.metadata_type = None
+        self.metadata_type: str | None = None
         self.axes = None
         self.shape = None
         self.dim_res: DimRes | None = None
+        # Slice 6: extractor instance stashed by ``find_metadata`` and
+        # consumed by ``load_metadata`` (whose only job is now
+        # ``self._extractor.parse_dim_res()``). Not part of the public
+        # surface — callers should read ``metadata_type``/``axes``/
+        # ``shape``/``dim_res`` instead.
+        self._extractor: MetadataExtractor | None = None
 
         self.input_dir = os.path.dirname(filepath)
         self.basename = os.path.basename(filepath)
@@ -306,56 +263,18 @@ class FileInfo:
         os.makedirs(self.output_dir, exist_ok=True)
         os.makedirs(self.nellie_necessities_dir, exist_ok=True)
 
-    def _find_tif_metadata(self):
-        """
-        Extracts metadata from TIFF or OME-TIFF files and updates relevant class attributes.
-
-        Returns
-        -------
-        tuple
-            Metadata and metadata type extracted from the TIFF file.
-        """
-        with tifffile.TiffFile(self.filepath) as tif:
-            if tif.is_ome or tif.ome_metadata is not None:
-                ome_xml = tifffile.tiffcomment(self.filepath)
-                metadata = ome_types.from_xml(ome_xml)
-                metadata_type = 'ome'
-            elif tif.is_imagej:
-                metadata = tif.imagej_metadata
-                metadata_type = 'imagej'
-                if 'physicalsizex' not in metadata:
-                    metadata_type = 'imagej_tif_tags'
-                    metadata = [metadata, tif.pages[0].tags._dict]
-            else:
-                metadata = tif.pages[0].tags._dict
-                metadata_type = None
-
-            self.metadata = metadata
-            self.metadata_type = metadata_type
-            self.axes = tif.series[0].axes
-            self.shape = tif.series[0].shape
-            self.axes = infer_t_axis(self.axes, self.shape)
-
-        return metadata, metadata_type
-
-    def _find_nd2_metadata(self):
-        """
-        Extracts metadata from ND2 files and updates relevant class attributes.
-        """
-        with nd2.ND2File(self.filepath) as nd2_file:
-            metadata = {
-                "root": nd2_file.metadata,
-                "recorded_data": nd2_file.events(orient='list'),
-            }
-            self.metadata = metadata
-            self.metadata_type = 'nd2'
-            self.axes = ''.join(nd2_file.sizes.keys())
-            self.shape = tuple(nd2_file.sizes.values())
-            self.axes = infer_t_axis(self.axes, self.shape)
-
     def find_metadata(self):
         """
-        Detects file type (e.g., TIFF or ND2) and calls the appropriate metadata extraction method.
+        Detect file type and read its metadata via the appropriate extractor.
+
+        Slice 6 thinned this method to a 1-line factory call. The
+        legacy 6-method per-format dispatch
+        (``_find_tif_metadata``/``_find_nd2_metadata`` →
+        ``_get_*_metadata``) was extracted into the
+        ``nellie.im_info.extractors`` subpackage; ``detect_extractor``
+        opens the file ONCE, classifies it, and returns the appropriate
+        ``MetadataExtractor`` instance carrying ``axes``, ``shape``,
+        ``metadata_type``, and the format-specific raw fields.
 
         Also calls ``prepare_output_dirs`` so output directories exist
         before any subsequent ``save_ome_tiff`` call. Construction
@@ -367,148 +286,29 @@ class FileInfo:
             If the file type is not supported.
         """
         self.prepare_output_dirs()
-        if self.extension in ('.tiff', '.tif'):
-            self._find_tif_metadata()
-        elif self.extension == '.nd2':
-            self._find_nd2_metadata()
-        else:
-            raise ValueError('File type not supported')
-
-    def _get_imagej_metadata(self, metadata):
-        """
-        Extracts dimensional resolution from ImageJ metadata and stores it in `dim_res`.
-
-        Parameters
-        ----------
-        metadata : dict
-            ImageJ metadata extracted from the file.
-        """
-        self.dim_res['X'] = metadata['physicalsizex'] if 'physicalsizex' in metadata else None
-        self.dim_res['Y'] = metadata['physicalsizey'] if 'physicalsizey' in metadata else None
-        self.dim_res['Z'] = metadata['spacing'] if 'spacing' in metadata else None
-        self.dim_res['T'] = metadata['finterval'] if 'finterval' in metadata else None
-
-    def _get_ome_metadata(self, metadata):
-        """
-        Extracts dimensional resolution from OME metadata and stores it in `dim_res`.
-
-        Parameters
-        ----------
-        metadata : ome_types.OME
-            OME metadata object.
-        """
-        self.dim_res['X'] = metadata.images[0].pixels.physical_size_x
-        self.dim_res['Y'] = metadata.images[0].pixels.physical_size_y
-        self.dim_res['Z'] = metadata.images[0].pixels.physical_size_z
-        self.dim_res['T'] = metadata.images[0].pixels.time_increment
-
-    def _get_tif_tags_metadata(self, metadata, axes):
-        """
-        Extracts dimensional resolution from TIFF tag metadata and stores it in `dim_res`.
-
-        Parameters
-        ----------
-        metadata : dict
-            Dictionary of TIFF tags.
-        axes : str
-            Axes string for the file (used to gate Z/T extraction).
-            Pass ``self.axes`` from the caller; this is taken as an
-            explicit parameter rather than read from ``self`` to make
-            the dependency visible in the signature.
-        """
-        tag_names = {tag_value.name: tag_code for tag_code, tag_value in metadata.items()}
-
-        if 'XResolution' in tag_names:
-            self.dim_res['X'] = metadata[tag_names['XResolution']].value[1] \
-                                  / metadata[tag_names['XResolution']].value[0]
-        if 'YResolution' in tag_names:
-            self.dim_res['Y'] = metadata[tag_names['YResolution']].value[1] \
-                                  / metadata[tag_names['YResolution']].value[0]
-        if 'ResolutionUnit' in tag_names:
-            if metadata[tag_names['ResolutionUnit']].value == tifffile.RESUNIT.CENTIMETER:
-                self.dim_res['X'] *= 1E4
-                self.dim_res['Y'] *= 1E4
-            elif metadata[tag_names['ResolutionUnit']].value == tifffile.RESUNIT.INCH:
-                self.dim_res['X'] *= 25400
-                self.dim_res['Y'] *= 25400
-        if 'Z' in axes:
-            if 'ZResolution' in tag_names:
-                self.dim_res['Z'] = 1 / metadata[tag_names['ZResolution']].value[0]
-        if 'T' in axes:
-            if 'FrameRate' in tag_names:
-                self.dim_res['T'] = 1 / metadata[tag_names['FrameRate']].value[0]
-
-    def _get_nd2_metadata(self, metadata):
-        """
-        Extracts dimensional resolution from ND2 metadata and stores it in `dim_res`.
-
-        Parameters
-        ----------
-        metadata : dict
-            ND2 metadata object.
-        """
-        recorded_data = {}
-        root_metadata = None
-        if isinstance(metadata, dict):
-            recorded_data = metadata.get("recorded_data") or {}
-            root_metadata = metadata.get("root")
-        else:
-            recorded_data = getattr(metadata, "recorded_data", {}) or {}
-            root_metadata = metadata
-
-        timestamps = recorded_data.get("Time [s]")
-        if timestamps is not None:
-            if len(timestamps) >= 2:
-                diffs = np.diff(timestamps)
-                self.dim_res['T'] = float(np.median(diffs))
-            else:
-                self.dim_res['T'] = None
-
-        axes_calibration = None
-        if root_metadata is not None:
-            if isinstance(root_metadata, dict):
-                volume = root_metadata.get("volume")
-            else:
-                volume = getattr(root_metadata, "volume", None)
-            axes_calibration = getattr(volume, "axesCalibration", None)
-
-        if axes_calibration is None and root_metadata is not None:
-            if isinstance(root_metadata, dict):
-                channels = root_metadata.get("channels")
-            else:
-                channels = getattr(root_metadata, "channels", None)
-            if channels:
-                channel = channels[0]
-                if isinstance(channel, dict):
-                    channel_volume = channel.get("volume")
-                else:
-                    channel_volume = getattr(channel, "volume", None)
-                axes_calibration = getattr(channel_volume, "axesCalibration", None)
-
-        if axes_calibration is not None:
-            if len(axes_calibration) > 0:
-                self.dim_res['X'] = axes_calibration[0]
-            if len(axes_calibration) > 1:
-                self.dim_res['Y'] = axes_calibration[1]
-            if len(axes_calibration) > 2:
-                self.dim_res['Z'] = axes_calibration[2]
+        self._extractor = detect_extractor(self.filepath)
+        self.metadata_type = self._extractor.metadata_type
+        self.axes = self._extractor.axes
+        self.shape = self._extractor.shape
 
     def load_metadata(self):
         """
-        Loads and validates dimensional metadata based on the file type (OME, ImageJ, ND2, or generic TIFF).
+        Parse ``dim_res`` from the previously-detected extractor.
+
+        Must be called after ``find_metadata`` (which stashes the
+        extractor instance on ``self._extractor``). Populates
+        ``self.dim_res`` with the per-format physical pixel sizes and
+        time interval, then runs ``_validate``.
+
+        Raises
+        ------
+        ValueError
+            If ``find_metadata`` was not called first (no extractor
+            stashed on ``self._extractor``).
         """
-        self.dim_res = {'X': None, 'Y': None, 'Z': None, 'T': None}
-        if self.metadata_type == 'ome':
-            self._get_ome_metadata(self.metadata)
-        elif self.metadata_type == 'imagej':
-            self._get_imagej_metadata(self.metadata)
-        elif self.metadata_type == 'imagej_tif_tags':
-            self._get_imagej_metadata(self.metadata[0])
-            self._get_tif_tags_metadata(self.metadata[1], self.axes)
-        elif self.metadata_type == 'nd2':
-            self._get_nd2_metadata(self.metadata)
-        elif self.metadata_type is None:
-            self._get_tif_tags_metadata(self.metadata, self.axes)
+        if self._extractor is None:
+            raise ValueError("find_metadata must be called before load_metadata")
+        self.dim_res = self._extractor.parse_dim_res()
         self._validate()
 
     def _axis_errors(self):

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,423 @@
+"""Per-extractor + factory tests for ``nellie.im_info.extractors``.
+
+Slice 6 of the verifier dechaos refactor (see
+``wiki/outputs/dechaos-verifier.md`` Pass 8 Slice 6). The legacy
+6-method per-format dispatch on ``FileInfo`` was extracted into 5
+``MetadataExtractor`` dataclasses + a ``detect_extractor`` factory.
+
+Test layout:
+
+- **Per-extractor unit tests** (sections 1-5): construct each extractor
+  with **synthetic dataclass arguments** (no filesystem needed) and
+  pin the per-format ``parse_dim_res`` outputs. This is the
+  pure-logic surface — adding a new ND2 calibration fallback or
+  changing the ResolutionUnit scaling table should be testable here
+  without writing a TIFF/ND2 file.
+- **Factory tests** (section 6): one per fixture in conftest's
+  ``verifier_fixture_paths`` dict, asserting both the returned class
+  type AND the ``metadata_type`` discriminator string. These exercise
+  the file-classification branches end-to-end against real fixtures.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tifffile import tifffile
+
+from nellie.im_info.extractors import (
+    ImageJExtractor,
+    ImageJTifTagExtractor,
+    Nd2Extractor,
+    OmeExtractor,
+    RawTiffTagExtractor,
+    detect_extractor,
+)
+
+
+# ============================================================
+# Test helpers — minimal stand-ins for the format-specific raw shapes
+# ============================================================
+
+
+@dataclass
+class _FakeTag:
+    """Stand-in for a ``tifffile.TiffTag`` — only ``name`` and ``value`` matter."""
+    name: str
+    value: Any
+
+
+def _build_tags(entries: dict[str, Any]) -> dict[int, _FakeTag]:
+    """Build a ``tags`` dict of the shape ``RawTiffTagExtractor.tags`` expects.
+
+    The legacy ``_get_tif_tags_metadata`` builds a ``tag_names`` index
+    by iterating ``metadata.items()`` and reading ``.name`` off the
+    value, then looks values back up via the ``code → tag`` mapping.
+    The codes themselves don't matter for the projection — they are an
+    opaque key — so we synthesize sequential ints.
+    """
+    return {
+        100 + i: _FakeTag(name=name, value=value)
+        for i, (name, value) in enumerate(entries.items())
+    }
+
+
+@dataclass
+class _FakeOmePixels:
+    physical_size_x: float | None
+    physical_size_y: float | None
+    physical_size_z: float | None
+    time_increment: float | None
+
+
+@dataclass
+class _FakeOmeImage:
+    pixels: _FakeOmePixels
+
+
+@dataclass
+class _FakeOme:
+    images: list[_FakeOmeImage]
+
+
+def _build_ome(x: float | None, y: float | None, z: float | None, t: float | None) -> _FakeOme:
+    """Build a fake OME object whose ``images[0].pixels`` reads cleanly."""
+    return _FakeOme(images=[_FakeOmeImage(pixels=_FakeOmePixels(x, y, z, t))])
+
+
+@dataclass
+class _FakeNd2Volume:
+    axesCalibration: tuple | list | None
+
+
+@dataclass
+class _FakeNd2Channel:
+    volume: Any
+
+
+@dataclass
+class _FakeNd2Root:
+    volume: Any = None
+    channels: Any = None
+
+
+# ============================================================
+# 1. OmeExtractor
+# ============================================================
+
+
+def test_ome_extractor_parses_all_four_dims() -> None:
+    """All four pixels fields populated → all four dim_res entries set."""
+    ome = _build_ome(x=0.0655, y=0.0655, z=0.25, t=4.5)
+    extractor = OmeExtractor(ome=ome, axes='TZYX', shape=(2, 16, 192, 279))
+    assert extractor.metadata_type == 'ome'
+    assert extractor.parse_dim_res() == {
+        'X': 0.0655, 'Y': 0.0655, 'Z': 0.25, 'T': 4.5,
+    }
+
+
+def test_ome_extractor_propagates_none_z() -> None:
+    """A 2D OME (``physical_size_z`` is None) → dim_res['Z'] is None."""
+    ome = _build_ome(x=0.1, y=0.1, z=None, t=2.0)
+    extractor = OmeExtractor(ome=ome, axes='TYX', shape=(2, 192, 279))
+    result = extractor.parse_dim_res()
+    assert result['Z'] is None
+    assert result == {'X': 0.1, 'Y': 0.1, 'Z': None, 'T': 2.0}
+
+
+def test_ome_extractor_against_real_fixture() -> None:
+    """End-to-end smoke: real OME-TIFF → factory → parse_dim_res matches conftest fixture."""
+    fixture = Path(__file__).resolve().parent / 'fixtures' / 'yeast_3d_t0_to_1.ome.tif'
+    extractor = detect_extractor(str(fixture))
+    assert isinstance(extractor, OmeExtractor)
+    assert extractor.parse_dim_res() == pytest.approx(
+        {'X': 0.0655, 'Y': 0.0655, 'Z': 0.25, 'T': 4.535566806793213}
+    )
+
+
+# ============================================================
+# 2. ImageJExtractor
+# ============================================================
+
+
+def test_imagej_extractor_full_dict_parses_all_four() -> None:
+    """All four imagej keys present → all four dim_res entries set."""
+    meta = {'physicalsizex': 0.108, 'physicalsizey': 0.108, 'spacing': 0.5, 'finterval': 2.0}
+    extractor = ImageJExtractor(imagej_meta=meta, axes='YX', shape=(32, 32))
+    assert extractor.metadata_type == 'imagej'
+    assert extractor.parse_dim_res() == {
+        'X': 0.108, 'Y': 0.108, 'Z': 0.5, 'T': 2.0,
+    }
+
+
+def test_imagej_extractor_missing_physicalsizex_returns_none_for_x() -> None:
+    """``physicalsizex`` missing → dim_res['X'] is None (rest pulled normally)."""
+    meta = {'physicalsizey': 0.108, 'spacing': 0.5, 'finterval': 2.0}
+    extractor = ImageJExtractor(imagej_meta=meta, axes='YX', shape=(32, 32))
+    result = extractor.parse_dim_res()
+    assert result['X'] is None
+    assert result['Y'] == 0.108
+
+
+def test_imagej_extractor_missing_spacing_returns_none_for_z() -> None:
+    """``spacing`` missing → dim_res['Z'] is None."""
+    meta = {'physicalsizex': 0.108, 'physicalsizey': 0.108, 'finterval': 2.0}
+    extractor = ImageJExtractor(imagej_meta=meta, axes='YX', shape=(32, 32))
+    assert extractor.parse_dim_res()['Z'] is None
+
+
+def test_imagej_extractor_missing_finterval_returns_none_for_t() -> None:
+    """``finterval`` missing → dim_res['T'] is None."""
+    meta = {'physicalsizex': 0.108, 'physicalsizey': 0.108, 'spacing': 0.5}
+    extractor = ImageJExtractor(imagej_meta=meta, axes='YX', shape=(32, 32))
+    assert extractor.parse_dim_res()['T'] is None
+
+
+def test_imagej_extractor_empty_dict_returns_all_none() -> None:
+    """Empty imagej_meta → all four dim_res entries are None."""
+    extractor = ImageJExtractor(imagej_meta={}, axes='YX', shape=(32, 32))
+    assert extractor.parse_dim_res() == {'X': None, 'Y': None, 'Z': None, 'T': None}
+
+
+# ============================================================
+# 3. ImageJTifTagExtractor
+# ============================================================
+
+
+def test_imagej_tif_tags_extractor_layers_imagej_then_tags() -> None:
+    """imagej dict carries Y, raw tags carry X — both end up in dim_res."""
+    imagej_meta = {'physicalsizey': 0.108}
+    tif_tags = _build_tags({
+        'XResolution': (10000, 1),  # → 1 / 10000 = 0.0001
+        'ResolutionUnit': tifffile.RESUNIT.NONE,
+    })
+    extractor = ImageJTifTagExtractor(
+        imagej_meta=imagej_meta, tif_tags=tif_tags, axes='YX', shape=(32, 32),
+    )
+    result = extractor.parse_dim_res()
+    assert extractor.metadata_type == 'imagej_tif_tags'
+    assert result['X'] == pytest.approx(0.0001)
+    assert result['Y'] == 0.108
+    assert result['Z'] is None
+    assert result['T'] is None
+
+
+def test_imagej_tif_tags_extractor_tags_overwrite_imagej_xy() -> None:
+    """If both imagej AND tif tags carry X/Y, the raw-tag values win (legacy ordering)."""
+    imagej_meta = {'physicalsizex': 999.0, 'physicalsizey': 999.0}
+    tif_tags = _build_tags({
+        'XResolution': (10000, 1),
+        'YResolution': (10000, 1),
+        'ResolutionUnit': tifffile.RESUNIT.CENTIMETER,
+    })
+    extractor = ImageJTifTagExtractor(
+        imagej_meta=imagej_meta, tif_tags=tif_tags, axes='YX', shape=(32, 32),
+    )
+    result = extractor.parse_dim_res()
+    # CENTIMETER scaling: 1/10000 * 1e4 = 1.0
+    assert result['X'] == pytest.approx(1.0)
+    assert result['Y'] == pytest.approx(1.0)
+
+
+def test_imagej_tif_tags_extractor_against_real_fixture() -> None:
+    """End-to-end: real ImageJ TIFF without ``physicalsizex`` → tif-tags fallback fires."""
+    fixture = Path(__file__).resolve().parent / 'fixtures' / 'imagej_no_physicalsize.tif'
+    extractor = detect_extractor(str(fixture))
+    assert isinstance(extractor, ImageJTifTagExtractor)
+    assert extractor.parse_dim_res() == {'X': 1.0, 'Y': 1.0, 'Z': None, 'T': None}
+
+
+# ============================================================
+# 4. Nd2Extractor
+# ============================================================
+
+
+def test_nd2_extractor_volume_axes_calibration_path() -> None:
+    """root_meta.volume.axesCalibration → X/Y/Z populated."""
+    root = _FakeNd2Root(volume=_FakeNd2Volume(axesCalibration=(0.1, 0.2, 0.5)))
+    recorded = {'Time [s]': [0.0, 1.0, 2.0]}
+    extractor = Nd2Extractor(
+        root_meta=root, recorded_data=recorded, axes='TZYX', shape=(3, 4, 32, 32),
+    )
+    result = extractor.parse_dim_res()
+    assert extractor.metadata_type == 'nd2'
+    assert result['X'] == 0.1
+    assert result['Y'] == 0.2
+    assert result['Z'] == 0.5
+    # Median diff of [0, 1, 2] is 1.0
+    assert result['T'] == pytest.approx(1.0)
+
+
+def test_nd2_extractor_channel_volume_fallback() -> None:
+    """root_meta.volume.axesCalibration absent → fall back to channels[0].volume.axesCalibration."""
+    fallback_volume = _FakeNd2Volume(axesCalibration=(0.3, 0.4, 0.7))
+    root = _FakeNd2Root(volume=None, channels=[_FakeNd2Channel(volume=fallback_volume)])
+    extractor = Nd2Extractor(
+        root_meta=root, recorded_data={}, axes='ZYX', shape=(4, 32, 32),
+    )
+    result = extractor.parse_dim_res()
+    assert result['X'] == 0.3
+    assert result['Y'] == 0.4
+    assert result['Z'] == 0.7
+    # No timestamps → T is None
+    assert result['T'] is None
+
+
+def test_nd2_extractor_median_of_diffs_uses_median_not_mean() -> None:
+    """Robust to outliers: timestamps [0, 1, 2, 100] have median diff 1.0 (mean would be 33.0)."""
+    root = _FakeNd2Root()  # no axes calibration anywhere
+    recorded = {'Time [s]': [0.0, 1.0, 2.0, 100.0]}
+    extractor = Nd2Extractor(
+        root_meta=root, recorded_data=recorded, axes='TYX', shape=(4, 32, 32),
+    )
+    assert extractor.parse_dim_res()['T'] == pytest.approx(1.0)
+
+
+def test_nd2_extractor_single_timepoint_returns_none_for_t() -> None:
+    """Only one timestamp → cannot compute diff → T is None."""
+    extractor = Nd2Extractor(
+        root_meta=_FakeNd2Root(),
+        recorded_data={'Time [s]': [42.0]},
+        axes='TYX',
+        shape=(1, 32, 32),
+    )
+    assert extractor.parse_dim_res()['T'] is None
+
+
+def test_nd2_extractor_missing_recorded_data_returns_all_none_for_t() -> None:
+    """``recorded_data`` empty → ``Time [s]`` lookup returns None → T stays None."""
+    extractor = Nd2Extractor(
+        root_meta=_FakeNd2Root(),
+        recorded_data={},
+        axes='TYX',
+        shape=(1, 32, 32),
+    )
+    result = extractor.parse_dim_res()
+    assert result == {'X': None, 'Y': None, 'Z': None, 'T': None}
+
+
+# ============================================================
+# 5. RawTiffTagExtractor
+# ============================================================
+
+
+def test_raw_tiff_no_resunit_no_scaling() -> None:
+    """RESUNIT.NONE: 1/10000 = 0.0001 (no scaling)."""
+    tags = _build_tags({
+        'XResolution': (10000, 1),
+        'YResolution': (10000, 1),
+        'ResolutionUnit': tifffile.RESUNIT.NONE,
+    })
+    extractor = RawTiffTagExtractor(tags=tags, axes='YX', shape=(32, 32))
+    assert extractor.metadata_type is None
+    result = extractor.parse_dim_res()
+    assert result['X'] == pytest.approx(0.0001)
+    assert result['Y'] == pytest.approx(0.0001)
+
+
+def test_raw_tiff_centimeter_scales_by_1e4() -> None:
+    """RESUNIT.CENTIMETER: (1/10000) * 1e4 = 1.0."""
+    tags = _build_tags({
+        'XResolution': (10000, 1),
+        'YResolution': (10000, 1),
+        'ResolutionUnit': tifffile.RESUNIT.CENTIMETER,
+    })
+    extractor = RawTiffTagExtractor(tags=tags, axes='YX', shape=(32, 32))
+    result = extractor.parse_dim_res()
+    assert result['X'] == pytest.approx(1.0)
+    assert result['Y'] == pytest.approx(1.0)
+
+
+def test_raw_tiff_inch_scales_by_25400() -> None:
+    """RESUNIT.INCH: (1/10000) * 25400 = 2.54."""
+    tags = _build_tags({
+        'XResolution': (10000, 1),
+        'YResolution': (10000, 1),
+        'ResolutionUnit': tifffile.RESUNIT.INCH,
+    })
+    extractor = RawTiffTagExtractor(tags=tags, axes='YX', shape=(32, 32))
+    result = extractor.parse_dim_res()
+    assert result['X'] == pytest.approx(2.54)
+    assert result['Y'] == pytest.approx(2.54)
+
+
+def test_raw_tiff_z_resolution_only_when_z_in_axes() -> None:
+    """ZResolution present but axes lack 'Z' → Z stays None."""
+    tags = _build_tags({
+        'XResolution': (10000, 1),
+        'ZResolution': (4, 1),  # would yield Z=0.25 if gated open
+    })
+    yx_extractor = RawTiffTagExtractor(tags=tags, axes='YX', shape=(32, 32))
+    assert yx_extractor.parse_dim_res()['Z'] is None
+    zyx_extractor = RawTiffTagExtractor(tags=tags, axes='ZYX', shape=(4, 32, 32))
+    assert zyx_extractor.parse_dim_res()['Z'] == pytest.approx(0.25)
+
+
+def test_raw_tiff_frame_rate_only_when_t_in_axes() -> None:
+    """FrameRate present but axes lack 'T' → T stays None."""
+    tags = _build_tags({
+        'XResolution': (10000, 1),
+        'FrameRate': (2, 1),  # would yield T=0.5 if gated open
+    })
+    yx_extractor = RawTiffTagExtractor(tags=tags, axes='YX', shape=(32, 32))
+    assert yx_extractor.parse_dim_res()['T'] is None
+    tyx_extractor = RawTiffTagExtractor(tags=tags, axes='TYX', shape=(2, 32, 32))
+    assert tyx_extractor.parse_dim_res()['T'] == pytest.approx(0.5)
+
+
+# ============================================================
+# 6. detect_extractor factory — one test per verifier_fixture_paths entry
+# ============================================================
+
+
+def test_factory_unsupported_extension_raises(tmp_path: Path) -> None:
+    """Non-TIFF/ND2 extension raises ValueError."""
+    bogus = tmp_path / 'foo.png'
+    bogus.write_bytes(b'\x89PNG\r\n\x1a\n')
+    with pytest.raises(ValueError, match='File type not supported'):
+        detect_extractor(str(bogus))
+
+
+def test_factory_returns_ome_for_3d_yeast(verifier_fixture_paths) -> None:
+    extractor = detect_extractor(str(verifier_fixture_paths['ome']))
+    assert isinstance(extractor, OmeExtractor)
+    assert extractor.metadata_type == 'ome'
+
+
+def test_factory_returns_ome_for_2d_yeast(verifier_fixture_paths) -> None:
+    extractor = detect_extractor(str(verifier_fixture_paths['ome_2d']))
+    assert isinstance(extractor, OmeExtractor)
+    assert extractor.metadata_type == 'ome'
+
+
+def test_factory_returns_imagej_for_imagej_with_physicalsize(verifier_fixture_paths) -> None:
+    extractor = detect_extractor(str(verifier_fixture_paths['imagej']))
+    assert isinstance(extractor, ImageJExtractor)
+    assert extractor.metadata_type == 'imagej'
+
+
+def test_factory_returns_imagej_tif_tags_for_imagej_no_physicalsize(verifier_fixture_paths) -> None:
+    extractor = detect_extractor(str(verifier_fixture_paths['imagej_tif_tags']))
+    assert isinstance(extractor, ImageJTifTagExtractor)
+    assert extractor.metadata_type == 'imagej_tif_tags'
+
+
+def test_factory_returns_raw_tiff_for_no_resunit(verifier_fixture_paths) -> None:
+    extractor = detect_extractor(str(verifier_fixture_paths['raw_no_resunit']))
+    assert isinstance(extractor, RawTiffTagExtractor)
+    assert extractor.metadata_type is None
+
+
+def test_factory_returns_raw_tiff_for_centimeter(verifier_fixture_paths) -> None:
+    extractor = detect_extractor(str(verifier_fixture_paths['raw_centimeter']))
+    assert isinstance(extractor, RawTiffTagExtractor)
+    assert extractor.metadata_type is None
+
+
+def test_factory_returns_raw_tiff_for_inch(verifier_fixture_paths) -> None:
+    extractor = detect_extractor(str(verifier_fixture_paths['raw_inch']))
+    assert isinstance(extractor, RawTiffTagExtractor)
+    assert extractor.metadata_type is None


### PR DESCRIPTION
## Summary

Slice 6 of the verifier dechaos refactor (issue #129) — **the structural payoff**. Defines a ``MetadataExtractor`` Protocol with 5 per-format implementations in a new ``nellie/im_info/extractors/`` subpackage. Unblocks the queued bioio integration.

**New subpackage** (9 files, ~360 lines):
- ``nellie/im_info/types.py``: shared ``DimRes`` + ``infer_t_axis`` (moved to break circular import)
- ``nellie/im_info/extractors/protocol.py``: ``MetadataExtractor`` Protocol (PEP 544)
- ``nellie/im_info/extractors/{ome,imagej,imagej_tif_tags,nd2,raw_tiff}.py``: 5 dataclass extractors
- ``nellie/im_info/extractors/factory.py``: ``detect_extractor(filepath)`` — single file open per detection
- ``nellie/im_info/extractors/_tif_tags.py``: private helper shared by raw-tiff and imagej-tif-tags

**verifier.py**: −200 net lines. Deleted 6 methods (``_find_*_metadata``, ``_get_*_metadata``). Dropped the polymorphic ``self.metadata`` field. ``find_metadata`` is now 5 lines; ``load_metadata`` is 3 lines.

**Behavior change**: ``fi.metadata`` field deleted (verified via grep: no in-tree readers). ``fi.metadata_type`` still works as a string.

**ImageJTifTagExtractor**: carries ``imagej_meta`` AND ``tif_tags`` as proper named fields — no more list-of-dicts shoehorn (the smoking gun the dechaos report Pass 2 #2 flagged).

**Tests**: 29 new in ``test_extractors.py`` (pure-logic, no fixtures needed for per-extractor tests; factory tests use the 7 conftest fixtures).

## Test plan

- [x] Pyright on verifier.py: 83 → 48 errors (−35 net)
- [x] Pyright on extractors/ + test files: 0 errors
- [x] Test suite: 316 passed (287 baseline + 29 new)
- [x] All 287 existing tests still pass without modification

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)