### PR TITLE
verifier: load_image() orchestrator (Slice 8 — FINAL slice of #133)

### DIFF
--- a/nellie/im_info/__init__.py
+++ b/nellie/im_info/__init__.py
@@ -1,1 +1,56 @@
+from pathlib import Path
+
+from .types import DimRes
 from .verifier import FileInfo, ImInfo
+
+
+def load_image(
+    path: str | Path,
+    *,
+    output_dir: str | None = None,
+    output_naming: str = "detailed",
+) -> ImInfo:
+    """
+    Load an image from ``path`` and return a fully-loaded ``ImInfo``.
+
+    The canonical one-call entry point for programmatic image loading.
+    Equivalent to::
+
+        file_info = FileInfo(path, output_dir=output_dir, output_naming=output_naming)
+        file_info.find_metadata()
+        file_info.load_metadata()
+        return ImInfo.from_file_info(file_info)
+
+    The napari fileselect widget intentionally splits these steps so
+    the UI can surface auto-detected axes for user override before
+    triggering ``ImInfo`` construction; programmatic callers should use
+    this function instead.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the image file (.tif, .tiff, or .nd2).
+    output_dir : str, optional
+        Override the output directory. Defaults to
+        ``<input_dir>/nellie_output``.
+    output_naming : str, optional
+        Output naming strategy: ``"detailed"`` (default) bakes axes +
+        ``dim_res`` into the filename; ``"stable"`` preserves the
+        input filename.
+
+    Returns
+    -------
+    ImInfo
+        A fully-loaded ``ImInfo`` with ``axes``, ``dim_res``,
+        ``pipeline_paths`` populated and the canonical OME-TIFF
+        memmapped.
+    """
+    file_info = FileInfo(
+        str(path), output_dir=output_dir, output_naming=output_naming
+    )
+    file_info.find_metadata()
+    file_info.load_metadata()
+    return ImInfo.from_file_info(file_info)
+
+
+__all__ = ["FileInfo", "ImInfo", "DimRes", "load_image"]

--- a/nellie/tracking/flow_vector_viz.py
+++ b/nellie/tracking/flow_vector_viz.py
@@ -123,14 +123,10 @@ def load_mocap_markers_as_points(
 
 
 if __name__ == "__main__":
-    from nellie.im_info.verifier import FileInfo
-    
-    test_file = "/Users/austin/test_files/nellie_all_tests/yeast_3d_mitochondria.ome_variants/variant_TCZYX_dup2.ome.tif"
-    file_info = FileInfo(test_file)
-    file_info.find_metadata()
-    file_info.load_metadata()
+    from nellie.im_info import load_image
 
-    im_info = ImInfo.from_file_info(file_info)
+    test_file = "/Users/austin/test_files/nellie_all_tests/yeast_3d_mitochondria.ome_variants/variant_TCZYX_dup2.ome.tif"
+    im_info = load_image(test_file)
 
     tracks, props = load_flow_vectors_as_tracks(im_info, cost_threshold=None, stride=1)
     markers = load_mocap_markers_as_points(im_info, point_stride=1)

--- a/scripts/voxel_reassignment_demo.py
+++ b/scripts/voxel_reassignment_demo.py
@@ -8,7 +8,7 @@ import pickle
 
 import numpy as np
 
-from nellie.im_info.verifier import FileInfo, ImInfo
+from nellie.im_info import load_image
 from nellie.tracking.voxel_reassignment import VoxelReassigner, VoxelReassignerConfig
 
 
@@ -50,10 +50,7 @@ def accumulate_pair_counts(src_ids, dst_ids, n_src, n_dst, use_gpu=True):
 
 def main():
     im_path = r"D:\test_files\nelly_smorgasbord\deskewed-iono_pre.ome.tif"
-    file_info = FileInfo(im_path)
-    file_info.find_metadata()
-    file_info.load_metadata()
-    im_info = ImInfo.from_file_info(file_info)
+    im_info = load_image(im_path)
 
     run_obj = VoxelReassigner(im_info, VoxelReassignerConfig(), num_t=3)
     run_obj.run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ from pathlib import Path
 
 import pytest
 
-from nellie.im_info.verifier import FileInfo, ImInfo
+from nellie.im_info import ImInfo, load_image
 from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label, LabelConfig
 from nellie.segmentation.mocap_marking import Markers, MarkersConfig
@@ -108,10 +108,7 @@ FIXTURE_RAW_TIFF_INCH_PATH = (
 def _build_iminfo(source: Path, workdir: Path) -> ImInfo:
     dst = workdir / source.name
     shutil.copy(source, dst)
-    file_info = FileInfo(str(dst))
-    file_info.find_metadata()
-    file_info.load_metadata()
-    return ImInfo.from_file_info(file_info)
+    return load_image(dst)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_hu_tracking.py
+++ b/tests/test_hu_tracking.py
@@ -79,7 +79,7 @@ import numpy as np
 import pytest
 import tifffile
 
-from nellie.im_info.verifier import FileInfo, ImInfo
+from nellie.im_info import ImInfo, load_image
 from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label, LabelConfig
 from nellie.segmentation.mocap_marking import Markers, MarkersConfig
@@ -392,10 +392,7 @@ def _build_single_frame_iminfo(workdir: Path) -> ImInfo:
             "PhysicalSizeYUnit": "µm",
         },
     )
-    file_info = FileInfo(str(raw_path))
-    file_info.find_metadata()
-    file_info.load_metadata()
-    info = ImInfo.from_file_info(file_info)
+    info = load_image(raw_path)
     Filter(info, FrangiConfig(device="cpu"), num_t=1).run()
     Label(info, LabelConfig(device="cpu"), num_t=1).run()
     Markers(info, MarkersConfig(device="cpu"), num_t=1).run()

--- a/tests/test_labelling.py
+++ b/tests/test_labelling.py
@@ -26,7 +26,7 @@ import numpy as np
 import pytest
 import tifffile
 
-from nellie.im_info.verifier import FileInfo, ImInfo
+from nellie.im_info import ImInfo, load_image
 from nellie.segmentation.labelling import Label, LabelConfig
 
 
@@ -100,10 +100,7 @@ def _build_synthetic_label_iminfo(workdir: Path) -> ImInfo:
         },
     )
 
