### PR TITLE
Napari widget Config-return typing pass — get_*_params returns Config (#137)

### DIFF
--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -445,7 +445,7 @@ class NellieProcessor(QWidget):
         self._start_worker(worker, next_step=next_step)
 
     @thread_worker(ignore_errors=True)
-    def _run_tracking(self, im_info_list, step_kwargs):
+    def _run_tracking(self, im_info_list, config: HuMomentTrackingConfig, num_t: int | None):
         """
         Run the tracking step in a separate thread. Tracks the motion of the marked points over time.
 
@@ -453,21 +453,20 @@ class NellieProcessor(QWidget):
         ----------
         im_info_list : list
             List of ImInfo objects.
-        step_kwargs : dict
-            Keyword arguments for the HuMomentTracking class (excluding im_info/viewer).
+        config : HuMomentTrackingConfig
+            Algorithm configuration for the HuMomentTracking stage.
+        num_t : int or None
+            Optional per-step override for number of timepoints.
         """
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Tracking file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            config_kwargs = dict(step_kwargs)
-            num_t = config_kwargs.pop("num_t", None)
-            hu_tracking = HuMomentTracking(
+            HuMomentTracking(
                 im_info=self.current_im_info,
-                config=HuMomentTrackingConfig(**config_kwargs),
+                config=config,
                 viewer=self.viewer,
                 num_t=num_t,
-            )
-            hu_tracking.run()
+            ).run()
 
     def run_tracking(self):
         """
@@ -476,8 +475,10 @@ class NellieProcessor(QWidget):
         """
         self.status = "tracking"
         settings = self._get_settings()
-        step_kwargs = settings.get_tracking_params() if settings else {}
-        worker = self._run_tracking(self.im_info_list, step_kwargs)
+        config, num_t = (
+            settings.get_tracking_params() if settings else (HuMomentTrackingConfig(), None)
+        )
+        worker = self._run_tracking(self.im_info_list, config, num_t)
         next_step = None
         if self.pipeline:
             if self.nellie.settings.voxel_reassign.isChecked():

--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -526,7 +526,12 @@ class NellieProcessor(QWidget):
         self._start_worker(worker, next_step=next_step)
 
     @thread_worker(ignore_errors=True)
-    def _run_feature_export(self, im_info_list, skip_nodes, remove_intermediates_checked, step_kwargs):
+    def _run_feature_export(
+        self,
+        im_info_list,
+        config: HierarchyConfig,
+        remove_intermediates_checked: bool,
+    ):
         """
         Run the feature extraction step in a separate thread. Extracts various features from the processed image data for analysis.
 
@@ -534,22 +539,19 @@ class NellieProcessor(QWidget):
         ----------
         im_info_list : list
             List of ImInfo objects.
-        skip_nodes : bool
-            Whether to skip node-level feature extraction.
+        config : HierarchyConfig
+            Algorithm configuration for the Hierarchy stage.
         remove_intermediates_checked : bool
-            Whether to remove intermediate files.
-        step_kwargs : dict
-            Keyword arguments for the Hierarchy class (excluding im_info/viewer/skip_nodes).
+            Whether to remove intermediate files after each Hierarchy run.
         """
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Feature export file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            hierarchy = Hierarchy(
+            Hierarchy(
                 im_info=self.current_im_info,
-                config=HierarchyConfig(skip_nodes=skip_nodes, **step_kwargs),
+                config=config,
                 viewer=self.viewer,
-            )
-            hierarchy.run()
+            ).run()
             if remove_intermediates_checked:
                 try:
                     self.current_im_info.remove_intermediates()
@@ -573,20 +575,13 @@ class NellieProcessor(QWidget):
         Start the feature extraction step and updates the UI to reflect that feature extraction is running.
         """
         self.status = "feature export"
-        analyze_node_level_checked = self.nellie.settings.analyze_node_level.isChecked()
         remove_intermediates_checked = self.nellie.settings.remove_intermediates_checkbox.isChecked()
         settings = self._get_settings()
-        step_kwargs = settings.get_feature_params() if settings else {}
-        skip_nodes_override = step_kwargs.pop("skip_nodes", None)
-        skip_nodes = not bool(analyze_node_level_checked)
-        if skip_nodes_override is not None:
-            skip_nodes = bool(skip_nodes_override)
-
+        config = settings.get_feature_params() if settings else HierarchyConfig()
         worker = self._run_feature_export(
             self.im_info_list,
-            skip_nodes,
+            config,
             remove_intermediates_checked,
-            step_kwargs,
         )
         # This is the last step in the pipeline; always treat as final.
         self._start_worker(worker, final=True)

--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -309,7 +309,7 @@ class NellieProcessor(QWidget):
         return getattr(self.nellie, "settings", None)
 
     @thread_worker(ignore_errors=True)
-    def _run_preprocessing(self, im_info_list, step_kwargs):
+    def _run_preprocessing(self, im_info_list, config: FrangiConfig, num_t: int | None):
         """
         Run the preprocessing step in a separate thread. Filters the image to remove noise or unwanted edges before segmentation.
 
@@ -317,21 +317,20 @@ class NellieProcessor(QWidget):
         ----------
         im_info_list : list
             List of ImInfo objects.
-        step_kwargs : dict
-            Keyword arguments for the Filter class (excluding im_info/viewer).
+        config : FrangiConfig
+            Algorithm configuration for the Filter stage.
+        num_t : int or None
+            Optional per-step override for number of timepoints.
         """
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Preprocessing file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            config_kwargs = dict(step_kwargs)
-            num_t = config_kwargs.pop("num_t", None)
-            preprocessing = Filter(
+            Filter(
                 im_info=self.current_im_info,
-                config=FrangiConfig(**config_kwargs),
+                config=config,
                 viewer=self.viewer,
                 num_t=num_t,
-            )
-            preprocessing.run()
+            ).run()
 
     def run_preprocessing(self):
         """
@@ -339,11 +338,11 @@ class NellieProcessor(QWidget):
         If the full pipeline is running, it automatically proceeds to segmentation after preprocessing is finished.
         """
         self.status = "preprocessing"
-        remove_edges = self.nellie.settings.remove_edges_checkbox.isChecked()
         settings = self._get_settings()
-        step_kwargs = settings.get_preprocessing_params() if settings else {}
-        step_kwargs["remove_edges"] = remove_edges
-        worker = self._run_preprocessing(self.im_info_list, step_kwargs)
+        config, num_t = (
+            settings.get_preprocessing_params() if settings else (FrangiConfig(), None)
+        )
+        worker = self._run_preprocessing(self.im_info_list, config, num_t)
         next_step = self.run_segmentation if self.pipeline else None
         self._start_worker(worker, next_step=next_step)
 

--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -407,7 +407,7 @@ class NellieProcessor(QWidget):
         self._start_worker(worker, next_step=next_step)
 
     @thread_worker(ignore_errors=True)
-    def _run_mocap(self, im_info_list, step_kwargs):
+    def _run_mocap(self, im_info_list, config: MarkersConfig, num_t: int | None):
         """
         Run the mocap marking step in a separate thread. Marks the motion capture points within the segmented regions.
 
@@ -415,21 +415,20 @@ class NellieProcessor(QWidget):
         ----------
         im_info_list : list
             List of ImInfo objects.
-        step_kwargs : dict
-            Keyword arguments for the Markers class (excluding im_info/viewer).
+        config : MarkersConfig
+            Algorithm configuration for the Markers stage.
+        num_t : int or None
+            Optional per-step override for number of timepoints.
         """
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Mocap Marking file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            config_kwargs = dict(step_kwargs)
-            num_t = config_kwargs.pop("num_t", None)
-            mocap_marking = Markers(
+            Markers(
                 im_info=self.current_im_info,
-                config=MarkersConfig(**config_kwargs),
+                config=config,
                 viewer=self.viewer,
                 num_t=num_t,
-            )
-            mocap_marking.run()
+            ).run()
 
     def run_mocap(self):
         """
@@ -438,8 +437,10 @@ class NellieProcessor(QWidget):
         """
         self.status = "mocap marking"
         settings = self._get_settings()
-        step_kwargs = settings.get_mocap_params() if settings else {}
-        worker = self._run_mocap(self.im_info_list, step_kwargs)
+        config, num_t = (
+            settings.get_mocap_params() if settings else (MarkersConfig(), None)
+        )
+        worker = self._run_mocap(self.im_info_list, config, num_t)
         next_step = self.run_tracking if self.pipeline else None
         self._start_worker(worker, next_step=next_step)
 

--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -347,7 +347,14 @@ class NellieProcessor(QWidget):
         self._start_worker(worker, next_step=next_step)
 
     @thread_worker(ignore_errors=True)
-    def _run_segmentation(self, im_info_list, label_kwargs, network_kwargs):
+    def _run_segmentation(
+        self,
+        im_info_list,
+        label_config: LabelConfig,
+        label_num_t: int | None,
+        network_config: NetworkConfig,
+        network_num_t: int | None,
+    ):
         """
         Run the segmentation step in a separate thread. Labels and segments regions of interest in the preprocessed image.
 
@@ -355,32 +362,30 @@ class NellieProcessor(QWidget):
         ----------
         im_info_list : list
             List of ImInfo objects.
-        label_kwargs : dict
-            Keyword arguments for the Label class (excluding im_info/viewer).
-        network_kwargs : dict
-            Keyword arguments for the Network class (excluding im_info/viewer).
+        label_config : LabelConfig
+            Algorithm configuration for the Label stage.
+        label_num_t : int or None
+            Optional per-step override for Label's number of timepoints.
+        network_config : NetworkConfig
+            Algorithm configuration for the Network stage.
+        network_num_t : int or None
+            Optional per-step override for Network's number of timepoints.
         """
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Segmentation file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            label_config_kwargs = dict(label_kwargs)
-            label_num_t = label_config_kwargs.pop("num_t", None)
-            segmenting = Label(
+            Label(
                 im_info=self.current_im_info,
-                config=LabelConfig(**label_config_kwargs),
+                config=label_config,
                 viewer=self.viewer,
                 num_t=label_num_t,
-            )
-            segmenting.run()
-            network_config_kwargs = dict(network_kwargs)
-            network_num_t = network_config_kwargs.pop("num_t", None)
-            networking = Network(
+            ).run()
+            Network(
                 im_info=self.current_im_info,
-                config=NetworkConfig(**network_config_kwargs),
+                config=network_config,
                 viewer=self.viewer,
                 num_t=network_num_t,
-            )
-            networking.run()
+            ).run()
 
     def run_segmentation(self):
         """
@@ -389,9 +394,15 @@ class NellieProcessor(QWidget):
         """
         self.status = "segmentation"
         settings = self._get_settings()
-        label_kwargs = settings.get_segmentation_label_params() if settings else {}
-        network_kwargs = settings.get_segmentation_network_params() if settings else {}
-        worker = self._run_segmentation(self.im_info_list, label_kwargs, network_kwargs)
+        label_config, label_num_t = (
+            settings.get_segmentation_label_params() if settings else (LabelConfig(), None)
+        )
+        network_config, network_num_t = (
+            settings.get_segmentation_network_params() if settings else (NetworkConfig(), None)
+        )
+        worker = self._run_segmentation(
+            self.im_info_list, label_config, label_num_t, network_config, network_num_t
+        )
         next_step = self.run_mocap if self.pipeline else None
         self._start_worker(worker, next_step=next_step)
 

--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -488,7 +488,7 @@ class NellieProcessor(QWidget):
         self._start_worker(worker, next_step=next_step)
 
     @thread_worker(ignore_errors=True)
-    def _run_reassign(self, im_info_list, step_kwargs):
+    def _run_reassign(self, im_info_list, config: VoxelReassignerConfig, num_t: int | None):
         """
         Run the voxel reassignment step in a separate thread. Reassigns voxel labels based on the tracked motion.
 
@@ -496,21 +496,20 @@ class NellieProcessor(QWidget):
         ----------
         im_info_list : list
             List of ImInfo objects.
-        step_kwargs : dict
-            Keyword arguments for the VoxelReassigner class (excluding im_info/viewer).
+        config : VoxelReassignerConfig
+            Algorithm configuration for the VoxelReassigner stage.
+        num_t : int or None
+            Optional per-step override for number of timepoints.
         """
         for im_num, im_info in enumerate(im_info_list):
             show_info(f"Nellie is running: Voxel Reassignment file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            config_kwargs = dict(step_kwargs)
-            num_t = config_kwargs.pop("num_t", None)
-            vox_reassign = VoxelReassigner(
+            VoxelReassigner(
                 im_info=self.current_im_info,
-                config=VoxelReassignerConfig(**config_kwargs),
+                config=config,
                 viewer=self.viewer,
                 num_t=num_t,
-            )
-            vox_reassign.run()
+            ).run()
 
     def run_reassign(self):
         """
@@ -519,8 +518,10 @@ class NellieProcessor(QWidget):
         """
         self.status = "voxel reassignment"
         settings = self._get_settings()
-        step_kwargs = settings.get_reassign_params() if settings else {}
-        worker = self._run_reassign(self.im_info_list, step_kwargs)
+        config, num_t = (
+            settings.get_reassign_params() if settings else (VoxelReassignerConfig(), None)
+        )
+        worker = self._run_reassign(self.im_info_list, config, num_t)
         next_step = self.run_feature_export if self.pipeline else None
         self._start_worker(worker, next_step=next_step)
 

--- a/nellie_napari/nellie_settings.py
+++ b/nellie_napari/nellie_settings.py
@@ -899,21 +899,21 @@ class Settings(QWidget):
         )
         return config, num_t
 
-    def get_mocap_params(self) -> dict:
-        params = {
-            "num_t": self._optional_spinbox_value(
-                self.mocap_num_t_override, self.mocap_num_t
-            ),
-            "min_radius_um": self.mocap_min_radius_um.value(),
-            "max_radius_um": self.mocap_max_radius_um.value(),
-            "use_im": self.mocap_use_im.currentText(),
-            "num_sigma": self.mocap_num_sigma.value(),
-            "peak_min_distance": self.mocap_peak_min_distance.value(),
-            "device": self.mocap_device.currentText(),
-            "low_memory": self.mocap_low_memory.isChecked(),
-            "max_chunk_voxels": self.mocap_max_chunk_voxels.value(),
-        }
-        return self._prune_none(params)
+    def get_mocap_params(self) -> tuple[MarkersConfig, int | None]:
+        config = MarkersConfig(
+            min_radius_um=self.mocap_min_radius_um.value(),
+            max_radius_um=self.mocap_max_radius_um.value(),
+            use_im=self.mocap_use_im.currentText(),
+            num_sigma=self.mocap_num_sigma.value(),
+            peak_min_distance=self.mocap_peak_min_distance.value(),
+            device=self.mocap_device.currentText(),
+            low_memory=self.mocap_low_memory.isChecked(),
+            max_chunk_voxels=self.mocap_max_chunk_voxels.value(),
+        )
+        num_t = self._optional_spinbox_value(
+            self.mocap_num_t_override, self.mocap_num_t
+        )
+        return config, num_t
 
     def get_tracking_params(self) -> dict:
         params = {

--- a/nellie_napari/nellie_settings.py
+++ b/nellie_napari/nellie_settings.py
@@ -930,19 +930,19 @@ class Settings(QWidget):
         )
         return config, num_t
 
-    def get_reassign_params(self) -> dict:
-        params = {
-            "num_t": self._optional_spinbox_value(
-                self.reassign_num_t_override, self.reassign_num_t
-            ),
-            "store_running_matches": self.reassign_store_running_matches.isChecked(),
-            "max_refine_iterations": self.reassign_max_refine_iterations.value(),
-            "device": self.reassign_device.currentText(),
-            "low_memory": self.reassign_low_memory.isChecked(),
-            "max_query_points": self.reassign_max_query_points.value(),
-            "max_bruteforce_pairs": self.reassign_max_bruteforce_pairs.value(),
-        }
-        return self._prune_none(params)
+    def get_reassign_params(self) -> tuple[VoxelReassignerConfig, int | None]:
+        config = VoxelReassignerConfig(
+            store_running_matches=self.reassign_store_running_matches.isChecked(),
+            max_refine_iterations=self.reassign_max_refine_iterations.value(),
+            device=self.reassign_device.currentText(),
+            low_memory=self.reassign_low_memory.isChecked(),
+            max_query_points=self.reassign_max_query_points.value(),
+            max_bruteforce_pairs=self.reassign_max_bruteforce_pairs.value(),
+        )
+        num_t = self._optional_spinbox_value(
+            self.reassign_num_t_override, self.reassign_num_t
+        )
+        return config, num_t
 
     def get_feature_params(self) -> dict:
         params = {

--- a/nellie_napari/nellie_settings.py
+++ b/nellie_napari/nellie_settings.py
@@ -416,9 +416,6 @@ class Settings(QWidget):
     def _optional_spinbox_value(self, override, spinbox):
         return spinbox.value() if override.isChecked() else None
 
-    def _prune_none(self, params: dict) -> dict:
-        return {key: value for key, value in params.items() if value is not None}
-
     def set_ui(self):
         """
         Initialize and set the layout and UI components for the Settings class.
@@ -944,21 +941,25 @@ class Settings(QWidget):
         )
         return config, num_t
 
