### PR TITLE
verifier: OME-TIFF writer extraction (Slice 7 of #131)

### DIFF
--- a/nellie/im_info/verifier.py
+++ b/nellie/im_info/verifier.py
@@ -126,6 +126,75 @@ def transform_to_axes(
     return data, ''.join(final_axes)
 
 
+def _write_ome_tiff(
+    path: str,
+    *,
+    data: np.ndarray | None = None,
+    shape: tuple[int, ...] | None = None,
+    dtype: str | np.dtype | None = None,
+    axes: str,
+    dim_res: DimRes,
+    description: str = "No description.",
+) -> None:
+    """
+    Write an OME-TIFF file and inject canonical OME XML metadata.
+
+    Either ``data`` (writes the array) or ``shape`` + ``dtype``
+    (allocates an empty file) must be provided. After writing, re-opens
+    the OME XML to set ``physical_size_*`` + ``time_increment`` from
+    ``dim_res`` (only non-None values are written; None values leave
+    the OME field at the tifffile default), set the OME pixel type
+    (mapping ``float32`` → ``'float'``, ``float64`` → ``'double'``),
+    and set the OME image description.
+
+    Single source of truth for the write-then-reopen-to-set-OME-XML
+    pattern shared by ``FileInfo.save_ome_tiff`` and
+    ``ImInfo.allocate_memory``.
+
+    Raises
+    ------
+    ValueError
+        If neither ``data`` nor both ``shape`` and ``dtype`` are
+        provided.
+    """
+    if data is not None:
+        tifffile.imwrite(
+            path, data, bigtiff=True,
+            metadata={"axes": axes}, photometric="minisblack",
+        )
+        dtype_name = data.dtype.name
+    else:
+        if shape is None or dtype is None:
+            raise ValueError(
+                "Either data or both shape+dtype must be provided"
+            )
+        tifffile.imwrite(
+            path, shape=shape, dtype=dtype, bigtiff=True,
+            metadata={"axes": axes}, photometric="minisblack",
+        )
+        dtype_name = np.dtype(dtype).name
+
+    if dtype_name == 'float64':
+        dtype_name = 'double'
+    elif dtype_name == 'float32':
+        dtype_name = 'float'
+
+    comment = tifffile.tiffcomment(path)
+    assert comment is not None
+    ome = ome_types.from_xml(comment)
+    ome.images[0].description = description
+    if dim_res.get('X') is not None:
+        ome.images[0].pixels.physical_size_x = dim_res['X']
+    if dim_res.get('Y') is not None:
+        ome.images[0].pixels.physical_size_y = dim_res['Y']
+    if dim_res.get('Z') is not None:
+        ome.images[0].pixels.physical_size_z = dim_res['Z']
+    if dim_res.get('T') is not None:
+        ome.images[0].pixels.time_increment = dim_res['T']
+    ome.images[0].pixels.type = dtype_name
+    tifffile.tiffcomment(path, ome.to_xml())
+
+
 class FileInfo:
     """
     A class to handle file information, metadata extraction, and basic file operations for microscopy image files.
@@ -678,20 +747,6 @@ class FileInfo:
             data = np.moveaxis(data, t_index, 0)
             axes = 'T' + axes.replace('T', '')
 
-        tifffile.imwrite(
-            self.ome_output_path,
-            data,
-            bigtiff=True,
-            metadata={"axes": axes},
-            photometric="minisblack",
-        )
-
-        ome_xml = tifffile.tiffcomment(self.ome_output_path)
-        ome = ome_types.from_xml(ome_xml)
-        ome.images[0].pixels.physical_size_x = self.dim_res['X']
-        ome.images[0].pixels.physical_size_y = self.dim_res['Y']
-        ome.images[0].pixels.physical_size_z = self.dim_res['Z']
-        ome.images[0].pixels.time_increment = self.dim_res['T']
         def _normalize_value(value):
             if isinstance(value, np.generic):
                 return value.item()
@@ -705,15 +760,15 @@ class FileInfo:
             "t_start": self.t_start,
             "t_end": self.t_end,
         }
-        ome.images[0].description = json.dumps(provenance, sort_keys=True)
-        dtype_name = data.dtype.name
-        if data.dtype.name == 'float64':
-            dtype_name = 'double'
-        if data.dtype.name == 'float32':
-            dtype_name = 'float'
-        ome.images[0].pixels.type = dtype_name
-        ome_xml = ome.to_xml()
-        tifffile.tiffcomment(self.ome_output_path, ome_xml)
+        assert self.ome_output_path is not None
+        assert self.dim_res is not None
+        _write_ome_tiff(
+            self.ome_output_path,
+            data=data,
+            axes=axes,
+            dim_res=self.dim_res,
+            description=json.dumps(provenance, sort_keys=True),
+        )
 
 
 class ImInfo:
@@ -1013,43 +1068,23 @@ class ImInfo:
             else:
                 raise ValueError('Data dimensions do not match axes')
         if data is None:
-            if len(axes) != len(self.shape):
+            if self.shape is None or len(axes) != len(self.shape):
                 raise ValueError('Shape does not match axes')
-            tifffile.imwrite(
+            _write_ome_tiff(
                 output_path,
                 shape=self.shape,
                 dtype=dtype,
-                bigtiff=True,
-                metadata={"axes": axes},
-                photometric="minisblack",
+                axes=axes,
+                dim_res=self.dim_res,
+                description=description,
             )
-            dtype_name = np.dtype(dtype).name if dtype is not None else 'float'
         else:
-            tifffile.imwrite(
+            _write_ome_tiff(
                 output_path,
-                data,
-                bigtiff=True,
-                metadata={"axes": axes},
-                photometric="minisblack",
+                data=data,
+                axes=axes,
+                dim_res=self.dim_res,
+                description=description,
             )
-            dtype_name = data.dtype.name
-        ome = ome_types.from_xml(tifffile.tiffcomment(output_path))
-        ome.images[0].description = description
-        if self.dim_res.get('X') is not None:
-            ome.images[0].pixels.physical_size_x = self.dim_res['X']
-        if self.dim_res.get('Y') is not None:
-            ome.images[0].pixels.physical_size_y = self.dim_res['Y']
-        if self.dim_res.get('Z') is not None:
-            ome.images[0].pixels.physical_size_z = self.dim_res['Z']
-        if self.dim_res.get('T') is not None:
-            ome.images[0].pixels.time_increment = self.dim_res['T']
-
-        if dtype_name == 'float64':
-            dtype_name = 'double'
-        if dtype_name == 'float32':
-            dtype_name = 'float'
-        ome.images[0].pixels.type = dtype_name
-        ome_xml = ome.to_xml()
-        tifffile.tiffcomment(output_path, ome_xml)
         if return_memmap:
             return self.get_memmap(output_path, read_mode=read_mode)

--- a/tests/test_verifier_fileinfo.py
+++ b/tests/test_verifier_fileinfo.py
@@ -125,6 +125,117 @@ def test_find_metadata_creates_output_dirs(tmp_path) -> None:
 
 
 # ============================================================
+# A0a. _write_ome_tiff helper (Slice 7 — shared OME XML writer)
+# ============================================================
+
+
+def test_write_ome_tiff_data_path_round_trip(tmp_path) -> None:
+    """``_write_ome_tiff`` with ``data`` writes the array + injects metadata.
+
+    Verifies the post-Slice 7 helper produces a file that round-trips
+    through tifffile + ome_types: shape preserved, dim_res in OME pixel
+    metadata, description in OME image description.
+    """
+    from nellie.im_info.verifier import _write_ome_tiff
+
+    arr = np.arange(2 * 16 * 16, dtype=np.uint16).reshape(2, 16, 16)
+    out = tmp_path / "round_trip.ome.tif"
+    _write_ome_tiff(
+        str(out),
+        data=arr,
+        axes="TYX",
+        dim_res={"X": 0.108, "Y": 0.108, "Z": None, "T": 2.0},
+        description="hello",
+    )
+    assert out.exists()
+    assert tifffile.imread(str(out)).shape == (2, 16, 16)
+    comment = tifffile.tiffcomment(str(out))
+    assert comment is not None
+    ome = ome_types.from_xml(comment)
+    assert ome.images[0].description == "hello"
+    assert ome.images[0].pixels.physical_size_x == pytest.approx(0.108)
+    assert ome.images[0].pixels.physical_size_y == pytest.approx(0.108)
+    assert ome.images[0].pixels.time_increment == pytest.approx(2.0)
+
+
+def test_write_ome_tiff_shape_dtype_path_allocates_empty(tmp_path) -> None:
+    """``_write_ome_tiff`` with ``shape`` + ``dtype`` allocates an empty file."""
+    from nellie.im_info.verifier import _write_ome_tiff
+
+    out = tmp_path / "empty.ome.tif"
+    _write_ome_tiff(
+        str(out),
+        shape=(2, 16, 16),
+        dtype="uint16",
+        axes="TYX",
+        dim_res={"X": 0.1, "Y": 0.1, "Z": None, "T": None},
+    )
+    assert out.exists()
+    arr = tifffile.imread(str(out))
+    assert arr.shape == (2, 16, 16)
+    assert arr.dtype == np.uint16
+
+
+def test_write_ome_tiff_skips_none_dim_res_values(tmp_path) -> None:
+    """None ``dim_res`` values are NOT written into the OME XML.
+
+    Pins the conditional-set behavior. None values leave the OME field
+    at the tifffile default (typically also None) instead of explicitly
+    overwriting with None.
+    """
+    from nellie.im_info.verifier import _write_ome_tiff
+
+    arr = np.zeros((1, 8, 8), dtype=np.uint16)
+    out = tmp_path / "partial.ome.tif"
+    _write_ome_tiff(
+        str(out),
+        data=arr,
+        axes="TYX",
+        dim_res={"X": 0.5, "Y": 0.5, "Z": None, "T": None},
+        description="partial",
+    )
+    comment = tifffile.tiffcomment(str(out))
+    assert comment is not None
+    ome = ome_types.from_xml(comment)
+    assert ome.images[0].pixels.physical_size_x == pytest.approx(0.5)
+    assert ome.images[0].pixels.physical_size_y == pytest.approx(0.5)
+    # Z and T were None in dim_res — left at tifffile's default (None).
+    assert ome.images[0].pixels.physical_size_z is None
+    assert ome.images[0].pixels.time_increment is None
+
+
+def test_write_ome_tiff_dtype_name_mapping(tmp_path) -> None:
+    """float32 → 'float', float64 → 'double' in the OME pixel type."""
+    from nellie.im_info.verifier import _write_ome_tiff
+
+    arr32 = np.zeros((1, 4, 4), dtype=np.float32)
+    out32 = tmp_path / "f32.ome.tif"
+    _write_ome_tiff(str(out32), data=arr32, axes="TYX", dim_res={"X": 1.0, "Y": 1.0, "Z": None, "T": None})
+    comment32 = tifffile.tiffcomment(str(out32))
+    assert comment32 is not None
+    assert ome_types.from_xml(comment32).images[0].pixels.type.value == "float"
+
+    arr64 = np.zeros((1, 4, 4), dtype=np.float64)
+    out64 = tmp_path / "f64.ome.tif"
+    _write_ome_tiff(str(out64), data=arr64, axes="TYX", dim_res={"X": 1.0, "Y": 1.0, "Z": None, "T": None})
+    comment64 = tifffile.tiffcomment(str(out64))
+    assert comment64 is not None
+    assert ome_types.from_xml(comment64).images[0].pixels.type.value == "double"
+
+
+def test_write_ome_tiff_raises_when_missing_data_and_shape(tmp_path) -> None:
+    """``_write_ome_tiff`` requires either ``data`` OR ``shape``+``dtype``."""
+    from nellie.im_info.verifier import _write_ome_tiff
+
+    with pytest.raises(ValueError, match="Either data or both shape\\+dtype must be provided"):
+        _write_ome_tiff(
+            str(tmp_path / "nope.ome.tif"),
+            axes="TYX",
+            dim_res={"X": 1.0, "Y": 1.0, "Z": None, "T": None},
+        )
+
+
+# ============================================================
 # A. Per-format dim_res extraction (metadata_type branches)
 # ============================================================
 


### PR DESCRIPTION
## Summary

Slice 7 of the verifier dechaos refactor (issue #131). Smallest structural slice. Extracts the write-then-reopen-to-set-OME-XML pattern shared by ``FileInfo.save_ome_tiff`` and ``ImInfo.allocate_memory`` into a single module-level helper.

**New helper** (60 lines, in ``verifier.py`` after ``transform_to_axes``):
- ``_write_ome_tiff(path, *, data=None, shape=None, dtype=None, axes, dim_res, description)`` — single source of truth for the OME XML metadata-injection dance.

**Caller refactors**:
- ``FileInfo.save_ome_tiff``: ~37 lines of duplicated write+inject removed, replaced with a 7-line helper call. Provenance JSON construction stays (caller-specific).
- ``ImInfo.allocate_memory``: ~36 lines removed, replaced with one of two helper calls (data path vs shape+dtype path).

**Behavior change** (subtle): ``save_ome_tiff`` previously set ``physical_size_z = None`` unconditionally for files without Z (2D fixtures). After Slice 7, Z is left at the tifffile default. Provenance JSON behavior unchanged.

**New tests** (5): round-trip with data, round-trip with shape+dtype, conditional dim_res setting, dtype-name mapping (float32 → 'float', float64 → 'double'), ValueError on missing inputs.

## Test plan

- [x] Pyright on ``verifier.py``: 48 → 38 errors (−10 net)
- [x] Pyright on test files: 0 errors
- [x] Verifier tests: 145 passed (140 baseline + 5 new)
- [x] Full test suite: 321 passed (316 baseline + 5 new)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)