-    file_info = FileInfo(str(raw_path))
-    file_info.find_metadata()
-    file_info.load_metadata()
-    info = ImInfo.from_file_info(file_info)
+    info = load_image(raw_path)
 
     rng = np.random.default_rng(42)
     frangi = rng.uniform(0.005, 0.05, size=_SYNTHETIC_SHAPE).astype(np.float32)

--- a/tests/test_mocap_marking.py
+++ b/tests/test_mocap_marking.py
@@ -53,7 +53,7 @@ import numpy as np
 import pytest
 import tifffile
 
-from nellie.im_info.verifier import FileInfo, ImInfo
+from nellie.im_info import ImInfo, load_image
 from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label, LabelConfig
 from nellie.segmentation.mocap_marking import Markers, MarkersConfig
@@ -493,10 +493,7 @@ def _build_single_frame_iminfo(workdir: Path) -> ImInfo:
             "PhysicalSizeYUnit": "µm",
         },
     )
-    file_info = FileInfo(str(raw_path))
-    file_info.find_metadata()
-    file_info.load_metadata()
-    info = ImInfo.from_file_info(file_info)
+    info = load_image(raw_path)
     Filter(info, FrangiConfig(device="cpu"), num_t=1).run()
     Label(info, LabelConfig(device="cpu"), num_t=1).run()
     gc.collect()

--- a/tests/test_verifier_iminfo.py
+++ b/tests/test_verifier_iminfo.py
@@ -834,3 +834,64 @@ def test_remove_intermediates_deletes_canonical_im_path(make_imageinfo_3d) -> No
     _release_iminfo_memmap(info)  # Windows: release im_path mmap before delete
     info.remove_intermediates()
     assert not os.path.exists(info.im_path)