-    def get_feature_params(self) -> dict:
-        params = {
-            "low_memory": self.feature_low_memory.isChecked(),
-            "enable_motility": self.feature_enable_motility.isChecked(),
-            "enable_adjacency": self.feature_enable_adjacency.isChecked(),
-            "device": self.feature_device.currentText(),
-            "max_node_mask_elems": self.feature_max_node_mask_elems.value(),
-        }
-
+    def get_feature_params(self) -> HierarchyConfig:
         if self.feature_skip_nodes_override.isChecked():
-            params["skip_nodes"] = self.feature_skip_nodes.isChecked()
-        if self.feature_node_chunk_size_override.isChecked():
-            params["node_chunk_size"] = self.feature_node_chunk_size.value()
-
-        return params
+            skip_nodes = self.feature_skip_nodes.isChecked()
+        else:
+            skip_nodes = not self.analyze_node_level.isChecked()
+        node_chunk_size = (
+            self.feature_node_chunk_size.value()
+            if self.feature_node_chunk_size_override.isChecked()
+            else None
+        )
+        return HierarchyConfig(
+            skip_nodes=skip_nodes,
+            low_memory=self.feature_low_memory.isChecked(),
+            enable_motility=self.feature_enable_motility.isChecked(),
+            enable_adjacency=self.feature_enable_adjacency.isChecked(),
+            device=self.feature_device.currentText(),
+            node_chunk_size=node_chunk_size,
+            max_node_mask_elems=self.feature_max_node_mask_elems.value(),
+        )
 
 
 if __name__ == "__main__":

--- a/nellie_napari/nellie_settings.py
+++ b/nellie_napari/nellie_settings.py
@@ -864,40 +864,40 @@ class Settings(QWidget):
         )
         return config, num_t
 
-    def get_segmentation_label_params(self) -> dict:
-        params = {
-            "num_t": self._optional_spinbox_value(
-                self.segmentation_label_num_t_override, self.segmentation_label_num_t
-            ),
-            "threshold": self._optional_spinbox_value(
+    def get_segmentation_label_params(self) -> tuple[LabelConfig, int | None]:
+        config = LabelConfig(
+            threshold=self._optional_spinbox_value(
                 self.segmentation_label_threshold_override, self.segmentation_label_threshold
             ),
-            "otsu_thresh_intensity": self.segmentation_label_otsu_thresh_intensity.isChecked(),
-            "chunk_z": self._optional_spinbox_value(
+            otsu_thresh_intensity=self.segmentation_label_otsu_thresh_intensity.isChecked(),
+            chunk_z=self._optional_spinbox_value(
                 self.segmentation_label_chunk_z_override, self.segmentation_label_chunk_z
             ),
-            "flush_interval": self.segmentation_label_flush_interval.value(),
-            "min_radius_um": self.segmentation_label_min_radius_um.value(),
-            "threshold_sampling_pixels": self.segmentation_label_threshold_sampling_pixels.value(),
-            "histogram_nbins": self.segmentation_label_histogram_nbins.value(),
-            "device": self.segmentation_label_device.currentText(),
-            "low_memory": self.segmentation_label_low_memory.isChecked(),
-            "max_chunk_voxels": self.segmentation_label_max_chunk_voxels.value(),
-        }
-        return self._prune_none(params)
+            flush_interval=self.segmentation_label_flush_interval.value(),
+            min_radius_um=self.segmentation_label_min_radius_um.value(),
+            threshold_sampling_pixels=self.segmentation_label_threshold_sampling_pixels.value(),
+            histogram_nbins=self.segmentation_label_histogram_nbins.value(),
+            device=self.segmentation_label_device.currentText(),
+            low_memory=self.segmentation_label_low_memory.isChecked(),
+            max_chunk_voxels=self.segmentation_label_max_chunk_voxels.value(),
+        )
+        num_t = self._optional_spinbox_value(
+            self.segmentation_label_num_t_override, self.segmentation_label_num_t
+        )
+        return config, num_t
 
-    def get_segmentation_network_params(self) -> dict:
-        params = {
-            "num_t": self._optional_spinbox_value(
-                self.segmentation_network_num_t_override, self.segmentation_network_num_t
-            ),
-            "min_radius_um": self.segmentation_network_min_radius_um.value(),
-            "max_radius_um": self.segmentation_network_max_radius_um.value(),
-            "device": self.segmentation_network_device.currentText(),
-            "low_memory": self.segmentation_network_low_memory.isChecked(),
-            "max_chunk_voxels": self.segmentation_network_max_chunk_voxels.value(),
-        }
-        return self._prune_none(params)
+    def get_segmentation_network_params(self) -> tuple[NetworkConfig, int | None]:
+        config = NetworkConfig(
+            min_radius_um=self.segmentation_network_min_radius_um.value(),
+            max_radius_um=self.segmentation_network_max_radius_um.value(),
+            device=self.segmentation_network_device.currentText(),
+            low_memory=self.segmentation_network_low_memory.isChecked(),
+            max_chunk_voxels=self.segmentation_network_max_chunk_voxels.value(),
+        )
+        num_t = self._optional_spinbox_value(
+            self.segmentation_network_num_t_override, self.segmentation_network_num_t
+        )
+        return config, num_t
 
     def get_mocap_params(self) -> dict:
         params = {

--- a/nellie_napari/nellie_settings.py
+++ b/nellie_napari/nellie_settings.py
@@ -16,6 +16,14 @@ from qtpy.QtWidgets import (
     QScrollArea,
 )
 
+from nellie.feature_extraction.hierarchical import HierarchyConfig
+from nellie.segmentation.filtering import FrangiConfig
+from nellie.segmentation.labelling import LabelConfig
+from nellie.segmentation.mocap_marking import MarkersConfig
+from nellie.segmentation.networking import NetworkConfig
+from nellie.tracking.hu_tracking import HuMomentTrackingConfig
+from nellie.tracking.voxel_reassignment import VoxelReassignerConfig
+
 
 @dataclass
 class SettingsConfig:
@@ -835,25 +843,26 @@ class Settings(QWidget):
             self.feature_node_chunk_size.setValue(config.feature_node_chunk_size)
         self.feature_max_node_mask_elems.setValue(config.feature_max_node_mask_elems)
 
-    def get_preprocessing_params(self) -> dict:
-        params = {
-            "num_t": self._optional_spinbox_value(
-                self.preprocessing_num_t_override, self.preprocessing_num_t
-            ),
-            "min_radius_um": self.preprocessing_min_radius_um.value(),
-            "max_radius_um": self.preprocessing_max_radius_um.value(),
-            "alpha_sq": self.preprocessing_alpha_sq.value(),
-            "beta_sq": self.preprocessing_beta_sq.value(),
-            "frob_thresh": self._optional_spinbox_value(
+    def get_preprocessing_params(self) -> tuple[FrangiConfig, int | None]:
+        config = FrangiConfig(
+            remove_edges=self.remove_edges_checkbox.isChecked(),
+            min_radius_um=self.preprocessing_min_radius_um.value(),
+            max_radius_um=self.preprocessing_max_radius_um.value(),
+            alpha_sq=self.preprocessing_alpha_sq.value(),
+            beta_sq=self.preprocessing_beta_sq.value(),
+            frob_thresh=self._optional_spinbox_value(
                 self.preprocessing_frob_thresh_override, self.preprocessing_frob_thresh
             ),
-            "frob_thresh_division": self.preprocessing_frob_thresh_division.value(),
-            "device": self.preprocessing_device.currentText(),
-            "low_memory": self.preprocessing_low_memory.isChecked(),
-            "max_chunk_voxels": self.preprocessing_max_chunk_voxels.value(),
-            "max_threshold_samples": self.preprocessing_max_threshold_samples.value(),
-        }
-        return self._prune_none(params)
+            frob_thresh_division=self.preprocessing_frob_thresh_division.value(),
+            device=self.preprocessing_device.currentText(),
+            low_memory=self.preprocessing_low_memory.isChecked(),
+            max_chunk_voxels=self.preprocessing_max_chunk_voxels.value(),
+            max_threshold_samples=self.preprocessing_max_threshold_samples.value(),
+        )
+        num_t = self._optional_spinbox_value(
+            self.preprocessing_num_t_override, self.preprocessing_num_t
+        )
+        return config, num_t
 
     def get_segmentation_label_params(self) -> dict:
         params = {

--- a/nellie_napari/nellie_settings.py
+++ b/nellie_napari/nellie_settings.py
@@ -915,20 +915,20 @@ class Settings(QWidget):
         )
         return config, num_t
 
-    def get_tracking_params(self) -> dict:
-        params = {
-            "num_t": self._optional_spinbox_value(
-                self.tracking_num_t_override, self.tracking_num_t
-            ),
-            "max_distance_um": self.tracking_max_distance_um.value(),
-            "device": self.tracking_device.currentText(),
-            "mode": self.tracking_mode.currentText(),
-            "max_dense_pairs": self.tracking_max_dense_pairs.value(),
-            "max_dense_roi_voxels_cpu": self.tracking_max_dense_roi_voxels_cpu.value(),
-            "max_dense_roi_voxels_gpu": self.tracking_max_dense_roi_voxels_gpu.value(),
-            "low_memory": self.tracking_low_memory.isChecked(),
-        }
-        return self._prune_none(params)
+    def get_tracking_params(self) -> tuple[HuMomentTrackingConfig, int | None]:
+        config = HuMomentTrackingConfig(
+            max_distance_um=self.tracking_max_distance_um.value(),
+            device=self.tracking_device.currentText(),
+            mode=self.tracking_mode.currentText(),
+            max_dense_pairs=self.tracking_max_dense_pairs.value(),
+            max_dense_roi_voxels_cpu=self.tracking_max_dense_roi_voxels_cpu.value(),
+            max_dense_roi_voxels_gpu=self.tracking_max_dense_roi_voxels_gpu.value(),
+            low_memory=self.tracking_low_memory.isChecked(),
+        )
+        num_t = self._optional_spinbox_value(
+            self.tracking_num_t_override, self.tracking_num_t
+        )
+        return config, num_t
 
     def get_reassign_params(self) -> dict:
         params = {


### PR DESCRIPTION
## Summary

Switches all 7 `get_*_params` methods in `nellie_napari/nellie_settings.py` from returning untyped `dict`s to returning typed Config objects. The processor's `_run_*` methods drop the `dict(step_kwargs)` + `pop("num_t")` + `Config(**...)` triplet and take the Config directly.

| Settings method | Before | After |
|---|---|---|
| `get_preprocessing_params` | `dict` | `tuple[FrangiConfig, int \| None]` |
| `get_segmentation_label_params` | `dict` | `tuple[LabelConfig, int \| None]` |
| `get_segmentation_network_params` | `dict` | `tuple[NetworkConfig, int \| None]` |
| `get_mocap_params` | `dict` | `tuple[MarkersConfig, int \| None]` |
| `get_tracking_params` | `dict` | `tuple[HuMomentTrackingConfig, int \| None]` |
| `get_reassign_params` | `dict` | `tuple[VoxelReassignerConfig, int \| None]` |
| `get_feature_params` | `dict` | `HierarchyConfig` (no num_t — asymmetric per PRD #112 resolved decision #3) |

Two cross-cutting checkboxes fold into their respective getter:
- `remove_edges` → baked into the `FrangiConfig` returned by `get_preprocessing_params()` (was: injected by the processor)
- `skip_nodes` decision (override + `analyze_node_level` default) → baked into the `HierarchyConfig` returned by `get_feature_params()` (was: override math in the processor)

`remove_intermediates_checked` stays on the processor (it's a post-Hierarchy cleanup arg, not a Config field).

`_prune_none` deleted — vestigial now that Configs accept `None` for genuinely-optional fields (per PR #136, optional fields are only gated when non-None).

## Test plan

- [x] All 389 existing tests stay green (this PR only touches `nellie_napari/`; algorithmic stage code unchanged).
- [x] `nellie_napari` modules import cleanly via `uv run python`.
- [x] Pyright: no new errors at the settings/processor seam (the existing baseline noise on `nellie_napari/nellie_processor.py` is unchanged — pre-existing issues at lines 99, 189, 247, etc.).
- Manual smoke test (recommended but not required): launch napari, run the full pipeline on a test image.

6 commits, one per stage (segmentation pairs label+network), for clean bisection.

Closes #137. Closes Follow-up B from PRD #112 — both PRD #112 follow-ups are now landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)