+
+
+# ============================================================================
+# I. ``load_image`` orchestrator (Slice 8 — final slice)
+# ============================================================================
+
+
+def test_load_image_returns_loaded_iminfo(tmp_path: Path) -> None:
+    """``load_image(path)`` returns a fully-loaded ImInfo with axes/shape/dim_res populated."""
+    from nellie.im_info import load_image
+
+    workdir = tmp_path / 'wd'
+    workdir.mkdir()
+    src = copy_fixture_to_tmp(FIXTURE_3D_PATH, workdir)
+
+    info = load_image(src)
+    assert info.axes == 'TZYX'
+    assert info.shape == (2, 17, 192, 279)
+    assert info.dim_res == pytest.approx(
+        {'X': 0.0655, 'Y': 0.0655, 'Z': 0.25, 'T': 4.535566806793213}
+    )
+    assert info.im is not None
+    assert info.pipeline_paths
+    assert info.im_path is not None
+    assert os.path.exists(info.im_path)
+
+
+def test_load_image_equivalent_to_explicit_boot(tmp_path: Path) -> None:
+    """``load_image(path)`` produces an ImInfo equivalent to the manual 4-step boot."""
+    from nellie.im_info import load_image
+
+    workdir = tmp_path / 'wd'
+    workdir.mkdir()
+    src_a = copy_fixture_to_tmp(FIXTURE_3D_PATH, workdir / 'a')
+    src_b = copy_fixture_to_tmp(FIXTURE_3D_PATH, workdir / 'b')
+
+    via_orchestrator = load_image(src_a)
+
+    fi = FileInfo(str(src_b))
+    fi.find_metadata()
+    fi.load_metadata()
+    via_explicit = ImInfo.from_file_info(fi)
+
+    assert via_orchestrator.axes == via_explicit.axes
+    assert via_orchestrator.shape == via_explicit.shape
+    assert via_orchestrator.dim_res == via_explicit.dim_res
+    assert via_orchestrator.no_z == via_explicit.no_z
+    assert via_orchestrator.no_t == via_explicit.no_t
+    assert set(via_orchestrator.pipeline_paths.keys()) == set(via_explicit.pipeline_paths.keys())
+
+
+def test_load_image_forwards_output_dir_kwarg(tmp_path: Path) -> None:
+    """``load_image(path, output_dir=...)`` forwards the kwarg to FileInfo."""
+    from nellie.im_info import load_image
+
+    src = copy_fixture_to_tmp(FIXTURE_3D_PATH, tmp_path / 'src')
+    custom_out = tmp_path / 'custom_output'
+
+    info = load_image(src, output_dir=str(custom_out))
+    assert info.file_info.output_dir == str(custom_out)
+    assert custom_out.exists()


### PR DESCRIPTION
## Summary

Slice 8 of the verifier dechaos refactor (issue #133) — **the final slice**. Closes the 8-slice arc.

**New free function** in ``nellie/im_info/__init__.py``:
- ``load_image(path, *, output_dir=None, output_naming="detailed") -> ImInfo`` — canonical one-call entry point for programmatic image loading.

**Callsite updates** (6 of 9): `flow_vector_viz.py`, `voxel_reassignment_demo.py`, `conftest._build_iminfo`, `test_hu_tracking.py`, `test_labelling.py`, `test_mocap_marking.py`.

**Callsites NOT updated** (3 of 9):
- 2 napari fileselect callsites: intentional split-boot for user-override UX.
- ``nellie/run.py`` __main__: the boot is split across two scopes (``__main__`` does FileInfo+find+load, ``run()`` does the ``ImInfo.from_file_info``). Refactoring ``run()``'s signature is out of scope.

**New tests** (3): orchestrator returns loaded ImInfo, equivalent to explicit boot, forwards ``output_dir`` kwarg.

## 8-slice verifier dechaos arc — COMPLETE

| Slice | PR | Scope |
|---|---|---|
| 1 | #120 | Characterization tests (122 tests) |
| 2 | #122 | Clarify pass + change_axes gate restoration |
| 3 | #124 | Constructor I/O extraction (`from_file_info`) |
| 4 | #126 | Unified axes normalizer (`infer_t_axis` + `transform_to_axes`) |
| 5 | #128 | Validation split (`compute_errors` + `apply_defaults`, no more asymmetric raise) |
| 6 | #130 | Extractor strategy + bioio prep (5 per-format extractors in subpackage) |
| 7 | #132 | OME-TIFF writer extraction (`_write_ome_tiff`) |
| 8 | this | `load_image()` orchestrator |

**Net pyright impact**: 93 → 38 errors on verifier.py (−55 net, 59% reduction).
**Test suite**: grew from 147 baseline to 324 (+177 tests).

## Test plan

- [x] Pyright on verifier.py: 38 errors (unchanged from Slice 7)
- [x] Pyright on test files + __init__.py: 0 errors
- [x] Verifier tests: 148 passed (145 baseline + 3 new)
- [x] Full test suite: 324 passed (321 baseline + 3 new)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)