### PR TITLE
MPS slice 1: shims + adaptive_run dispatch + install plumbing

### DIFF
--- a/nellie/__init__.py
+++ b/nellie/__init__.py
@@ -1,55 +1,34 @@
-# from nellie.utils.base_logger import logger
+# Static module-level dispatch — keeps the legacy ``nellie.xp`` / ``nellie.ndi``
+# attributes that early callers still import. This is *not* the canonical
+# device-resolution surface — see :mod:`nellie.utils.adaptive_run` and
+# wiki/decisions/0002-adaptive-run-extension-over-static-torch-xp.md
+# for why per-stage dispatch is the path forward.
+#
+# macOS stays pinned to numpy here. MPS is selected per-stage via
+# ``adaptive_run.resolve_backend("mps")`` when the user opts in via
+# ``device="auto"`` / ``"gpu"`` / ``"mps"``.
 import platform
 
-device_type = 'cpu'
-# if it's a mac
-if platform.system() == 'Darwin':
-    # if it has pytorch
-    # try:
-    #     import torch
-    #     # For Mac GPUs with MPS support
-    #     if torch.backends.mps.is_available():
-    #         import nellie.utils.torch_xp as xp
-    #         device_type = 'mps'
-    #         logger.warning('GPU packages detected, running via GPU.')
-    #     else:
-    #         import numpy as xp
-    #         device_type = 'cpu'
-    #         logger.warning('GPU packages not detected, running via CPU.')
-    # except ModuleNotFoundError:
-    import numpy as xp
-    device_type = 'cpu'
-    # logger.warning('GPU packages not detected, running via CPU.')
 
-    xp_bk = None
+device_type = "cpu"
+xp_bk = None
+is_gpu = False
+
+if platform.system() == "Darwin":
+    import numpy as xp
     import scipy.ndimage as ndi
     from skimage import filters, morphology, measure
-
-    is_gpu = False
-
-
-# if it's an NVIDIA GPU
 else:
     try:
         import cupy as xp
         import cupy_backends as xp_bk
         import cupyx.scipy.ndimage as ndi
+
         is_gpu = True
-        # logger.info('GPU packages detected, running via GPU.')
-        device_type = 'cuda'
+        device_type = "cuda"
     except ModuleNotFoundError:
         import numpy as xp
-
-        xp_bk = None
         import scipy.ndimage as ndi
         from skimage import filters, morphology, measure
 
-        is_gpu = False
-        # logger.warning('GPU packages not detected, running via CPU.')
-        device_type = 'cpu'
-
-# from .segmentation import Filter, Label, Markers, Network
-# from .tracking import HuMomentTracking, VoxelReassigner, LabelTracks, FlowInterpolator
-# from .feature_extraction import Hierarchy
-# from .im_info import FileInfo, ImInfo
-# from .run import run
+        xp_bk = None

--- a/nellie/feature_extraction/hierarchical.py
+++ b/nellie/feature_extraction/hierarchical.py
@@ -549,16 +549,14 @@ class Hierarchy:
         Main execution method.
         """
         device = adaptive_run.normalize_device(self.device)
-        gpu_ok = adaptive_run.gpu_available()
-        if device == "gpu" and not gpu_ok:
+        device_order = adaptive_run.device_cascade(self.device)
+        if device == "gpu" and device_order == ["cpu"]:
             logger.warning("Hierarchy: GPU requested but not available; falling back to CPU.")
-        if device == "cpu" or not gpu_ok:
-            device_order = ["cpu"]
-        else:
-            device_order = ["gpu", "cpu"]
 
         start_low_memory = bool(self.low_memory) or adaptive_run.should_use_low_memory(
-            self.im_info, include_gpu="gpu" in device_order
+            self.im_info,
+            include_gpu="gpu" in device_order,
+            device_order=device_order,
         )
         if start_low_memory and not self.low_memory:
             logger.info("Hierarchy: enabling low-memory mode based on estimated usage.")
@@ -572,7 +570,7 @@ class Hierarchy:
                 return
             except Exception as exc:
                 last_exc = exc
-                if adaptive_run.is_gpu_unavailable_error(exc) and dev == "gpu":
+                if adaptive_run.is_gpu_unavailable_error(exc) and dev in ("gpu", "mps"):
                     logger.warning("Hierarchy: GPU backend unavailable; retrying on CPU.")
                     continue
                 if adaptive_run.is_oom_error(exc):

--- a/nellie/segmentation/filtering.py
+++ b/nellie/segmentation/filtering.py
@@ -118,7 +118,7 @@ class Filter:
         self.low_memory = config.low_memory
 
         self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(self.device)
-        self.force_device = self.device.lower() in ("cpu", "gpu", "cuda")
+        self.force_device = self.device.lower() in ("cpu", "gpu", "cuda", "mps")
         self.truncate = 3.0
         if not self.im_info.no_z:
             z_res = self.im_info.dim_res.get("Z") or self.im_info.dim_res.get("X") or 1.0
@@ -162,7 +162,7 @@ class Filter:
         device = adaptive_run.normalize_device(device)
         self.device = device
         self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(device)
-        self.force_device = device in ("cpu", "gpu", "cuda")
+        self.force_device = device in ("cpu", "gpu", "cuda", "mps")
 
     def _set_low_memory(self, low_memory):
         self.low_memory = bool(low_memory)
@@ -609,7 +609,7 @@ class Filter:
             except Exception as exc2:
                 if not adaptive_run.is_oom_error(exc2):
                     raise
-                if self.device_type == "cuda" and not self.force_device:
+                if self.device_type in ("cuda", "mps") and not self.force_device:
                     self._switch_to_cpu()
                     return self._run_frame_chunked(t, mask=mask)
                 raise
@@ -704,16 +704,14 @@ class Filter:
         """
         logger.info("Running Frangi filter.")
         device = adaptive_run.normalize_device(self.device)
-        gpu_ok = adaptive_run.gpu_available()
-        if device == "gpu" and not gpu_ok:
+        device_order = adaptive_run.device_cascade(self.device)
+        if device == "gpu" and device_order == ["cpu"]:
             logger.warning("Filter: GPU requested but not available; falling back to CPU.")
-        if device == "cpu" or not gpu_ok:
-            device_order = ["cpu"]
-        else:
-            device_order = ["gpu", "cpu"]
 
         start_low_memory = bool(self.low_memory) or adaptive_run.should_use_low_memory(
-            self.im_info, include_gpu="gpu" in device_order
+            self.im_info,
+            include_gpu="gpu" in device_order,
+            device_order=device_order,
         )
         if start_low_memory and not self.low_memory:
             logger.info("Filter: enabling low-memory mode based on estimated usage.")
@@ -730,7 +728,7 @@ class Filter:
                 return
             except Exception as exc:
                 last_exc = exc
-                if adaptive_run.is_gpu_unavailable_error(exc) and dev == "gpu":
+                if adaptive_run.is_gpu_unavailable_error(exc) and dev in ("gpu", "mps"):
                     logger.warning("Filter: GPU backend unavailable; retrying on CPU.")
                     continue
                 if adaptive_run.is_oom_error(exc):

--- a/nellie/segmentation/labelling.py
+++ b/nellie/segmentation/labelling.py
@@ -650,16 +650,14 @@ class Label:
         """
         logger.info('Running semantic segmentation.')
         device = adaptive_run.normalize_device(self.device)
-        gpu_ok = adaptive_run.gpu_available()
-        if device == "gpu" and not gpu_ok:
+        device_order = adaptive_run.device_cascade(self.device)
+        if device == "gpu" and device_order == ["cpu"]:
             logger.warning("Label: GPU requested but not available; falling back to CPU.")
-        if device == "cpu" or not gpu_ok:
-            device_order = ["cpu"]
-        else:
-            device_order = ["gpu", "cpu"]
 
         start_low_memory = bool(self.low_memory) or adaptive_run.should_use_low_memory(
-            self.im_info, include_gpu="gpu" in device_order
+            self.im_info,
+            include_gpu="gpu" in device_order,
+            device_order=device_order,
         )
         if start_low_memory and not self.low_memory:
             logger.info("Label: enabling low-memory mode based on estimated usage.")
@@ -674,7 +672,7 @@ class Label:
                 return
             except Exception as exc:
                 last_exc = exc
-                if adaptive_run.is_gpu_unavailable_error(exc) and dev == "gpu":
+                if adaptive_run.is_gpu_unavailable_error(exc) and dev in ("gpu", "mps"):
                     logger.warning("Label: GPU backend unavailable; retrying on CPU.")
                     continue
                 if adaptive_run.is_oom_error(exc):

--- a/nellie/segmentation/mocap_marking.py
+++ b/nellie/segmentation/mocap_marking.py
@@ -673,16 +673,14 @@ class Markers:
         """
         # Note: We must run mocap marking even if there is no time dimension, since we need the distance and border images for feature extraction
         device = adaptive_run.normalize_device(self.device)
-        gpu_ok = adaptive_run.gpu_available()
-        if device == "gpu" and not gpu_ok:
+        device_order = adaptive_run.device_cascade(self.device)
+        if device == "gpu" and device_order == ["cpu"]:
             logger.warning("Markers: GPU requested but not available; falling back to CPU.")
-        if device == "cpu" or not gpu_ok:
-            device_order = ["cpu"]
-        else:
-            device_order = ["gpu", "cpu"]
 
         start_low_memory = bool(self.low_memory) or adaptive_run.should_use_low_memory(
-            self.im_info, include_gpu="gpu" in device_order
+            self.im_info,
+            include_gpu="gpu" in device_order,
+            device_order=device_order,
         )
         if start_low_memory and not self.low_memory:
             logger.info("Markers: enabling low-memory mode based on estimated usage.")
@@ -698,7 +696,7 @@ class Markers:
                 return
             except Exception as exc:
                 last_exc = exc
-                if adaptive_run.is_gpu_unavailable_error(exc) and dev == "gpu":
+                if adaptive_run.is_gpu_unavailable_error(exc) and dev in ("gpu", "mps"):
                     logger.warning("Markers: GPU backend unavailable; retrying on CPU.")
                     continue
                 if adaptive_run.is_oom_error(exc):

--- a/nellie/segmentation/networking.py
+++ b/nellie/segmentation/networking.py
@@ -89,7 +89,7 @@ class Network:
         self.low_memory = bool(config.low_memory)
 
         self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(self.device)
-        self.force_device = config.device.lower() in ("cpu", "gpu", "cuda")
+        self.force_device = config.device.lower() in ("cpu", "gpu", "cuda", "mps")
         self.max_chunk_voxels = int(config.max_chunk_voxels)
         self.num_t = num_t
         if num_t is None and not self.im_info.no_t:
@@ -126,7 +126,7 @@ class Network:
         device = adaptive_run.normalize_device(device)
         self.device = device
         self.xp, self.ndi, self.device_type = adaptive_run.resolve_backend(device)
-        self.force_device = device in ("cpu", "gpu")
+        self.force_device = device in ("cpu", "gpu", "mps")
 
     def _set_low_memory(self, low_memory):
         self.low_memory = bool(low_memory)
@@ -731,16 +731,14 @@ class Network:
         Execute the full network analysis pipeline.
         """
         device = adaptive_run.normalize_device(self.device)
-        gpu_ok = adaptive_run.gpu_available()
-        if device == "gpu" and not gpu_ok:
+        device_order = adaptive_run.device_cascade(self.device)
+        if device == "gpu" and device_order == ["cpu"]:
             logger.warning("Network: GPU requested but not available; falling back to CPU.")
-        if device == "cpu" or not gpu_ok:
-            device_order = ["cpu"]
-        else:
-            device_order = ["gpu", "cpu"]
 
         start_low_memory = bool(self.low_memory) or adaptive_run.should_use_low_memory(
-            self.im_info, include_gpu="gpu" in device_order
+            self.im_info,
+            include_gpu="gpu" in device_order,
+            device_order=device_order,
         )
         if start_low_memory and not self.low_memory:
             logger.info("Network: enabling low-memory mode based on estimated usage.")
@@ -755,7 +753,7 @@ class Network:
                 return
             except Exception as exc:
                 last_exc = exc
-                if adaptive_run.is_gpu_unavailable_error(exc) and dev == "gpu":
+                if adaptive_run.is_gpu_unavailable_error(exc) and dev in ("gpu", "mps"):
                     logger.warning("Network: GPU backend unavailable; retrying on CPU.")
                     continue
                 if adaptive_run.is_oom_error(exc):

--- a/nellie/tracking/hu_tracking.py
+++ b/nellie/tracking/hu_tracking.py
@@ -1198,16 +1198,14 @@ class HuMomentTracking:
             return
 
         device = adaptive_run.normalize_device(self.device)
-        gpu_ok = adaptive_run.gpu_available()
-        if device == "gpu" and not gpu_ok:
+        device_order = adaptive_run.device_cascade(self.device)
+        if device == "gpu" and device_order == ["cpu"]:
             logger.warning("HuMomentTracking: GPU requested but not available; falling back to CPU.")
-        if device == "cpu" or not gpu_ok:
-            device_order = ["cpu"]
-        else:
-            device_order = ["gpu", "cpu"]
 
         start_low_memory = bool(self.low_memory) or adaptive_run.should_use_low_memory(
-            self.im_info, include_gpu="gpu" in device_order
+            self.im_info,
+            include_gpu="gpu" in device_order,
+            device_order=device_order,
         )
         if start_low_memory and not self.low_memory:
             logger.info("HuMomentTracking: enabling low-memory mode based on estimated usage.")
@@ -1222,7 +1220,7 @@ class HuMomentTracking:
                 return
             except Exception as exc:
                 last_exc = exc
-                if adaptive_run.is_gpu_unavailable_error(exc) and dev == "gpu":
+                if adaptive_run.is_gpu_unavailable_error(exc) and dev in ("gpu", "mps"):
                     logger.warning("HuMomentTracking: GPU backend unavailable; retrying on CPU.")
                     continue
                 if adaptive_run.is_oom_error(exc):

--- a/nellie/tracking/voxel_reassignment.py
+++ b/nellie/tracking/voxel_reassignment.py
@@ -1051,16 +1051,14 @@ class VoxelReassigner:
             logger.info("Skipping voxel reassignment for non-temporal dataset.")
             return
         device = adaptive_run.normalize_device(self.device)
-        gpu_ok = adaptive_run.gpu_available()
-        if device == "gpu" and not gpu_ok:
+        device_order = adaptive_run.device_cascade(self.device)
+        if device == "gpu" and device_order == ["cpu"]:
             logger.warning("VoxelReassigner: GPU requested but not available; falling back to CPU.")
-        if device == "cpu" or not gpu_ok:
-            device_order = ["cpu"]
-        else:
-            device_order = ["gpu", "cpu"]
 
         start_low_memory = bool(self.low_memory) or adaptive_run.should_use_low_memory(
-            self.im_info, include_gpu="gpu" in device_order
+            self.im_info,
+            include_gpu="gpu" in device_order,
+            device_order=device_order,
         )
         if start_low_memory and not self.low_memory:
             logger.info("VoxelReassigner: enabling low-memory mode based on estimated usage.")
@@ -1074,7 +1072,7 @@ class VoxelReassigner:
                 return
             except Exception as exc:
                 last_exc = exc
-                if adaptive_run.is_gpu_unavailable_error(exc) and dev == "gpu":
+                if adaptive_run.is_gpu_unavailable_error(exc) and dev in ("gpu", "mps"):
                     logger.warning("VoxelReassigner: GPU backend unavailable; retrying on CPU.")
                     continue
                 if adaptive_run.is_oom_error(exc):

--- a/nellie/utils/adaptive_run.py
+++ b/nellie/utils/adaptive_run.py
@@ -5,11 +5,27 @@ from __future__ import annotations
 
 import math
 import os
+import platform
 from typing import Any
 
 
 _ESTIMATED_PEAK_MULTIPLIER = 6.0
-_MEMORY_HEADROOM = 0.7
+# Per-device headroom: CUDA gets 0.7 of discrete VRAM; MPS gets 0.5 of
+# system-shared RAM (must leave room for the OS, IDE, browser). CPU
+# follows the CUDA value historically; this is the public contract for
+# the free-memory cascade.
+_MEMORY_HEADROOM_BY_DEVICE = {
+    "cuda": 0.7,
+    "mps": 0.5,
+    "cpu": 0.7,
+}
+# Backwards-compatible alias for callers (and tests) that read the legacy
+# scalar. Resolves to the CUDA/CPU value, which matches prior behavior.
+_MEMORY_HEADROOM = _MEMORY_HEADROOM_BY_DEVICE["cuda"]
+
+
+def _headroom(device_type: str) -> float:
+    return _MEMORY_HEADROOM_BY_DEVICE.get(device_type, _MEMORY_HEADROOM)
 
 
 def try_import_cupy(require: bool = False) -> tuple[Any | None, Any | None]:
@@ -41,6 +57,43 @@ def try_import_cupy(require: bool = False) -> tuple[Any | None, Any | None]:
     return cupy, cupy_ndi
 
 
+def try_import_torch_mps(require: bool = False) -> tuple[Any | None, Any | None]:
+    """Return ``(torch_xp, torch_ndi)`` or ``(None, None)`` if MPS is unavailable.
+
+    With ``require=True``, raises ``RuntimeError`` instead of returning
+    None when torch is missing or MPS is not available on this platform
+    or torch wheel.
+    """
+    try:
+        import torch
+    except ModuleNotFoundError as exc:
+        if require:
+            raise RuntimeError(
+                "MPS backend requested but torch is not installed. "
+                "Install with `pip install 'nellie[mps]'`."
+            ) from exc
+        return None, None
+
+    # Probe MPS availability — torch may be built without MPS support
+    # (e.g. CPU-only wheel) or the device may be unavailable on this OS.
+    backends = getattr(torch, "backends", None)
+    mps = getattr(backends, "mps", None) if backends is not None else None
+    is_built = bool(getattr(mps, "is_built", lambda: False)()) if mps is not None else False
+    is_available = bool(getattr(mps, "is_available", lambda: False)()) if mps is not None else False
+    if not is_available or not is_built:
+        if require:
+            raise RuntimeError(
+                "MPS backend requested but no MPS device is available "
+                "(torch.backends.mps.is_available() is False)."
+            )
+        return None, None
+
+    # Lazy import — avoids loading torch at module import time on CUDA/CPU boxes.
+    from nellie.utils import torch_ndi, torch_xp
+
+    return torch_xp, torch_ndi
+
+
 def _cpu_backend() -> tuple[Any, Any, str]:
     import numpy as np
     import scipy.ndimage as ndi
@@ -48,57 +101,111 @@ def _cpu_backend() -> tuple[Any, Any, str]:
     return np, ndi, "cpu"
 
 
+def _is_darwin() -> bool:
+    return platform.system() == "Darwin"
+
+
 def resolve_backend(device: str) -> tuple[Any, Any, str]:
     """Resolve a device string to ``(xp, ndi, device_type)``.
 
-    Accepts ``"auto"``, ``"cpu"``, ``"gpu"``, ``"cuda"``. ``"cuda"`` is a
-    synonym for ``"gpu"``. ``"auto"`` uses GPU if available, otherwise CPU.
+    Accepts ``"auto"``, ``"cpu"``, ``"gpu"``, ``"cuda"``, ``"mps"``.
 
-    The returned ``device_type`` is ``"cuda"`` for GPU and ``"cpu"`` for CPU,
-    matching the per-stage convention.
+    - ``"cuda"`` forces CuPy (a no-fallback explicit pin).
+    - ``"mps"`` forces torch+MPS (a no-fallback explicit pin).
+    - ``"gpu"`` is **platform-aware**: MPS on Darwin, CUDA elsewhere
+      (per [[wiki/decisions/0003-device-gpu-platform-aware]]).
+    - ``"auto"`` tries the platform's preferred GPU first, then CPU.
+
+    The returned ``device_type`` is the canonical backend identifier
+    (``"cuda"``, ``"mps"``, or ``"cpu"``) used by per-stage code.
     """
     device = (device or "auto").lower()
-    if device not in ("auto", "cpu", "gpu", "cuda"):
-        raise ValueError(f"Unsupported device '{device}'. Use 'auto', 'cpu', or 'gpu'.")
+    if device not in ("auto", "cpu", "gpu", "cuda", "mps"):
+        raise ValueError(
+            f"Unsupported device '{device}'. Use 'auto', 'cpu', 'gpu', 'cuda', or 'mps'."
+        )
 
-    if device in ("gpu", "cuda"):
-        xp, ndi = try_import_cupy(require=True)
-        return xp, ndi, "cuda"
     if device == "cpu":
         return _cpu_backend()
 
-    # auto
-    xp, ndi = try_import_cupy(require=False)
-    if xp is not None:
+    if device == "cuda":
+        xp, ndi = try_import_cupy(require=True)
         return xp, ndi, "cuda"
+
+    if device == "mps":
+        xp, ndi = try_import_torch_mps(require=True)
+        return xp, ndi, "mps"
+
+    if device == "gpu":
+        # Platform-aware: MPS on Darwin, CUDA elsewhere.
+        if _is_darwin():
+            xp, ndi = try_import_torch_mps(require=True)
+            return xp, ndi, "mps"
+        xp, ndi = try_import_cupy(require=True)
+        return xp, ndi, "cuda"
+
+    # auto — try platform's preferred GPU, fall back to CPU.
+    if _is_darwin():
+        xp, ndi = try_import_torch_mps(require=False)
+        if xp is not None:
+            return xp, ndi, "mps"
+    else:
+        xp, ndi = try_import_cupy(require=False)
+        if xp is not None:
+            return xp, ndi, "cuda"
     return _cpu_backend()
 
 
 def free_gpu_memory(xp: Any) -> None:
-    """Free CuPy's default memory pool. No-op when ``xp`` is NumPy.
+    """Free the active backend's memory pool. No-op on NumPy.
 
-    Detects the backend via duck-typing (``get_default_memory_pool``)
-    rather than importing cupy unconditionally.
+    Detects the backend via duck-typing rather than importing cupy or
+    torch unconditionally. CuPy: ``get_default_memory_pool().free_all_blocks()``.
+    Torch+MPS: ``torch.mps.empty_cache()``.
     """
     pool_fn = getattr(xp, "get_default_memory_pool", None)
-    if pool_fn is None:
+    if pool_fn is not None:
+        try:
+            pool_fn().free_all_blocks()
+        except Exception:
+            pass
         return
-    try:
-        pool_fn().free_all_blocks()
-    except Exception:
-        return
+    # Torch path: detect by module-name suffix (the torch_xp shim is a
+    # module, not a class — use its name to disambiguate from numpy).
+    mod_name = getattr(xp, "__name__", "")
+    if "torch_xp" in mod_name:
+        try:
+            import torch
+            empty = getattr(getattr(torch, "mps", None), "empty_cache", None)
+            if empty is not None:
+                empty()
+        except Exception:
+            pass
 
 
 def normalize_device(device: str | None) -> str:
+    """Normalize a user-supplied device string to a canonical form.
+
+    Returns one of ``"auto"``, ``"cpu"``, ``"gpu"``, ``"mps"``. ``"cuda"``
+    is normalized to ``"gpu"`` (it stays user-explicit at the outer API
+    surface but we don't carry the alias inside the cascade). Unknown
+    values raise ``ValueError``.
+    """
     device = (device or "auto").lower()
     if device == "cuda":
         device = "gpu"
-    if device not in ("auto", "cpu", "gpu"):
-        raise ValueError(f"Unsupported device '{device}'. Use 'auto', 'cpu', or 'gpu'.")
+    if device not in ("auto", "cpu", "gpu", "mps"):
+        raise ValueError(
+            f"Unsupported device '{device}'. Use 'auto', 'cpu', 'gpu', or 'mps'."
+        )
     return device
 
 
 def gpu_available() -> bool:
+    """Legacy CUDA-availability probe. Use :func:`device_cascade` for new code.
+
+    Retained for stages that haven't migrated to ``device_cascade`` yet.
+    """
     try:
         import cupy
     except ModuleNotFoundError:
@@ -107,6 +214,74 @@ def gpu_available() -> bool:
         return cupy.cuda.runtime.getDeviceCount() > 0
     except Exception:
         return False
+
+
+def mps_available() -> bool:
+    """Probe whether torch+MPS is available on this machine.
+
+    Returns False when torch is missing, MPS is not built into the wheel,
+    or no MPS device is exposed.
+    """
+    try:
+        import torch
+    except ModuleNotFoundError:
+        return False
+    backends = getattr(torch, "backends", None)
+    mps = getattr(backends, "mps", None) if backends is not None else None
+    if mps is None:
+        return False
+    try:
+        return bool(mps.is_built()) and bool(mps.is_available())
+    except Exception:
+        return False
+
+
+def device_cascade(device: str | None) -> list[str]:
+    """Return the device retry order for the OOM/availability cascade.
+
+    The single source of truth for "what backends should this stage try,
+    in what order?" — per :doc:`/wiki/decisions/0002-adaptive-run-extension-over-static-torch-xp`.
+    Adding a new backend in the future is a one-line change here, not a
+    refactor across every cascade-using stage.
+
+    Semantics:
+
+    - ``"auto"``: platform's preferred GPU first (if available), then CPU.
+      Mac with torch+MPS → ``["mps", "cpu"]``; Linux/Windows with cupy →
+      ``["gpu", "cpu"]``; no GPU → ``["cpu"]``.
+    - ``"gpu"``: same as ``"auto"`` (platform-aware).
+    - ``"mps"``: pinned to ``["mps"]`` (no fallback — explicit user pin).
+    - ``"cuda"``: pinned to ``["gpu"]`` (no fallback — explicit user pin
+      for cupy).
+    - ``"cpu"``: ``["cpu"]``.
+
+    The cascade list uses the *outer* device names (``"gpu"`` rather
+    than ``"cuda"``) for compatibility with the existing per-stage
+    ``_set_backend`` implementations. ``"mps"`` is its own outer name
+    because no other backend resolves to it.
+    """
+    raw = (device or "auto").lower()
+    if raw == "cpu":
+        return ["cpu"]
+    if raw == "mps":
+        return ["mps"]
+    if raw == "cuda":
+        # Explicit pin — the user wants CuPy on CUDA, no fallback.
+        return ["gpu"]
+    if raw not in ("auto", "gpu"):
+        raise ValueError(
+            f"device_cascade: unsupported device '{device}'. "
+            f"Use 'auto', 'cpu', 'gpu', 'cuda', or 'mps'."
+        )
+
+    # 'auto' / 'gpu' — platform-aware best-effort with CPU fallback.
+    if _is_darwin():
+        if mps_available():
+            return ["mps", "cpu"]
+        return ["cpu"]
+    if gpu_available():
+        return ["gpu", "cpu"]
+    return ["cpu"]
 
 
 def get_gpu_free_bytes() -> int | None:
@@ -119,6 +294,47 @@ def get_gpu_free_bytes() -> int | None:
         return int(free_bytes)
     except Exception:
         return None
+
+
+def get_mps_free_bytes() -> int | None:
+    """Return free MPS memory in bytes, or None if torch is unavailable.
+
+    Apple Silicon's MPS shares system RAM with the OS and other apps.
+    We approximate "free MPS bytes" as ``cpu_available - torch.mps.driver_allocated_memory()``,
+    capped by the ``PYTORCH_MPS_HIGH_WATERMARK_RATIO`` env var if set.
+    Returns None if torch is missing (so callers can short-circuit).
+    """
+    try:
+        import torch
+    except ModuleNotFoundError:
+        return None
+
+    cpu_free = get_cpu_available_bytes()
+    if cpu_free is None:
+        return None
+
+    # Subtract torch's already-allocated MPS memory (if torch+MPS is built).
+    allocated = 0
+    mps = getattr(torch, "mps", None)
+    if mps is not None:
+        try:
+            allocated = int(mps.driver_allocated_memory())
+        except Exception:
+            allocated = 0
+
+    free = max(0, cpu_free - allocated)
+
+    # Honor PYTORCH_MPS_HIGH_WATERMARK_RATIO when set (a fraction in [0, 1]).
+    watermark_env = os.environ.get("PYTORCH_MPS_HIGH_WATERMARK_RATIO")
+    if watermark_env:
+        try:
+            watermark = float(watermark_env)
+            if 0.0 < watermark <= 1.0:
+                free = min(free, int(cpu_free * watermark))
+        except ValueError:
+            pass
+
+    return free
 
 
 def _sysconf(name: str) -> int | None:
@@ -163,17 +379,35 @@ def estimate_frame_bytes(im_info) -> int | None:
     return int(math.prod(frame_shape) * itemsize)
 
 
-def should_use_low_memory(im_info, include_gpu: bool) -> bool:
+def should_use_low_memory(im_info, include_gpu: bool, *, device_order=None) -> bool:
+    """Heuristic: should this stage start in low-memory mode?
+
+    Compares the estimated peak (``frame_bytes * _ESTIMATED_PEAK_MULTIPLIER``)
+    against the active device's free memory budget, scaled by the
+    device-specific headroom in ``_MEMORY_HEADROOM_BY_DEVICE``.
+
+    ``include_gpu`` is the legacy boolean toggle — when True we consult
+    the CUDA budget. When ``device_order`` is provided we additionally
+    consult the MPS budget if MPS is in the cascade. Both probes are
+    independent OR-conditions (any one being tight triggers low-memory).
+    """
     frame_bytes = estimate_frame_bytes(im_info)
     if frame_bytes is None:
         return False
     peak_bytes = frame_bytes * _ESTIMATED_PEAK_MULTIPLIER
+
     if include_gpu:
         gpu_free = get_gpu_free_bytes()
-        if gpu_free is not None and peak_bytes > gpu_free * _MEMORY_HEADROOM:
+        if gpu_free is not None and peak_bytes > gpu_free * _headroom("cuda"):
             return True
+
+    if device_order and "mps" in device_order:
+        mps_free = get_mps_free_bytes()
+        if mps_free is not None and peak_bytes > mps_free * _headroom("mps"):
+            return True
+
     cpu_free = get_cpu_available_bytes()
-    if cpu_free is not None and peak_bytes > cpu_free * _MEMORY_HEADROOM:
+    if cpu_free is not None and peak_bytes > cpu_free * _headroom("cpu"):
         return True
     return False
 
@@ -202,18 +436,40 @@ def is_oom_error(exc: Exception) -> bool:
     except Exception:
         pass
     msg = repr(exc).lower()
-    return "out of memory" in msg or "outofmemory" in msg
+    # CuPy historically; "mps backend out of memory" is the torch wording.
+    return (
+        "out of memory" in msg
+        or "outofmemory" in msg
+        or "mps backend out of memory" in msg
+    )
 
 
 def is_gpu_unavailable_error(exc: Exception) -> bool:
     if isinstance(exc, (ModuleNotFoundError, ImportError)):
         name = getattr(exc, "name", "") or ""
-        if "cupy" in name:
+        if "cupy" in name or "torch" in name:
+            return True
+    # NotImplementedError from the torch_xp/torch_ndi shim signals "this
+    # stage isn't MPS-onboarded yet" — treat it as backend-unavailable so
+    # the cascade falls back to CPU rather than crashing the user's run.
+    # This is what makes ``device="auto"`` safe to pass to non-onboarded
+    # stages on a Mac with torch+MPS installed.
+    if isinstance(exc, NotImplementedError):
+        msg = str(exc).lower()
+        if "torch_xp" in msg or "torch_ndi" in msg:
             return True
     msg = repr(exc).lower()
     return (
+        # CuPy / generic
         "gpu backend requested" in msg
         or "cupy is not installed" in msg
         or "cuda is not available" in msg
         or "no cuda devices" in msg
+        # Torch + MPS
+        or "mps backend requested" in msg
+        or "torch is not installed" in msg
+        or "no mps device" in msg
+        or "mps is not available" in msg
+        or "is_available() is false" in msg
+        or "mps not built" in msg
     )

--- a/nellie/utils/torch_ndi.py
+++ b/nellie/utils/torch_ndi.py
@@ -70,22 +70,66 @@ def _functional() -> Any:
 # Padding mode translation: scipy.ndimage <-> torch.nn.functional.pad
 # -----------------------------------------------------------------------------
 
+# scipy "reflect" is HALF-sample symmetric (boundary value duplicated:
+# `d c b a | a b c d | d c b a`). torch's `pad(mode='reflect')` is FULL-sample
+# symmetric (boundary value appears once: `d c b | a b c d | c b`) — that
+# matches scipy "mirror", NOT scipy "reflect". So we route "reflect" through a
+# custom helper (`_scipy_reflect_pad_along_axis`) and only delegate the other
+# modes to torch's pad.
 _SCIPY_TO_TORCH_PAD = {
     "constant": "constant",
-    "reflect": "reflect",
-    "mirror": "reflect",  # scipy "mirror" matches torch "reflect"
+    "mirror": "reflect",      # scipy "mirror" == torch "reflect"
     "nearest": "replicate",
     "wrap": "circular",
+    # "reflect" intentionally absent — handled by _scipy_reflect_pad_along_axis
 }
+
+_SUPPORTED_MODES = sorted(set(_SCIPY_TO_TORCH_PAD) | {"reflect"})
 
 
 def _pad_mode(mode: str) -> str:
+    if mode == "reflect":
+        # Caller must use _scipy_reflect_pad_* helpers, not torch's F.pad.
+        raise AssertionError(
+            "internal: scipy 'reflect' must use _scipy_reflect_pad_along_axis"
+        )
     if mode not in _SCIPY_TO_TORCH_PAD:
         raise ValueError(
             f"torch_ndi: unsupported boundary mode '{mode}'. "
-            f"Supported: {sorted(_SCIPY_TO_TORCH_PAD)}"
+            f"Supported: {_SUPPORTED_MODES}"
         )
     return _SCIPY_TO_TORCH_PAD[mode]
+
+
+def _scipy_reflect_pad_along_axis(x, axis: int, before: int, after: int):
+    """Apply scipy.ndimage's "reflect" padding along a single axis.
+
+    scipy reflects about the EDGE such that boundary values appear twice
+    (half-sample symmetric). torch's ``F.pad(mode='reflect')`` reflects
+    *between* values (full-sample symmetric — matches scipy "mirror"), so
+    it's not an option here. We synthesize the right behavior with
+    :func:`torch.index_select`.
+
+    For input ``[a, b, c, d]`` with ``before=2, after=2`` the result is
+    ``[b, a, a, b, c, d, d, c]``.
+    """
+    if before == 0 and after == 0:
+        return x
+    torch = _torch()
+    n = x.shape[axis]
+    # Left pad reads positions before-1, before-2, ..., 0 (inclusive).
+    left_idx = list(range(before - 1, -1, -1)) if before > 0 else []
+    middle_idx = list(range(n))
+    # Right pad reads positions n-1, n-2, ..., n-after (inclusive).
+    right_idx = [n - 1 - k for k in range(after)] if after > 0 else []
+    indices = left_idx + middle_idx + right_idx
+    idx_t = torch.tensor(indices, dtype=torch.long, device=x.device)
+    return torch.index_select(x, dim=axis, index=idx_t)
+
+
+def _scipy_reflect_pad_last_dim(x, before: int, after: int):
+    """Convenience: scipy "reflect" pad along the last axis (1-D conv path)."""
+    return _scipy_reflect_pad_along_axis(x, axis=-1, before=before, after=after)
 
 
 def _add_batch_channel(x):
@@ -106,6 +150,19 @@ def _pad_for_kernel(x, kernel_shape: Sequence[int], mode: str, cval: float):
     """
     torch = _torch()
     F = _functional()
+
+    if mode == "reflect":
+        # scipy reflect — apply the per-axis helper. Spatial axes start at 2
+        # (after batch and channel) for the 4-D / 5-D conv tensors.
+        out = x
+        for spatial_axis, ks in enumerate(kernel_shape):
+            before = ks // 2
+            after = ks - 1 - before
+            out = _scipy_reflect_pad_along_axis(
+                out, axis=spatial_axis + 2, before=before, after=after
+            )
+        return out
+
     pad_mode = _pad_mode(mode)
     # F.pad takes the spatial pads in REVERSED axis order, two values per axis.
     pad: list[int] = []
@@ -171,6 +228,25 @@ def _gaussian_kernel_1d(sigma: float, truncate: float = 4.0):
     return kernel
 
 
+def _gaussian_kernel_1d_order2(sigma: float, truncate: float = 4.0):
+    """Second-derivative-of-Gaussian 1-D kernel — matches scipy's ``order=2``.
+
+    Derivation: the normalized Gaussian phi(x) = exp(-x²/(2σ²)) / sum.
+    For order=2, scipy's kernel is q(x) * phi(x) where q(x) = x²/σ⁴ - 1/σ².
+    """
+    torch = _torch()
+    if sigma <= 0:
+        return torch.zeros(1, dtype=torch.float32)
+    radius = int(truncate * sigma + 0.5)
+    if radius < 1:
+        radius = 1
+    x = torch.arange(-radius, radius + 1, dtype=torch.float32)
+    sigma2 = sigma * sigma
+    phi = torch.exp(-(x * x) / (2.0 * sigma2))
+    phi = phi / phi.sum()
+    return (x * x / (sigma2 * sigma2) - 1.0 / sigma2) * phi
+
+
 # -----------------------------------------------------------------------------
 # Convolutional ops
 # -----------------------------------------------------------------------------
@@ -224,11 +300,14 @@ def _gaussian_filter_1d_along_axis(
     flat = x_perm.reshape(-1, 1, n)  # (B, 1, N)
 
     # Pad along the last dim only.
-    pad_mode = _pad_mode(mode)
-    if pad_mode == "constant":
-        padded = F.pad(flat, [radius, radius], mode="constant", value=float(cval))
+    if mode == "reflect":
+        padded = _scipy_reflect_pad_last_dim(flat, radius, radius)
     else:
-        padded = F.pad(flat, [radius, radius], mode=pad_mode)
+        pad_mode = _pad_mode(mode)
+        if pad_mode == "constant":
+            padded = F.pad(flat, [radius, radius], mode="constant", value=float(cval))
+        else:
+            padded = F.pad(flat, [radius, radius], mode=pad_mode)
 
     conv_kernel = kernel_1d.reshape(1, 1, -1)
     out_flat = F.conv1d(padded, conv_kernel)  # (B, 1, N)
@@ -289,11 +368,14 @@ def _conv1d_along_axis(x, axis: int, kernel_1d, mode: str, cval: float):
     flat = x_perm.reshape(-1, 1, n)
 
     radius = (kernel_1d.numel() - 1) // 2
-    pad_mode = _pad_mode(mode)
-    if pad_mode == "constant":
-        padded = F.pad(flat, [radius, radius], mode="constant", value=float(cval))
+    if mode == "reflect":
+        padded = _scipy_reflect_pad_last_dim(flat, radius, radius)
     else:
-        padded = F.pad(flat, [radius, radius], mode=pad_mode)
+        pad_mode = _pad_mode(mode)
+        if pad_mode == "constant":
+            padded = F.pad(flat, [radius, radius], mode="constant", value=float(cval))
+        else:
+            padded = F.pad(flat, [radius, radius], mode=pad_mode)
 
     out_flat = F.conv1d(padded, kernel_1d.reshape(1, 1, -1).to(flat.dtype))
     out_perm = out_flat.reshape(*leading_shape, n)
@@ -363,28 +445,40 @@ def gaussian_laplace(
 ):
     """Laplacian-of-Gaussian, mirroring :func:`scipy.ndimage.gaussian_laplace`.
 
-    Implementation follows scipy: smooth by Gaussian, then sum the
-    second derivatives along each axis.
+    Matches scipy's algorithm exactly: for each axis, convolve along that
+    axis with the second-derivative-of-Gaussian kernel and along every
+    other axis with the smoothing-Gaussian kernel; sum the per-axis
+    results. (The naive "smooth then finite-difference" approach is
+    *mathematically* equivalent in the continuous limit but discretizes
+    differently — see scipy's ``gaussian_laplace`` source for the
+    canonical implementation.)
     """
-    torch = _torch()
     sigmas = _normalize_sigma(sigma, input.ndim)
-    smoothed = gaussian_filter(input, sigmas, mode=mode, cval=cval)
-    # Sum of second derivatives along each axis.
     out = None
-    for axis in range(smoothed.ndim):
-        d2 = _second_derivative_along_axis(smoothed, axis, mode, cval)
+    for axis_with_d2 in range(input.ndim):
+        work = input
+        for axis, s in enumerate(sigmas):
+            order = 2 if axis == axis_with_d2 else 0
+            work = _gaussian_filter_1d_with_order(work, axis, s, order, 4.0, mode, cval)
         if out is None:
-            out = d2
+            out = work
         else:
-            out = out + d2
+            out = out + work
     return out
 
 
-def _second_derivative_along_axis(x, axis: int, mode: str, cval: float):
-    """Second-derivative kernel ``[1, -2, 1]`` along ``axis`` with scipy padding."""
-    torch = _torch()
-    kernel = torch.tensor([1.0, -2.0, 1.0], dtype=torch.float32)
-    return _conv1d_along_axis(x, axis, kernel, mode, cval)
+def _gaussian_filter_1d_with_order(
+    x, axis: int, sigma: float, order: int, truncate: float, mode: str, cval: float
+):
+    """Apply gaussian_filter1d with smoothing (order=0) or 2nd-derivative (order=2)."""
+    if order == 0:
+        return _gaussian_filter_1d_along_axis(x, axis, sigma, truncate, mode, cval)
+    if order == 2:
+        kernel = _gaussian_kernel_1d_order2(sigma, truncate)
+        return _conv1d_along_axis(x, axis, kernel, mode, cval)
+    raise NotImplementedError(
+        f"torch_ndi: gaussian filter order={order} not implemented"
+    )
 
 
 def maximum_filter(

--- a/nellie/utils/torch_ndi.py
+++ b/nellie/utils/torch_ndi.py
@@ -43,7 +43,7 @@ _TORCH: Any = None
 _F: Any = None
 
 
-def _torch():
+def _torch() -> Any:
     global _TORCH, _F
     if _TORCH is not None:
         return _TORCH
@@ -60,7 +60,7 @@ def _torch():
     return _TORCH
 
 
-def _functional():
+def _functional() -> Any:
     if _F is None:
         _torch()
     return _F

--- a/nellie/utils/torch_ndi.py
+++ b/nellie/utils/torch_ndi.py
@@ -32,12 +32,15 @@ See also:
 from __future__ import annotations
 
 import math
-from typing import Sequence
+from typing import Any, Sequence
 
 
-# Cached torch + functional module once an op imports them.
-_TORCH = None
-_F = None
+# Cached torch + functional module once an op imports them. Typed as ``Any``
+# so that ``F.conv2d(...)`` / ``F.pad(...)`` call sites don't trip Pyright's
+# Optional-narrowing — the lazy-import contract guarantees these are non-None
+# by the time any op runs.
+_TORCH: Any = None
+_F: Any = None
 
 
 def _torch():

--- a/nellie/utils/torch_ndi.py
+++ b/nellie/utils/torch_ndi.py
@@ -530,7 +530,10 @@ def label(input, structure=None, output=None):  # noqa: A002 - matches scipy API
     import scipy.ndimage as scipy_ndi
     in_np = _to_numpy(input)
     struct_np = _to_numpy(structure) if structure is not None else None
-    labels_np, num_features = scipy_ndi.label(in_np, structure=struct_np)
+    # scipy stub overloads `label` to return `int` when output= is provided,
+    # tuple otherwise. We always pass output=None here, so the tuple form is
+    # guaranteed — Pyright can't narrow the overload.
+    labels_np, num_features = scipy_ndi.label(in_np, structure=struct_np)  # type: ignore[misc]
     labels_out = _from_numpy_like(labels_np, input)
     if output is not None:
         output.copy_(labels_out if hasattr(output, "copy_") else labels_np)

--- a/nellie/utils/torch_ndi.py
+++ b/nellie/utils/torch_ndi.py
@@ -1,0 +1,535 @@
+"""scipy.ndimage-API shim over PyTorch + MPS.
+
+Implements the 9 ``scipy.ndimage`` ops nellie's four MPS-onboarded stages
+(filtering, labelling, networking, hu_tracking) need:
+
+- **Convolutional ops** dispatch via :mod:`torch.nn.functional` conv/pool
+  variants on the active torch device. They support the ``mode=`` and
+  ``cval=`` parameters scipy uses (``"reflect"``, ``"constant"``).
+
+  - :func:`gaussian_filter` (separable 1D Gaussian along each axis)
+  - :func:`gaussian_laplace` (Gaussian then Laplacian)
+  - :func:`uniform_filter` (separable mean filter)
+  - :func:`convolve` (general N-D correlation, scipy semantics)
+  - :func:`maximum_filter` (max pool with footprint shape)
+  - :func:`minimum_filter` (min pool — implemented as ``-max(-x)``)
+
+- **Structural ops** have no MPS-native equivalent and round-trip to
+  scipy on CPU. Cost is small on Apple Silicon's unified memory.
+
+  - :func:`binary_opening`
+  - :func:`binary_fill_holes`
+  - :func:`label`
+
+This module imports torch lazily (only when an op is called), matching
+the install model in :mod:`nellie.utils.torch_xp`.
+
+See also:
+    - PRD #140 (Apple Silicon / MPS)
+    - wiki/decisions/0001-pytorch-mps-over-mlx.md
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+
+# Cached torch + functional module once an op imports them.
+_TORCH = None
+_F = None
+
+
+def _torch():
+    global _TORCH, _F
+    if _TORCH is not None:
+        return _TORCH
+    try:
+        import torch as _t
+        import torch.nn.functional as _f
+    except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+        raise ModuleNotFoundError(
+            "torch is not installed. Install the MPS extra: "
+            "`pip install 'nellie[mps]'`."
+        ) from exc
+    _TORCH = _t
+    _F = _f
+    return _TORCH
+
+
+def _functional():
+    if _F is None:
+        _torch()
+    return _F
+
+
+# -----------------------------------------------------------------------------
+# Padding mode translation: scipy.ndimage <-> torch.nn.functional.pad
+# -----------------------------------------------------------------------------
+
+_SCIPY_TO_TORCH_PAD = {
+    "constant": "constant",
+    "reflect": "reflect",
+    "mirror": "reflect",  # scipy "mirror" matches torch "reflect"
+    "nearest": "replicate",
+    "wrap": "circular",
+}
+
+
+def _pad_mode(mode: str) -> str:
+    if mode not in _SCIPY_TO_TORCH_PAD:
+        raise ValueError(
+            f"torch_ndi: unsupported boundary mode '{mode}'. "
+            f"Supported: {sorted(_SCIPY_TO_TORCH_PAD)}"
+        )
+    return _SCIPY_TO_TORCH_PAD[mode]
+
+
+def _add_batch_channel(x):
+    """Promote an N-D tensor to (1, 1, *shape) for conv/pool ops."""
+    return x.unsqueeze(0).unsqueeze(0)
+
+
+def _strip_batch_channel(x):
+    return x.squeeze(0).squeeze(0)
+
+
+def _pad_for_kernel(x, kernel_shape: Sequence[int], mode: str, cval: float):
+    """Pad an N-D tensor by half-kernel on each side along its spatial axes.
+
+    Mirrors scipy's "extend then convolve" handling. ``mode`` is in
+    scipy parlance ('constant', 'reflect', 'nearest', 'wrap', 'mirror');
+    ``cval`` is only consulted when ``mode == "constant"``.
+    """
+    torch = _torch()
+    F = _functional()
+    pad_mode = _pad_mode(mode)
+    # F.pad takes the spatial pads in REVERSED axis order, two values per axis.
+    pad: list[int] = []
+    for ks in reversed(kernel_shape):
+        before = ks // 2
+        after = ks - 1 - before
+        pad.extend([before, after])
+    if pad_mode == "constant":
+        return F.pad(x, pad, mode="constant", value=float(cval))
+    return F.pad(x, pad, mode=pad_mode)
+
+
+def _to_4d_or_5d(x):
+    """Wrap an (H,W) or (D,H,W) input into a 4-D/5-D tensor for torch convN."""
+    if x.ndim == 2:
+        return _add_batch_channel(x), False  # (1,1,H,W)
+    if x.ndim == 3:
+        return _add_batch_channel(x), True   # (1,1,D,H,W)
+    raise ValueError(
+        f"torch_ndi: expected 2-D or 3-D input, got ndim={x.ndim}"
+    )
+
+
+def _conv(x_padded, kernel, *, dim_3d: bool):
+    """Run conv2d/conv3d with the padded input and a (kD,kH,kW)-style kernel."""
+    F = _functional()
+    if dim_3d:
+        # kernel: shape (1, 1, kD, kH, kW)
+        return F.conv3d(x_padded, kernel)
+    return F.conv2d(x_padded, kernel)
+
+
+# -----------------------------------------------------------------------------
+# Sigma normalization
+# -----------------------------------------------------------------------------
+
+
+def _normalize_sigma(sigma, ndim: int):
+    """Convert sigma to a per-axis tuple of floats."""
+    if isinstance(sigma, (int, float)):
+        return (float(sigma),) * ndim
+    sigma_list = [float(s) for s in sigma]
+    if len(sigma_list) != ndim:
+        raise ValueError(
+            f"torch_ndi: sigma length {len(sigma_list)} != ndim {ndim}"
+        )
+    return tuple(sigma_list)
+
+
+def _gaussian_kernel_1d(sigma: float, truncate: float = 4.0):
+    """1-D Gaussian kernel that mirrors scipy.ndimage._ni_support semantics."""
+    torch = _torch()
+    if sigma <= 0:
+        # scipy returns the input unchanged; we represent this with a length-1
+        # identity kernel (caller can short-circuit for efficiency).
+        return torch.ones(1, dtype=torch.float32)
+    radius = int(truncate * sigma + 0.5)
+    if radius < 1:
+        radius = 1
+    x = torch.arange(-radius, radius + 1, dtype=torch.float32)
+    kernel = torch.exp(-(x * x) / (2.0 * sigma * sigma))
+    kernel = kernel / kernel.sum()
+    return kernel
+
+
+# -----------------------------------------------------------------------------
+# Convolutional ops
+# -----------------------------------------------------------------------------
+
+
+def gaussian_filter(
+    input,  # noqa: A002 - matches scipy API
+    sigma,
+    *,
+    output=None,
+    mode: str = "reflect",
+    cval: float = 0.0,
+    truncate: float = 4.0,
+):
+    """Separable Gaussian filter dispatched via 1-D conv along each axis.
+
+    Mirrors :func:`scipy.ndimage.gaussian_filter`. The ``output=`` argument
+    accepts a tensor of the right shape; the result is written in-place
+    AND returned (matching scipy's behavior).
+    """
+    torch = _torch()
+    sigmas = _normalize_sigma(sigma, input.ndim)
+
+    work = input
+    for axis, s in enumerate(sigmas):
+        if s <= 0:
+            continue
+        work = _gaussian_filter_1d_along_axis(work, axis, s, truncate, mode, cval)
+
+    if output is not None:
+        output.copy_(work)
+        return output
+    return work
+
+
+def _gaussian_filter_1d_along_axis(
+    x, axis: int, sigma: float, truncate: float, mode: str, cval: float
+):
+    """Apply a 1-D Gaussian along ``axis`` using a depthwise conv1d trick."""
+    torch = _torch()
+    F = _functional()
+    kernel_1d = _gaussian_kernel_1d(sigma, truncate).to(x.dtype if x.dtype.is_floating_point else torch.float32)
+    radius = (kernel_1d.numel() - 1) // 2
+
+    # Move the target axis to the last position, collapse the rest into batch.
+    perm = list(range(x.ndim))
+    perm.append(perm.pop(axis))
+    x_perm = x.permute(perm).contiguous()
+    leading_shape = x_perm.shape[:-1]
+    n = x_perm.shape[-1]
+    flat = x_perm.reshape(-1, 1, n)  # (B, 1, N)
+
+    # Pad along the last dim only.
+    pad_mode = _pad_mode(mode)
+    if pad_mode == "constant":
+        padded = F.pad(flat, [radius, radius], mode="constant", value=float(cval))
+    else:
+        padded = F.pad(flat, [radius, radius], mode=pad_mode)
+
+    conv_kernel = kernel_1d.reshape(1, 1, -1)
+    out_flat = F.conv1d(padded, conv_kernel)  # (B, 1, N)
+    out_perm = out_flat.reshape(*leading_shape, n)
+
+    # Restore axis order.
+    inverse_perm = [0] * x.ndim
+    for new_pos, orig_pos in enumerate(perm):
+        inverse_perm[orig_pos] = new_pos
+    return out_perm.permute(inverse_perm).contiguous()
+
+
+def uniform_filter(
+    input,  # noqa: A002 - matches scipy API
+    size,
+    *,
+    output=None,
+    mode: str = "reflect",
+    cval: float = 0.0,
+):
+    """Mean filter with a box of given ``size``."""
+    torch = _torch()
+
+    if isinstance(size, int):
+        sizes = (size,) * input.ndim
+    else:
+        sizes = tuple(int(s) for s in size)
+        if len(sizes) != input.ndim:
+            raise ValueError(
+                f"torch_ndi.uniform_filter: size length {len(sizes)} != ndim {input.ndim}"
+            )
+
+    work = input
+    for axis, s in enumerate(sizes):
+        if s <= 1:
+            continue
+        # Build a uniform 1-D kernel along this axis.
+        kernel = torch.full((s,), 1.0 / s, dtype=torch.float32)
+        work = _conv1d_along_axis(work, axis, kernel, mode, cval)
+
+    if output is not None:
+        output.copy_(work)
+        return output
+    return work
+
+
+def _conv1d_along_axis(x, axis: int, kernel_1d, mode: str, cval: float):
+    """Generic 1-D conv along ``axis`` (centered) with scipy-style padding."""
+    torch = _torch()
+    F = _functional()
+    if not x.dtype.is_floating_point:
+        x = x.to(torch.float32)
+    perm = list(range(x.ndim))
+    perm.append(perm.pop(axis))
+    x_perm = x.permute(perm).contiguous()
+    leading_shape = x_perm.shape[:-1]
+    n = x_perm.shape[-1]
+    flat = x_perm.reshape(-1, 1, n)
+
+    radius = (kernel_1d.numel() - 1) // 2
+    pad_mode = _pad_mode(mode)
+    if pad_mode == "constant":
+        padded = F.pad(flat, [radius, radius], mode="constant", value=float(cval))
+    else:
+        padded = F.pad(flat, [radius, radius], mode=pad_mode)
+
+    out_flat = F.conv1d(padded, kernel_1d.reshape(1, 1, -1).to(flat.dtype))
+    out_perm = out_flat.reshape(*leading_shape, n)
+    inverse_perm = [0] * x.ndim
+    for new_pos, orig_pos in enumerate(perm):
+        inverse_perm[orig_pos] = new_pos
+    return out_perm.permute(inverse_perm).contiguous()
+
+
+def convolve(
+    input,  # noqa: A002 - matches scipy API
+    weights,
+    *,
+    output=None,
+    mode: str = "reflect",
+    cval: float = 0.0,
+):
+    """N-D convolution mirroring :func:`scipy.ndimage.convolve` semantics.
+
+    scipy's ``convolve`` does correlation flipped (true convolution).
+    We dispatch via padded ``conv2d``/``conv3d``. Note: torch's ``conv2d``
+    is *cross-correlation* (no flip), so for the symmetric kernels
+    nellie's networking stage uses (``ones((3, 3))``) the result is
+    identical to scipy's convolve. For asymmetric kernels we pre-flip
+    the weights to match scipy's true-convolution semantics.
+    """
+    torch = _torch()
+
+    if input.ndim != weights.ndim:
+        raise ValueError(
+            f"torch_ndi.convolve: input ndim {input.ndim} != weights ndim {weights.ndim}"
+        )
+    if input.ndim not in (2, 3):
+        raise ValueError(
+            f"torch_ndi.convolve: only 2-D or 3-D input supported, got ndim={input.ndim}"
+        )
+
+    work_dtype = input.dtype if input.dtype.is_floating_point else torch.float32
+    x = input.to(work_dtype)
+    w = weights.to(work_dtype)
+
+    # scipy.convolve = true convolution = correlation with flipped kernel.
+    w_flipped = torch.flip(w, dims=tuple(range(w.ndim)))
+    kernel = w_flipped.reshape(1, 1, *w_flipped.shape)
+
+    x4d, dim_3d = _to_4d_or_5d(x)
+    padded = _pad_for_kernel(x4d, w_flipped.shape, mode, cval)
+    out_4d = _conv(padded, kernel, dim_3d=dim_3d)
+    out = _strip_batch_channel(out_4d)
+
+    # Cast back to input dtype if needed.
+    if out.dtype != input.dtype:
+        out = out.to(input.dtype)
+
+    if output is not None:
+        output.copy_(out)
+        return output
+    return out
+
+
+def gaussian_laplace(
+    input,  # noqa: A002 - matches scipy API
+    sigma,
+    *,
+    mode: str = "reflect",
+    cval: float = 0.0,
+):
+    """Laplacian-of-Gaussian, mirroring :func:`scipy.ndimage.gaussian_laplace`.
+
+    Implementation follows scipy: smooth by Gaussian, then sum the
+    second derivatives along each axis.
+    """
+    torch = _torch()
+    sigmas = _normalize_sigma(sigma, input.ndim)
+    smoothed = gaussian_filter(input, sigmas, mode=mode, cval=cval)
+    # Sum of second derivatives along each axis.
+    out = None
+    for axis in range(smoothed.ndim):
+        d2 = _second_derivative_along_axis(smoothed, axis, mode, cval)
+        if out is None:
+            out = d2
+        else:
+            out = out + d2
+    return out
+
+
+def _second_derivative_along_axis(x, axis: int, mode: str, cval: float):
+    """Second-derivative kernel ``[1, -2, 1]`` along ``axis`` with scipy padding."""
+    torch = _torch()
+    kernel = torch.tensor([1.0, -2.0, 1.0], dtype=torch.float32)
+    return _conv1d_along_axis(x, axis, kernel, mode, cval)
+
+
+def maximum_filter(
+    input,  # noqa: A002 - matches scipy API
+    size=None,
+    *,
+    footprint=None,
+    output=None,
+    mode: str = "reflect",
+    cval: float = 0.0,
+):
+    """Max filter via depthwise N-D max pool.
+
+    ``size`` follows scipy's convention: scalar => same size on every
+    axis; tuple => per-axis size. ``footprint`` is supported only for
+    fully-true rectangular footprints (the only shape nellie uses); other
+    shapes raise NotImplementedError.
+    """
+    torch = _torch()
+    F = _functional()
+
+    if footprint is not None:
+        # Validate it's a fully-true rectangular footprint.
+        if not bool(footprint.all()):
+            raise NotImplementedError(
+                "torch_ndi.maximum_filter: non-rectangular footprints are not "
+                "supported by the MPS shim."
+            )
+        sizes = tuple(footprint.shape)
+    elif size is not None:
+        if isinstance(size, int):
+            sizes = (size,) * input.ndim
+        else:
+            sizes = tuple(int(s) for s in size)
+    else:
+        raise ValueError("torch_ndi.maximum_filter: size or footprint required")
+
+    if len(sizes) != input.ndim:
+        raise ValueError(
+            f"torch_ndi.maximum_filter: size/footprint ndim {len(sizes)} != input ndim {input.ndim}"
+        )
+
+    work_dtype = input.dtype if input.dtype.is_floating_point else torch.float32
+    x = input.to(work_dtype)
+    x4d, dim_3d = _to_4d_or_5d(x)
+
+    padded = _pad_for_kernel(x4d, sizes, mode, cval)
+    if dim_3d:
+        result = F.max_pool3d(padded, kernel_size=sizes, stride=1)
+    else:
+        result = F.max_pool2d(padded, kernel_size=sizes, stride=1)
+    out = _strip_batch_channel(result)
+    if out.dtype != input.dtype:
+        out = out.to(input.dtype)
+
+    if output is not None:
+        output.copy_(out)
+        return output
+    return out
+
+
+def minimum_filter(
+    input,  # noqa: A002 - matches scipy API
+    size=None,
+    *,
+    footprint=None,
+    output=None,
+    mode: str = "reflect",
+    cval: float = 0.0,
+):
+    """Min filter implemented as ``-max(-x)``.
+
+    The negation flips ``cval`` semantics: a constant-pad min filter pads
+    with ``+cval`` to ignore those positions, so negating means we pad
+    with ``-cval`` for the underlying max pool.
+    """
+    torch = _torch()
+    work_dtype = input.dtype if input.dtype.is_floating_point else torch.float32
+    neg = (-input.to(work_dtype))
+    neg_max = maximum_filter(
+        neg, size=size, footprint=footprint, mode=mode, cval=-float(cval)
+    )
+    result = -neg_max
+    if result.dtype != input.dtype:
+        result = result.to(input.dtype)
+
+    if output is not None:
+        output.copy_(result)
+        return output
+    return result
+
+
+# -----------------------------------------------------------------------------
+# Structural ops — round-trip to scipy on CPU
+# -----------------------------------------------------------------------------
+
+
+def _to_numpy(x):
+    """Move a tensor to host numpy for the scipy round-trip."""
+    torch = _torch()
+    if isinstance(x, torch.Tensor):
+        return x.detach().cpu().numpy()
+    return x
+
+
+def _from_numpy_like(arr_np, template):
+    """Wrap a numpy result back as a tensor on the same device as ``template``."""
+    torch = _torch()
+    if isinstance(template, torch.Tensor):
+        return torch.as_tensor(arr_np, device=template.device)
+    return arr_np
+
+
+def binary_opening(input, structure=None, **kwargs):  # noqa: A002 - matches scipy API
+    """Round-trip to ``scipy.ndimage.binary_opening`` on CPU.
+
+    No MPS-native morphology op exists. Cost on Apple Silicon's unified
+    memory is small.
+    """
+    import scipy.ndimage as scipy_ndi
+    in_np = _to_numpy(input)
+    struct_np = _to_numpy(structure) if structure is not None else None
+    result_np = scipy_ndi.binary_opening(in_np, structure=struct_np, **kwargs)
+    return _from_numpy_like(result_np, input)
+
+
+def binary_fill_holes(input, structure=None, **kwargs):  # noqa: A002 - matches scipy API
+    """Round-trip to ``scipy.ndimage.binary_fill_holes`` on CPU."""
+    import scipy.ndimage as scipy_ndi
+    in_np = _to_numpy(input)
+    struct_np = _to_numpy(structure) if structure is not None else None
+    result_np = scipy_ndi.binary_fill_holes(in_np, structure=struct_np, **kwargs)
+    return _from_numpy_like(result_np, input)
+
+
+def label(input, structure=None, output=None):  # noqa: A002 - matches scipy API
+    """Round-trip to ``scipy.ndimage.label`` on CPU.
+
+    Returns ``(labels, num_features)`` to match scipy's contract. Connected
+    components has no equivalent on MPS without third-party libs (kornia
+    etc.) — see PRD #140 § Out of Scope.
+    """
+    import scipy.ndimage as scipy_ndi
+    in_np = _to_numpy(input)
+    struct_np = _to_numpy(structure) if structure is not None else None
+    labels_np, num_features = scipy_ndi.label(in_np, structure=struct_np)
+    labels_out = _from_numpy_like(labels_np, input)
+    if output is not None:
+        output.copy_(labels_out if hasattr(output, "copy_") else labels_np)
+        return output, num_features
+    return labels_out, num_features

--- a/nellie/utils/torch_xp.py
+++ b/nellie/utils/torch_xp.py
@@ -560,11 +560,11 @@ def gradient(f, *varargs, axis=None):
 
 
 def _gradient_axis(f, axis: int, h: float, torch_mod):
-    """Central differences along ``axis`` with second-order forward/backward edges.
+    """Central differences along ``axis`` with first-order forward/backward edges.
 
-    Mirrors numpy.gradient's edge-handling (second-order at the boundaries
-    via 3-point one-sided stencils). For len-1 axes we return zeros to
-    match numpy's behavior on that edge case.
+    Mirrors ``numpy.gradient``'s default ``edge_order=1`` behavior: central
+    differences in the interior, simple forward/backward at the boundaries.
+    For len-1 axes we return zeros to match numpy's behavior on that edge case.
     """
     n = f.shape[axis]
     if n < 2:
@@ -578,9 +578,7 @@ def _gradient_axis(f, axis: int, h: float, torch_mod):
 
     out = torch_mod.empty_like(f)
     if n == 2:
-        # numpy uses first-order forward/backward at both ends.
         delta = (f[_idx(1, 2)] - f[_idx(0, 1)]) / h
-        # Both edges share the same value when n == 2.
         out[_idx(0, 1)] = delta
         out[_idx(1, 2)] = delta
         return out
@@ -588,16 +586,10 @@ def _gradient_axis(f, axis: int, h: float, torch_mod):
     # Interior: central difference.
     interior = (f[_idx(2, n)] - f[_idx(0, n - 2)]) / (2.0 * h)
     out[_idx(1, n - 1)] = interior
-    # Left edge (second-order forward): (-3*f0 + 4*f1 - f2) / (2*h)
-    left = (-3.0 * f[_idx(0, 1)] + 4.0 * f[_idx(1, 2)] - f[_idx(2, 3)]) / (2.0 * h)
-    out[_idx(0, 1)] = left
-    # Right edge (second-order backward): (3*fN-1 - 4*fN-2 + fN-3) / (2*h)
-    right = (
-        3.0 * f[_idx(n - 1, n)]
-        - 4.0 * f[_idx(n - 2, n - 1)]
-        + f[_idx(n - 3, n - 2)]
-    ) / (2.0 * h)
-    out[_idx(n - 1, n)] = right
+    # Left edge: first-order forward — (f1 - f0) / h
+    out[_idx(0, 1)] = (f[_idx(1, 2)] - f[_idx(0, 1)]) / h
+    # Right edge: first-order backward — (fN-1 - fN-2) / h
+    out[_idx(n - 1, n)] = (f[_idx(n - 1, n)] - f[_idx(n - 2, n - 1)]) / h
     return out
 
 

--- a/nellie/utils/torch_xp.py
+++ b/nellie/utils/torch_xp.py
@@ -1,0 +1,665 @@
+"""numpy-API shim over PyTorch + MPS.
+
+Implements the union of ``xp.*`` ops used by nellie's four MPS-onboarded
+stages (filtering, labelling, networking, hu_tracking) plus their helper
+modules (``frangi_math``, ``chunking``, ``gpu_functions``). Operations not
+listed in :data:`_SUPPORTED_OPS` raise :class:`NotImplementedError` with a
+message identifying the missing op so future maintainers can extend the
+shim deliberately.
+
+Float64 silently coerces to float32 — MPS does not support double
+precision. The coercion is announced at module load time via a single
+log message (see :func:`_announce_float64_coercion`).
+
+This module imports torch lazily: the import only happens when an op is
+actually called, so installs without the ``mps`` extra (where torch is
+absent) don't pay an import cost or raise at module load.
+
+See also:
+    - PRD #140 (Apple Silicon / MPS)
+    - wiki/decisions/0001-pytorch-mps-over-mlx.md
+    - wiki/decisions/0002-adaptive-run-extension-over-static-torch-xp.md
+    - :mod:`nellie.utils.torch_ndi`
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Set to True once the float64 coercion notice has been emitted.
+_FLOAT64_NOTICE_EMITTED = False
+
+# Cached torch module + dtypes once the first op imports torch successfully.
+_TORCH = None
+_TORCH_FLOAT32 = None
+_TORCH_FLOAT16 = None
+_TORCH_BOOL = None
+
+
+def _announce_float64_coercion() -> None:
+    """Emit the one-time float64 coercion notice.
+
+    Idempotent — subsequent calls are no-ops. The exact wording is part
+    of the public contract per the slice acceptance criteria.
+    """
+    global _FLOAT64_NOTICE_EMITTED
+    if _FLOAT64_NOTICE_EMITTED:
+        return
+    _FLOAT64_NOTICE_EMITTED = True
+    logger.info(
+        "MPS backend: float64 → float32 coercion is in effect; results may "
+        "differ from CPU within float32 tolerance."
+    )
+
+
+def _torch():
+    """Return the lazily-imported torch module, raising a clear error if missing."""
+    global _TORCH, _TORCH_FLOAT32, _TORCH_FLOAT16, _TORCH_BOOL
+    if _TORCH is not None:
+        return _TORCH
+    try:
+        import torch as _t
+    except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+        raise ModuleNotFoundError(
+            "torch is not installed. Install the MPS extra: "
+            "`pip install 'nellie[mps]'`."
+        ) from exc
+    _TORCH = _t
+    _TORCH_FLOAT32 = _t.float32
+    _TORCH_FLOAT16 = _t.float16
+    _TORCH_BOOL = _t.bool
+    return _TORCH
+
+
+# -----------------------------------------------------------------------------
+# Dtype attributes
+# -----------------------------------------------------------------------------
+#
+# These are exposed as module attributes via ``__getattr__`` because the
+# real torch dtype objects can only be created after torch is imported.
+# Special-cased: ``float64`` resolves to torch.float32 (with the one-time
+# log notice); MPS does not support double precision.
+
+
+class _LazyDtype:
+    """Sentinel that resolves to a torch dtype on first attribute access.
+
+    Equality and hashing pass through to the underlying torch dtype so
+    callers using ``dtype is xp.float32`` get sensible behavior.
+    """
+
+    __slots__ = ("_name", "_resolve_via")
+
+    def __init__(self, name: str, resolve_via: str) -> None:
+        self._name = name
+        self._resolve_via = resolve_via
+
+    def _resolve(self):
+        torch = _torch()
+        if self._resolve_via == "float64":
+            _announce_float64_coercion()
+            return torch.float32
+        return getattr(torch, self._resolve_via)
+
+    def __repr__(self) -> str:
+        return f"<torch_xp.{self._name} (resolves to torch.{self._resolve_via})>"
+
+    def __eq__(self, other: object) -> bool:
+        try:
+            return self._resolve() == other
+        except Exception:
+            return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(("torch_xp", self._name))
+
+
+float32 = _LazyDtype("float32", "float32")
+# float64 is intentionally aliased to torch.float32 with a logged notice.
+float64 = _LazyDtype("float64", "float64")
+float16 = _LazyDtype("float16", "float16")
+
+# -----------------------------------------------------------------------------
+# numpy API constants
+# -----------------------------------------------------------------------------
+
+# `xp.newaxis` is `None` in numpy — same in torch (used for indexing only).
+newaxis = None
+
+# `xp.inf` is the float; numpy/torch interop is via raw float.
+import math as _math
+inf = _math.inf
+
+
+# -----------------------------------------------------------------------------
+# Array class (for isinstance checks and type hints)
+# -----------------------------------------------------------------------------
+
+
+class _NdarrayProxy:
+    """Lazy proxy for ``torch.Tensor`` so ``isinstance(x, xp.ndarray)`` works.
+
+    Defining ``__instancecheck__`` on the metaclass lets the proxy stand
+    in for the real Tensor class without forcing torch to be imported at
+    module load.
+    """
+
+    class _Meta(type):
+        def __instancecheck__(cls, instance) -> bool:
+            try:
+                torch = _torch()
+            except Exception:
+                return False
+            return isinstance(instance, torch.Tensor)
+
+
+class ndarray(metaclass=_NdarrayProxy._Meta):
+    """Proxy class for ``torch.Tensor`` — for isinstance checks only.
+
+    ``isinstance(x, ndarray)`` returns True iff ``x`` is a torch.Tensor.
+    Instantiating this class is not supported; construct tensors via the
+    shim's ``zeros``/``asarray``/etc. ops instead.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise TypeError(
+            "torch_xp.ndarray is a proxy for torch.Tensor — use torch_xp.zeros, "
+            "torch_xp.asarray, etc. to construct tensors."
+        )
+
+
+# -----------------------------------------------------------------------------
+# Dtype coercion helper (silently downgrade float64 to float32)
+# -----------------------------------------------------------------------------
+
+
+def _resolve_dtype(dtype):
+    """Convert a dtype-ish value into a torch.dtype, coercing float64→float32.
+
+    Accepts torch.dtype, numpy dtype, _LazyDtype proxies, Python `bool`,
+    and `None` (returns None). Anything else falls through to torch's
+    dtype machinery (which will raise if it doesn't understand it).
+    """
+    if dtype is None:
+        return None
+    torch = _torch()
+    # Already a torch dtype.
+    if isinstance(dtype, torch.dtype):
+        if dtype == torch.float64:
+            _announce_float64_coercion()
+            return torch.float32
+        return dtype
+    # _LazyDtype proxies.
+    if isinstance(dtype, _LazyDtype):
+        return dtype._resolve()
+    # Python `bool` (numpy uses this for boolean arrays).
+    if dtype is bool:
+        return torch.bool
+    # Numpy dtype-likes: map to torch via numpy's standardized name.
+    try:
+        import numpy as np
+        np_dtype = np.dtype(dtype)
+    except Exception:
+        return dtype  # let torch deal with it
+    name = np_dtype.name
+    if name == "float64":
+        _announce_float64_coercion()
+        return torch.float32
+    name_to_torch = {
+        "float32": torch.float32,
+        "float16": torch.float16,
+        "int64": torch.int64,
+        "int32": torch.int32,
+        "int16": torch.int16,
+        "int8": torch.int8,
+        "uint8": torch.uint8,
+        "bool": torch.bool,
+        "complex64": torch.complex64,
+        "complex128": torch.complex128,
+    }
+    return name_to_torch.get(name, dtype)
+
+
+# -----------------------------------------------------------------------------
+# Construction
+# -----------------------------------------------------------------------------
+
+
+def asarray(obj, dtype=None):
+    torch = _torch()
+    target_dtype = _resolve_dtype(dtype)
+    if isinstance(obj, torch.Tensor):
+        if target_dtype is not None and obj.dtype != target_dtype:
+            return obj.to(target_dtype)
+        return obj
+    # Fall through to torch.as_tensor for numpy / list / scalar inputs.
+    if target_dtype is not None:
+        return torch.as_tensor(obj, dtype=target_dtype)
+    return torch.as_tensor(obj)
+
+
+def zeros(shape, dtype=None):
+    torch = _torch()
+    target_dtype = _resolve_dtype(dtype) if dtype is not None else torch.float32
+    if isinstance(shape, int):
+        shape = (shape,)
+    return torch.zeros(*shape, dtype=target_dtype) if shape else torch.zeros((), dtype=target_dtype)
+
+
+def zeros_like(arr, dtype=None):
+    torch = _torch()
+    if dtype is None:
+        return torch.zeros_like(arr)
+    return torch.zeros_like(arr, dtype=_resolve_dtype(dtype))
+
+
+def ones(shape, dtype=None):
+    torch = _torch()
+    target_dtype = _resolve_dtype(dtype) if dtype is not None else torch.float32
+    if isinstance(shape, int):
+        shape = (shape,)
+    return torch.ones(*shape, dtype=target_dtype) if shape else torch.ones((), dtype=target_dtype)
+
+
+def ones_like(arr, dtype=None):
+    torch = _torch()
+    if dtype is None:
+        return torch.ones_like(arr)
+    return torch.ones_like(arr, dtype=_resolve_dtype(dtype))
+
+
+def full_like(arr, fill_value, dtype=None):
+    torch = _torch()
+    if dtype is None:
+        return torch.full_like(arr, fill_value)
+    return torch.full_like(arr, fill_value, dtype=_resolve_dtype(dtype))
+
+
+def arange(*args, dtype=None):
+    """``arange(stop)`` / ``arange(start, stop)`` / ``arange(start, stop, step)``."""
+    torch = _torch()
+    target_dtype = _resolve_dtype(dtype)
+    if target_dtype is None:
+        return torch.arange(*args)
+    return torch.arange(*args, dtype=target_dtype)
+
+
+def meshgrid(*xi, indexing: str = "xy"):
+    """numpy-style meshgrid; defaults to 'xy' indexing for parity."""
+    torch = _torch()
+    return tuple(torch.meshgrid(*xi, indexing=indexing))
+
+
+# -----------------------------------------------------------------------------
+# Element-wise math
+# -----------------------------------------------------------------------------
+
+
+def abs(x):  # noqa: A001 - matches numpy API
+    return _torch().abs(x)
+
+
+def sqrt(x):
+    return _torch().sqrt(x)
+
+
+def exp(x):
+    return _torch().exp(x)
+
+
+def log10(x):
+    return _torch().log10(x)
+
+
+def cos(x):
+    return _torch().cos(x)
+
+
+def arccos(x):
+    return _torch().arccos(x)
+
+
+def sign(x):
+    return _torch().sign(x)
+
+
+def ceil(x):
+    return _torch().ceil(x)
+
+
+def clip(x, a_min, a_max):
+    return _torch().clamp(x, min=a_min, max=a_max)
+
+
+def isfinite(x):
+    return _torch().isfinite(x)
+
+
+def isinf(x):
+    return _torch().isinf(x)
+
+
+def nan_to_num(x, nan=0.0, posinf=None, neginf=None):
+    return _torch().nan_to_num(x, nan=nan, posinf=posinf, neginf=neginf)
+
+
+def maximum(a, b, *, out=None):
+    """numpy-style elementwise max with optional ``out=``.
+
+    Supports the ``out=`` write-target convention used in nellie's
+    in-place reductions (see Filter._compute_vesselness loop).
+    """
+    torch = _torch()
+    if out is not None:
+        return torch.maximum(a, b, out=out)
+    return torch.maximum(a, b)
+
+
+# -----------------------------------------------------------------------------
+# Reductions and scans
+# -----------------------------------------------------------------------------
+
+
+def any(x, axis=None):  # noqa: A001 - matches numpy API
+    torch = _torch()
+    if axis is None:
+        return torch.any(x)
+    return torch.any(x, dim=axis)
+
+
+def sum(x, axis=None, dtype=None):  # noqa: A001 - matches numpy API
+    torch = _torch()
+    target_dtype = _resolve_dtype(dtype)
+    if axis is None:
+        if target_dtype is not None:
+            return torch.sum(x, dtype=target_dtype)
+        return torch.sum(x)
+    if target_dtype is not None:
+        return torch.sum(x, dim=axis, dtype=target_dtype)
+    return torch.sum(x, dim=axis)
+
+
+def nansum(x, axis=None):
+    torch = _torch()
+    if axis is None:
+        return torch.nansum(x)
+    return torch.nansum(x, dim=axis)
+
+
+def max(x, axis=None):  # noqa: A001 - matches numpy API
+    torch = _torch()
+    if axis is None:
+        return torch.max(x)
+    out = torch.max(x, dim=axis)
+    return out.values  # numpy returns just the values
+
+
+def min(x, axis=None):  # noqa: A001 - matches numpy API
+    torch = _torch()
+    if axis is None:
+        return torch.min(x)
+    out = torch.min(x, dim=axis)
+    return out.values
+
+
+def argmin(x, axis=None):
+    torch = _torch()
+    if axis is None:
+        return torch.argmin(x)
+    return torch.argmin(x, dim=axis)
+
+
+def argmax(x, axis=None):
+    torch = _torch()
+    if axis is None:
+        return torch.argmax(x)
+    return torch.argmax(x, dim=axis)
+
+
+def cumsum(x, axis=None, dtype=None):
+    torch = _torch()
+    target_dtype = _resolve_dtype(dtype)
+    if axis is None:
+        flat = x.reshape(-1)
+        if target_dtype is not None:
+            return torch.cumsum(flat, dim=0, dtype=target_dtype)
+        return torch.cumsum(flat, dim=0)
+    if target_dtype is not None:
+        return torch.cumsum(x, dim=axis, dtype=target_dtype)
+    return torch.cumsum(x, dim=axis)
+
+
+def percentile(a, q):
+    """numpy-style percentile (q in [0, 100]).
+
+    torch's ``quantile`` takes q in [0, 1], so we rescale and forward.
+    Return a 0-d tensor matching numpy's scalar return for a scalar q.
+    """
+    torch = _torch()
+    q_tensor = torch.as_tensor(q, dtype=torch.float32) / 100.0
+    return torch.quantile(a.to(torch.float32) if a.dtype != torch.float32 else a, q_tensor)
+
+
+# -----------------------------------------------------------------------------
+# Comparison / selection
+# -----------------------------------------------------------------------------
+
+
+def where(condition, x=None, y=None):
+    torch = _torch()
+    if x is None and y is None:
+        # numpy.where(cond) returns a tuple of 1-D index tensors (per dim).
+        return torch.where(condition)
+    return torch.where(condition, x, y)
+
+
+def argwhere(x):
+    """Return a (N, ndim) tensor of indices where ``x`` is truthy.
+
+    Matches numpy's ``argwhere`` shape contract.
+    """
+    return _torch().argwhere(x)
+
+
+def flatnonzero(x):
+    """Return 1-D tensor of indices into the flattened array where ``x`` is nonzero."""
+    torch = _torch()
+    return torch.nonzero(x.reshape(-1), as_tuple=False).reshape(-1)
+
+
+def take_along_axis(arr, indices, axis):
+    return _torch().take_along_dim(arr, indices, dim=axis)
+
+
+def argsort(x, axis=-1):
+    return _torch().argsort(x, dim=axis)
+
+
+# -----------------------------------------------------------------------------
+# Combining / shape
+# -----------------------------------------------------------------------------
+
+
+def stack(arrays, axis=0):
+    return _torch().stack(list(arrays), dim=axis)
+
+
+def concatenate(arrays, axis=0):
+    return _torch().cat(list(arrays), dim=axis)
+
+
+def flip(x, axis=None):
+    torch = _torch()
+    if axis is None:
+        return torch.flip(x, dims=tuple(range(x.ndim)))
+    if isinstance(axis, int):
+        return torch.flip(x, dims=(axis,))
+    return torch.flip(x, dims=tuple(axis))
+
+
+# -----------------------------------------------------------------------------
+# Histogram / counting
+# -----------------------------------------------------------------------------
+
+
+def histogram(a, bins=10, range=None):  # noqa: A002 - matches numpy API
+    """numpy-style histogram returning ``(counts, bin_edges)``.
+
+    torch.histogram has the same return shape but slightly different
+    parameter handling for ``range``; we forward via the keyword
+    ``min``/``max`` form to keep the contract aligned.
+    """
+    torch = _torch()
+    a_flat = a.reshape(-1).to(torch.float32) if a.dtype not in (torch.float32, torch.float64) else a.reshape(-1)
+    if range is not None:
+        lo, hi = range
+        return torch.histogram(a_flat, bins=bins, range=(float(lo), float(hi)))
+    return torch.histogram(a_flat, bins=bins)
+
+
+def bincount(x, weights=None, minlength: int = 0):
+    return _torch().bincount(x, weights=weights, minlength=minlength)
+
+
+# -----------------------------------------------------------------------------
+# Gradient (numpy.gradient with axis= and per-axis spacing)
+# -----------------------------------------------------------------------------
+
+
+def gradient(f, *varargs, axis=None):
+    """Implements numpy.gradient's central-difference behavior.
+
+    nellie's ``frangi_math.compute_hessian`` uses three call shapes:
+
+    1. ``xp.gradient(image, h, axis=0)`` — single-axis with scalar spacing.
+    2. ``xp.gradient(image, h0, h1)`` — multi-axis (returns tuple) with
+       per-axis scalar spacing, no ``axis`` arg.
+    3. ``xp.gradient(image, h0, h1, h2)`` — same, 3D.
+
+    This implementation covers all three. Multi-axis returns a tuple of
+    tensors (one per axis), single-axis returns a single tensor.
+    """
+    torch = _torch()
+    ndim = f.ndim
+
+    if axis is not None:
+        # Single-axis path. varargs is at most 1 spacing scalar.
+        h = float(varargs[0]) if varargs else 1.0
+        return _gradient_axis(f, axis, h, torch)
+
+    # Multi-axis path: one spacing per dimension (must match ndim).
+    spacings = [float(v) for v in varargs] if varargs else [1.0] * ndim
+    if len(spacings) == 1 and ndim > 1:
+        spacings = spacings * ndim
+    return tuple(
+        _gradient_axis(f, ax, spacings[ax], torch) for ax in range(ndim)
+    )
+
+
+def _gradient_axis(f, axis: int, h: float, torch_mod):
+    """Central differences along ``axis`` with second-order forward/backward edges.
+
+    Mirrors numpy.gradient's edge-handling (second-order at the boundaries
+    via 3-point one-sided stencils). For len-1 axes we return zeros to
+    match numpy's behavior on that edge case.
+    """
+    n = f.shape[axis]
+    if n < 2:
+        return torch_mod.zeros_like(f)
+
+    # Build slices for centered-diff (shifted indices along axis).
+    def _idx(i_start, i_end):
+        sl = [slice(None)] * f.ndim
+        sl[axis] = slice(i_start, i_end)
+        return tuple(sl)
+
+    out = torch_mod.empty_like(f)
+    if n == 2:
+        # numpy uses first-order forward/backward at both ends.
+        delta = (f[_idx(1, 2)] - f[_idx(0, 1)]) / h
+        # Both edges share the same value when n == 2.
+        out[_idx(0, 1)] = delta
+        out[_idx(1, 2)] = delta
+        return out
+
+    # Interior: central difference.
+    interior = (f[_idx(2, n)] - f[_idx(0, n - 2)]) / (2.0 * h)
+    out[_idx(1, n - 1)] = interior
+    # Left edge (second-order forward): (-3*f0 + 4*f1 - f2) / (2*h)
+    left = (-3.0 * f[_idx(0, 1)] + 4.0 * f[_idx(1, 2)] - f[_idx(2, 3)]) / (2.0 * h)
+    out[_idx(0, 1)] = left
+    # Right edge (second-order backward): (3*fN-1 - 4*fN-2 + fN-3) / (2*h)
+    right = (
+        3.0 * f[_idx(n - 1, n)]
+        - 4.0 * f[_idx(n - 2, n - 1)]
+        + f[_idx(n - 3, n - 2)]
+    ) / (2.0 * h)
+    out[_idx(n - 1, n)] = right
+    return out
+
+
+# -----------------------------------------------------------------------------
+# Linalg
+# -----------------------------------------------------------------------------
+
+
+class _Linalg:
+    """Lazy linalg sub-namespace mirroring ``numpy.linalg`` / ``cupy.linalg``."""
+
+    def eigvalsh(self, a):
+        return _torch().linalg.eigvalsh(a)
+
+
+linalg = _Linalg()
+
+
+# -----------------------------------------------------------------------------
+# Misc helpers
+# -----------------------------------------------------------------------------
+
+
+def finfo(dtype):
+    """Mirror numpy.finfo for the float dtypes the pipeline asks about."""
+    torch = _torch()
+    target = _resolve_dtype(dtype) if not isinstance(dtype, torch.dtype) else dtype
+    return torch.finfo(target)
+
+
+def asnumpy(arr):
+    """Convert a tensor (or anything else) to a numpy array on CPU.
+
+    Mirrors ``cupy.asnumpy``. For numpy inputs this is a no-op identity.
+    """
+    torch = _torch()
+    if isinstance(arr, torch.Tensor):
+        return arr.detach().cpu().numpy()
+    import numpy as np
+    return np.asarray(arr)
+
+
+# -----------------------------------------------------------------------------
+# Unimplemented op trap (preserves stage-onboarding clarity)
+# -----------------------------------------------------------------------------
+
+
+def __getattr__(name: str) -> Any:
+    """Trap unknown ``xp.*`` access with a clear ``NotImplementedError``.
+
+    The shim covers the union of ops used by the four onboarded stages
+    (filtering, labelling, networking, hu_tracking) — see the function
+    definitions above. Anything else fires this trap. ``adaptive_run``'s
+    cascade recognizes the message and treats it as "stage not
+    MPS-onboarded yet" so the cascade can fall back to CPU.
+
+    Only fires for names that aren't already module attributes (Python
+    only consults ``__getattr__`` after the normal lookup fails).
+    """
+    raise NotImplementedError(
+        f"torch_xp.{name} is not implemented. The MPS shim only covers the "
+        f"union of ops used by the four onboarded stages (filtering, "
+        f"labelling, networking, hu_tracking). If you're onboarding a new "
+        f"stage to MPS, add the op here. See PRD #140."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ docs = [
 dev = [
     "pytest",
 ]
+mps = [
+    "torch",
+]
 
 [build-system]
 requires = ["setuptools>=64", "setuptools-scm>=8", "wheel"]
@@ -63,7 +66,8 @@ required-environments = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = ["-ra", "--strict-markers", "-m", "not benchmark"]
+addopts = ["-ra", "--strict-markers", "-m", "not benchmark and not mps"]
 markers = [
     "benchmark: timing-sensitive perf tests; opt in with `-m benchmark`",
+    "mps: torch+MPS hardware tests; opt in with `-m mps` (requires Mac + torch+MPS)",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,10 @@ dev = [
     "pytest",
 ]
 mps = [
-    "torch",
+    # MPS is Apple Silicon only; constrain to Darwin so uv's required-environments
+    # resolution doesn't force a torch wheel for Linux/Windows where the extra
+    # has no useful effect (the cuda path still goes through cupy, not torch).
+    "torch; sys_platform == 'darwin'",
 ]
 
 [build-system]

--- a/tests/test_adaptive_run.py
+++ b/tests/test_adaptive_run.py
@@ -1,0 +1,436 @@
+"""Tests for the MPS-aware extensions to ``nellie.utils.adaptive_run``.
+
+Covers the slice 1 acceptance criteria:
+
+- ``device_cascade(device) → list[str]`` returns the right order per
+  platform / requested device.
+- ``resolve_backend("mps")`` returns the torch shim tuple (mocked).
+- ``resolve_backend("gpu")`` is platform-aware (Mac → MPS, else CUDA).
+- ``normalize_device`` accepts ``"mps"``.
+- ``is_oom_error`` recognizes the MPS string.
+- ``is_gpu_unavailable_error`` recognizes the torch+MPS unavailable patterns.
+- ``get_mps_free_bytes`` returns sensible values when probes are mocked.
+- ``_MEMORY_HEADROOM_BY_DEVICE`` is 0.7 for CUDA, 0.5 for MPS.
+- Cascade callers honor ``device="mps"`` even when the stage is not
+  MPS-onboarded (graceful CPU fallback for hierarchical / voxel_reassignment).
+
+All tests run without torch installed (we mock the import path).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from contextlib import contextmanager
+from unittest import mock
+
+import pytest
+
+from nellie.utils import adaptive_run
+
+
+# -----------------------------------------------------------------------------
+# Helpers — mock torch availability
+# -----------------------------------------------------------------------------
+
+
+@contextmanager
+def _mock_torch_with_mps(*, available: bool, built: bool = True):
+    """Inject a fake torch module exposing the MPS-availability surface."""
+    real_torch = sys.modules.get("torch")
+    real_xp = sys.modules.get("nellie.utils.torch_xp")
+    real_ndi = sys.modules.get("nellie.utils.torch_ndi")
+
+    fake_torch = types.SimpleNamespace()
+    fake_backends = types.SimpleNamespace()
+    fake_mps = types.SimpleNamespace(
+        is_available=lambda: available,
+        is_built=lambda: built,
+        driver_allocated_memory=lambda: 0,
+    )
+    fake_backends.mps = fake_mps
+    fake_torch.backends = fake_backends
+    fake_torch.mps = fake_mps
+
+    sys.modules["torch"] = fake_torch
+    fake_xp = types.SimpleNamespace(__name__="nellie.utils.torch_xp")
+    fake_xp_ndi = types.SimpleNamespace(__name__="nellie.utils.torch_ndi")
+    sys.modules["nellie.utils.torch_xp"] = fake_xp
+    sys.modules["nellie.utils.torch_ndi"] = fake_xp_ndi
+    try:
+        yield fake_torch
+    finally:
+        if real_torch is None:
+            sys.modules.pop("torch", None)
+        else:
+            sys.modules["torch"] = real_torch
+        if real_xp is None:
+            sys.modules.pop("nellie.utils.torch_xp", None)
+        else:
+            sys.modules["nellie.utils.torch_xp"] = real_xp
+        if real_ndi is None:
+            sys.modules.pop("nellie.utils.torch_ndi", None)
+        else:
+            sys.modules["nellie.utils.torch_ndi"] = real_ndi
+
+
+@contextmanager
+def _mock_no_torch():
+    """Force ``import torch`` to raise ModuleNotFoundError."""
+    real_torch = sys.modules.pop("torch", None)
+    real_xp = sys.modules.pop("nellie.utils.torch_xp", None)
+    real_ndi = sys.modules.pop("nellie.utils.torch_ndi", None)
+    sys.modules["torch"] = None  # forces ImportError on subsequent import
+    try:
+        yield
+    finally:
+        sys.modules.pop("torch", None)
+        if real_torch is not None:
+            sys.modules["torch"] = real_torch
+        if real_xp is not None:
+            sys.modules["nellie.utils.torch_xp"] = real_xp
+        if real_ndi is not None:
+            sys.modules["nellie.utils.torch_ndi"] = real_ndi
+
+
+# -----------------------------------------------------------------------------
+# normalize_device
+# -----------------------------------------------------------------------------
+
+
+def test_normalize_device_accepts_mps() -> None:
+    assert adaptive_run.normalize_device("mps") == "mps"
+
+
+def test_normalize_device_accepts_existing_values() -> None:
+    assert adaptive_run.normalize_device("auto") == "auto"
+    assert adaptive_run.normalize_device("cpu") == "cpu"
+    assert adaptive_run.normalize_device("gpu") == "gpu"
+    assert adaptive_run.normalize_device("cuda") == "gpu"  # alias
+
+
+def test_normalize_device_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="Unsupported device"):
+        adaptive_run.normalize_device("bogus")
+
+
+def test_normalize_device_default_is_auto() -> None:
+    assert adaptive_run.normalize_device(None) == "auto"
+
+
+# -----------------------------------------------------------------------------
+# device_cascade
+# -----------------------------------------------------------------------------
+
+
+def test_device_cascade_cpu() -> None:
+    assert adaptive_run.device_cascade("cpu") == ["cpu"]
+
+
+def test_device_cascade_explicit_mps_pinned() -> None:
+    """``device="mps"`` is an explicit pin; no CPU fallback."""
+    assert adaptive_run.device_cascade("mps") == ["mps"]
+
+
+def test_device_cascade_explicit_cuda_pinned() -> None:
+    """``device="cuda"`` is an explicit pin to CuPy; no fallback."""
+    assert adaptive_run.device_cascade("cuda") == ["gpu"]
+
+
+def test_device_cascade_invalid_raises() -> None:
+    with pytest.raises(ValueError, match="unsupported device"):
+        adaptive_run.device_cascade("bogus")
+
+
+def test_device_cascade_auto_on_mac_with_mps() -> None:
+    with mock.patch.object(adaptive_run, "_is_darwin", return_value=True), \
+         mock.patch.object(adaptive_run, "mps_available", return_value=True):
+        assert adaptive_run.device_cascade("auto") == ["mps", "cpu"]
+
+
+def test_device_cascade_auto_on_mac_without_mps() -> None:
+    with mock.patch.object(adaptive_run, "_is_darwin", return_value=True), \
+         mock.patch.object(adaptive_run, "mps_available", return_value=False):
+        assert adaptive_run.device_cascade("auto") == ["cpu"]
+
+
+def test_device_cascade_auto_on_linux_with_cuda() -> None:
+    with mock.patch.object(adaptive_run, "_is_darwin", return_value=False), \
+         mock.patch.object(adaptive_run, "gpu_available", return_value=True):
+        assert adaptive_run.device_cascade("auto") == ["gpu", "cpu"]
+
+
+def test_device_cascade_auto_on_linux_without_cuda() -> None:
+    with mock.patch.object(adaptive_run, "_is_darwin", return_value=False), \
+         mock.patch.object(adaptive_run, "gpu_available", return_value=False):
+        assert adaptive_run.device_cascade("auto") == ["cpu"]
+
+
+def test_device_cascade_gpu_on_mac_is_mps() -> None:
+    """``device="gpu"`` is platform-aware: MPS on Darwin."""
+    with mock.patch.object(adaptive_run, "_is_darwin", return_value=True), \
+         mock.patch.object(adaptive_run, "mps_available", return_value=True):
+        assert adaptive_run.device_cascade("gpu") == ["mps", "cpu"]
+
+
+def test_device_cascade_gpu_on_linux_is_cuda() -> None:
+    with mock.patch.object(adaptive_run, "_is_darwin", return_value=False), \
+         mock.patch.object(adaptive_run, "gpu_available", return_value=True):
+        assert adaptive_run.device_cascade("gpu") == ["gpu", "cpu"]
+
+
+# -----------------------------------------------------------------------------
+# resolve_backend (with mocked torch)
+# -----------------------------------------------------------------------------
+
+
+def test_resolve_backend_mps_with_torch_returns_shim_tuple() -> None:
+    with _mock_torch_with_mps(available=True):
+        xp, ndi, device_type = adaptive_run.resolve_backend("mps")
+    assert device_type == "mps"
+    assert xp.__name__ == "nellie.utils.torch_xp"
+    assert ndi.__name__ == "nellie.utils.torch_ndi"
+
+
+def test_resolve_backend_mps_without_torch_raises() -> None:
+    with _mock_no_torch(), pytest.raises(RuntimeError, match="MPS backend requested"):
+        adaptive_run.resolve_backend("mps")
+
+
+def test_resolve_backend_mps_when_torch_lacks_mps_raises() -> None:
+    """torch installed but MPS not built/available → require=True raises."""
+    with _mock_torch_with_mps(available=False), pytest.raises(RuntimeError):
+        adaptive_run.resolve_backend("mps")
+
+
+def test_resolve_backend_gpu_on_mac_resolves_to_mps() -> None:
+    with mock.patch.object(adaptive_run, "_is_darwin", return_value=True), \
+         _mock_torch_with_mps(available=True):
+        xp, ndi, device_type = adaptive_run.resolve_backend("gpu")
+    assert device_type == "mps"
+
+
+def test_resolve_backend_auto_on_mac_with_mps_resolves_to_mps() -> None:
+    with mock.patch.object(adaptive_run, "_is_darwin", return_value=True), \
+         _mock_torch_with_mps(available=True):
+        xp, ndi, device_type = adaptive_run.resolve_backend("auto")
+    assert device_type == "mps"
+
+
+def test_resolve_backend_auto_on_mac_without_mps_falls_back_to_cpu() -> None:
+    with mock.patch.object(adaptive_run, "_is_darwin", return_value=True), \
+         _mock_no_torch():
+        xp, ndi, device_type = adaptive_run.resolve_backend("auto")
+    assert device_type == "cpu"
+
+
+def test_resolve_backend_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="Unsupported device"):
+        adaptive_run.resolve_backend("bogus")
+
+
+# -----------------------------------------------------------------------------
+# Memory headroom lookup
+# -----------------------------------------------------------------------------
+
+
+def test_memory_headroom_cuda_is_seven_tenths() -> None:
+    assert adaptive_run._MEMORY_HEADROOM_BY_DEVICE["cuda"] == pytest.approx(0.7)
+
+
+def test_memory_headroom_mps_is_one_half() -> None:
+    assert adaptive_run._MEMORY_HEADROOM_BY_DEVICE["mps"] == pytest.approx(0.5)
+
+
+def test_memory_headroom_lookup_falls_back_for_unknown() -> None:
+    """Unknown device names fall back to the legacy CUDA value."""
+    assert adaptive_run._headroom("nonexistent_device") == adaptive_run._MEMORY_HEADROOM
+
+
+def test_memory_headroom_legacy_alias_unchanged() -> None:
+    """The legacy scalar should still equal the CUDA value (back-compat)."""
+    assert adaptive_run._MEMORY_HEADROOM == pytest.approx(0.7)
+
+
+# -----------------------------------------------------------------------------
+# get_mps_free_bytes
+# -----------------------------------------------------------------------------
+
+
+def test_get_mps_free_bytes_returns_none_without_torch() -> None:
+    with _mock_no_torch():
+        assert adaptive_run.get_mps_free_bytes() is None
+
+
+def test_get_mps_free_bytes_subtracts_allocated() -> None:
+    with _mock_torch_with_mps(available=True) as fake_torch, \
+         mock.patch.object(adaptive_run, "get_cpu_available_bytes", return_value=1_000_000_000):
+        fake_torch.mps.driver_allocated_memory = lambda: 250_000_000
+        result = adaptive_run.get_mps_free_bytes()
+    assert result == 750_000_000
+
+
+def test_get_mps_free_bytes_returns_none_when_cpu_probe_fails() -> None:
+    with _mock_torch_with_mps(available=True), \
+         mock.patch.object(adaptive_run, "get_cpu_available_bytes", return_value=None):
+        result = adaptive_run.get_mps_free_bytes()
+    assert result is None
+
+
+def test_get_mps_free_bytes_honors_high_watermark_env(monkeypatch) -> None:
+    monkeypatch.setenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.5")
+    with _mock_torch_with_mps(available=True) as fake_torch, \
+         mock.patch.object(adaptive_run, "get_cpu_available_bytes", return_value=1_000_000_000):
+        fake_torch.mps.driver_allocated_memory = lambda: 0
+        result = adaptive_run.get_mps_free_bytes()
+    assert result == 500_000_000  # capped by watermark
+
+
+def test_get_mps_free_bytes_floor_is_zero() -> None:
+    """When allocated > available, free bytes can't go negative."""
+    with _mock_torch_with_mps(available=True) as fake_torch, \
+         mock.patch.object(adaptive_run, "get_cpu_available_bytes", return_value=100):
+        fake_torch.mps.driver_allocated_memory = lambda: 1000
+        result = adaptive_run.get_mps_free_bytes()
+    assert result == 0
+
+
+# -----------------------------------------------------------------------------
+# Error classifiers
+# -----------------------------------------------------------------------------
+
+
+def test_is_oom_error_matches_mps_string() -> None:
+    exc = RuntimeError("MPS backend out of memory (Total system memory: 16 GB)")
+    assert adaptive_run.is_oom_error(exc)
+
+
+def test_is_oom_error_still_matches_legacy_strings() -> None:
+    """Don't regress the existing CuPy / generic patterns."""
+    assert adaptive_run.is_oom_error(RuntimeError("Out of memory: allocation"))
+    assert adaptive_run.is_oom_error(MemoryError())
+
+
+def test_is_oom_error_negatives() -> None:
+    assert not adaptive_run.is_oom_error(RuntimeError("device side assert"))
+    assert not adaptive_run.is_oom_error(ValueError("unrelated"))
+
+
+def test_is_gpu_unavailable_error_matches_mps_unavailable() -> None:
+    """The string raised by ``try_import_torch_mps(require=True)``."""
+    exc = RuntimeError(
+        "MPS backend requested but no MPS device is available "
+        "(torch.backends.mps.is_available() is False)."
+    )
+    assert adaptive_run.is_gpu_unavailable_error(exc)
+
+
+def test_is_gpu_unavailable_error_matches_torch_missing() -> None:
+    exc = RuntimeError(
+        "MPS backend requested but torch is not installed. "
+        "Install with `pip install 'nellie[mps]'`."
+    )
+    assert adaptive_run.is_gpu_unavailable_error(exc)
+
+
+def test_is_gpu_unavailable_error_matches_module_not_found() -> None:
+    exc = ModuleNotFoundError(name="torch")
+    assert adaptive_run.is_gpu_unavailable_error(exc)
+
+
+def test_is_gpu_unavailable_error_still_matches_legacy_strings() -> None:
+    """Don't regress the existing CuPy patterns."""
+    assert adaptive_run.is_gpu_unavailable_error(
+        RuntimeError("GPU backend requested but CuPy is not installed.")
+    )
+    assert adaptive_run.is_gpu_unavailable_error(ModuleNotFoundError(name="cupy"))
+
+
+# -----------------------------------------------------------------------------
+# free_gpu_memory honors torch_xp
+# -----------------------------------------------------------------------------
+
+
+def test_free_gpu_memory_calls_torch_mps_empty_cache() -> None:
+    """When ``xp`` is the torch_xp shim, free_gpu_memory should call torch.mps.empty_cache."""
+    with _mock_torch_with_mps(available=True) as fake_torch:
+        called = []
+        fake_torch.mps.empty_cache = lambda: called.append(True)
+        fake_xp = types.SimpleNamespace(__name__="nellie.utils.torch_xp")
+        adaptive_run.free_gpu_memory(fake_xp)
+    assert called == [True]
+
+
+def test_free_gpu_memory_noop_on_numpy() -> None:
+    import numpy as np
+    # Should not raise.
+    adaptive_run.free_gpu_memory(np)
+
+
+# -----------------------------------------------------------------------------
+# Cascade-caller refactor: stages handle device="mps" gracefully
+# -----------------------------------------------------------------------------
+
+
+def test_filter_construction_with_device_mps_no_torch_raises_clean_error(make_imageinfo_2d) -> None:
+    """User on a Mac without torch installed who passes ``device="mps"``
+    explicitly hits the cascade's "GPU unavailable" path. ``device="mps"``
+    is an explicit pin (no CPU fallback) — Filter's constructor calls
+    ``resolve_backend(device)`` eagerly, so the error surfaces at
+    construction. We verify the error is recognized by ``is_gpu_unavailable_error``
+    so the cascade in :meth:`Filter.run` would react correctly if reached.
+    """
+    from nellie.segmentation.filtering import Filter, FrangiConfig
+
+    info = make_imageinfo_2d()
+    config = FrangiConfig(device="mps")
+    with _mock_no_torch():
+        with pytest.raises(RuntimeError) as excinfo:
+            Filter(info, config, num_t=2)
+        assert adaptive_run.is_gpu_unavailable_error(excinfo.value)
+
+
+def test_hierarchical_unimplemented_op_classifies_as_unavailable() -> None:
+    """A non-onboarded stage hitting ``xp.unimplemented_op`` on MPS should
+    raise ``NotImplementedError`` from the shim with a recognizable
+    message — that error is then classified as "GPU unavailable" so the
+    cascade falls back to CPU rather than crashing the run.
+    """
+    # Simulate what would happen inside Hierarchy._run_hierarchy if it
+    # called an op the torch_xp shim doesn't implement.
+    exc = NotImplementedError(
+        "torch_xp.cumsum_along_some_axis is not implemented. The MPS shim "
+        "only covers the union of ops used by the four onboarded stages..."
+    )
+    assert adaptive_run.is_gpu_unavailable_error(exc)
+
+
+def test_unrelated_not_implemented_does_not_classify_as_unavailable() -> None:
+    """Avoid false-positive: a NotImplementedError that ISN'T from the shim
+    must not be misclassified as a backend-unavailable signal."""
+    exc = NotImplementedError("Some unrelated thing isn't ready")
+    assert not adaptive_run.is_gpu_unavailable_error(exc)
+
+
+# -----------------------------------------------------------------------------
+# All seven stages: their Configs accept device="mps" without raising.
+# -----------------------------------------------------------------------------
+
+
+def test_all_stage_configs_accept_device_mps() -> None:
+    """Every stage Config must accept ``device="mps"`` since this slice
+    makes "mps" a canonical device value via ``normalize_device``."""
+    from nellie.segmentation.filtering import FrangiConfig
+    from nellie.segmentation.labelling import LabelConfig
+    from nellie.segmentation.networking import NetworkConfig
+    from nellie.segmentation.mocap_marking import MarkersConfig
+    from nellie.tracking.hu_tracking import HuMomentTrackingConfig
+    from nellie.tracking.voxel_reassignment import VoxelReassignerConfig
+    from nellie.feature_extraction.hierarchical import HierarchyConfig
+
+    for cls in (
+        FrangiConfig, LabelConfig, NetworkConfig, MarkersConfig,
+        HuMomentTrackingConfig, VoxelReassignerConfig, HierarchyConfig,
+    ):
+        cfg = cls(device="mps")
+        assert cfg.device == "mps"

--- a/tests/test_torch_ndi.py
+++ b/tests/test_torch_ndi.py
@@ -1,0 +1,294 @@
+"""Always-on contract tests for the ``nellie.utils.torch_ndi`` shim.
+
+Compares every implemented op to its scipy.ndimage reference on small
+random inputs. The tests use torch on CPU (no MPS hardware needed). When
+torch isn't installed the whole module skips, so default ``pytest`` stays
+green on installs that opted out of the ``mps`` extra.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.ndimage as scipy_ndi
+
+
+pytest.importorskip("torch")
+
+import torch  # noqa: E402
+
+from nellie.utils import torch_ndi  # noqa: E402
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _to_numpy(t):
+    if isinstance(t, torch.Tensor):
+        return t.detach().cpu().numpy()
+    return np.asarray(t)
+
+
+def _close(actual, expected, rtol=1e-3, atol=1e-3):
+    np.testing.assert_allclose(_to_numpy(actual), expected, rtol=rtol, atol=atol)
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(seed=42)
+
+
+@pytest.fixture
+def img_2d(rng):
+    arr = rng.standard_normal((10, 12)).astype(np.float32)
+    return arr, torch.from_numpy(arr)
+
+
+@pytest.fixture
+def img_3d(rng):
+    arr = rng.standard_normal((6, 8, 10)).astype(np.float32)
+    return arr, torch.from_numpy(arr)
+
+
+# -----------------------------------------------------------------------------
+# gaussian_filter
+# -----------------------------------------------------------------------------
+
+
+def test_gaussian_filter_2d_scalar_sigma(img_2d) -> None:
+    a_np, a_t = img_2d
+    out = torch_ndi.gaussian_filter(a_t, sigma=1.5, mode="reflect")
+    expected = scipy_ndi.gaussian_filter(a_np, sigma=1.5, mode="reflect")
+    _close(out, expected, rtol=1e-3, atol=1e-3)
+
+
+def test_gaussian_filter_2d_per_axis_sigma(img_2d) -> None:
+    a_np, a_t = img_2d
+    sigmas = (1.0, 2.0)
+    out = torch_ndi.gaussian_filter(a_t, sigma=sigmas, mode="reflect")
+    expected = scipy_ndi.gaussian_filter(a_np, sigma=sigmas, mode="reflect")
+    _close(out, expected, rtol=1e-3, atol=1e-3)
+
+
+def test_gaussian_filter_3d_per_axis_sigma(img_3d) -> None:
+    a_np, a_t = img_3d
+    sigmas = (1.0, 1.5, 2.0)
+    out = torch_ndi.gaussian_filter(a_t, sigma=sigmas, mode="reflect")
+    expected = scipy_ndi.gaussian_filter(a_np, sigma=sigmas, mode="reflect")
+    _close(out, expected, rtol=1e-3, atol=1e-3)
+
+
+def test_gaussian_filter_constant_mode(img_2d) -> None:
+    a_np, a_t = img_2d
+    out = torch_ndi.gaussian_filter(a_t, sigma=1.0, mode="constant", cval=0.0)
+    expected = scipy_ndi.gaussian_filter(a_np, sigma=1.0, mode="constant", cval=0.0)
+    _close(out, expected, rtol=1e-3, atol=1e-3)
+
+
+def test_gaussian_filter_with_output_arg(img_2d) -> None:
+    """Mirrors Filter._compute_vesselness_chunkwise's incremental-sigma update."""
+    a_np, a_t = img_2d
+    out_buf = a_t.clone()
+    returned = torch_ndi.gaussian_filter(out_buf, sigma=1.0, output=out_buf, mode="reflect")
+    expected = scipy_ndi.gaussian_filter(a_np, sigma=1.0, mode="reflect")
+    _close(out_buf, expected, rtol=1e-3, atol=1e-3)
+    # scipy's contract: returned tensor IS the output buffer.
+    assert returned is out_buf
+
+
+def test_gaussian_filter_zero_sigma_is_passthrough() -> None:
+    a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    out = torch_ndi.gaussian_filter(torch.from_numpy(a), sigma=0)
+    _close(out, a)
+
+
+# -----------------------------------------------------------------------------
+# uniform_filter
+# -----------------------------------------------------------------------------
+
+
+def test_uniform_filter_2d(img_2d) -> None:
+    a_np, a_t = img_2d
+    out = torch_ndi.uniform_filter(a_t, size=3, mode="reflect")
+    expected = scipy_ndi.uniform_filter(a_np, size=3, mode="reflect")
+    _close(out, expected, rtol=1e-3, atol=1e-3)
+
+
+def test_uniform_filter_3d(img_3d) -> None:
+    a_np, a_t = img_3d
+    out = torch_ndi.uniform_filter(a_t, size=3, mode="reflect")
+    expected = scipy_ndi.uniform_filter(a_np, size=3, mode="reflect")
+    _close(out, expected, rtol=1e-3, atol=1e-3)
+
+
+def test_uniform_filter_per_axis_size(img_2d) -> None:
+    a_np, a_t = img_2d
+    out = torch_ndi.uniform_filter(a_t, size=(3, 5), mode="reflect")
+    expected = scipy_ndi.uniform_filter(a_np, size=(3, 5), mode="reflect")
+    _close(out, expected, rtol=1e-3, atol=1e-3)
+
+
+# -----------------------------------------------------------------------------
+# convolve
+# -----------------------------------------------------------------------------
+
+
+def test_convolve_2d_symmetric_kernel(img_2d) -> None:
+    """The networking stage uses ``ones((3, 3))`` — a symmetric kernel."""
+    a_np, a_t = img_2d
+    weights = np.ones((3, 3), dtype=np.float32)
+    out = torch_ndi.convolve(a_t, torch.from_numpy(weights), mode="constant", cval=0.0)
+    expected = scipy_ndi.convolve(a_np, weights, mode="constant", cval=0.0)
+    _close(out, expected, rtol=1e-3, atol=1e-3)
+
+
+def test_convolve_3d_symmetric_kernel(img_3d) -> None:
+    """networking 3D path: ``ones((3, 3, 3))``."""
+    a_np, a_t = img_3d
+    weights = np.ones((3, 3, 3), dtype=np.float32)
+    out = torch_ndi.convolve(a_t, torch.from_numpy(weights), mode="constant", cval=0.0)
+    expected = scipy_ndi.convolve(a_np, weights, mode="constant", cval=0.0)
+    _close(out, expected, rtol=1e-3, atol=1e-3)
+
+
+def test_convolve_2d_asymmetric_kernel_matches_scipy(rng) -> None:
+    """Asymmetric kernel verifies the scipy "true convolution" semantics
+    (we pre-flip the kernel before forwarding to torch's correlation)."""
+    a = rng.standard_normal((10, 12)).astype(np.float32)
+    weights = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float32)
+    out = torch_ndi.convolve(torch.from_numpy(a), torch.from_numpy(weights),
+                             mode="constant", cval=0.0)
+    expected = scipy_ndi.convolve(a, weights, mode="constant", cval=0.0)
+    _close(out, expected, rtol=1e-3, atol=1e-3)
+
+
+# -----------------------------------------------------------------------------
+# gaussian_laplace
+# -----------------------------------------------------------------------------
+
+
+def test_gaussian_laplace_2d(img_2d) -> None:
+    a_np, a_t = img_2d
+    out = torch_ndi.gaussian_laplace(a_t, sigma=1.0, mode="reflect")
+    expected = scipy_ndi.gaussian_laplace(a_np, sigma=1.0, mode="reflect")
+    _close(out, expected, rtol=1e-2, atol=1e-2)
+
+
+def test_gaussian_laplace_3d(img_3d) -> None:
+    a_np, a_t = img_3d
+    out = torch_ndi.gaussian_laplace(a_t, sigma=1.0, mode="reflect")
+    expected = scipy_ndi.gaussian_laplace(a_np, sigma=1.0, mode="reflect")
+    _close(out, expected, rtol=1e-2, atol=1e-2)
+
+
+# -----------------------------------------------------------------------------
+# maximum_filter
+# -----------------------------------------------------------------------------
+
+
+def test_maximum_filter_2d(img_2d) -> None:
+    a_np, a_t = img_2d
+    out = torch_ndi.maximum_filter(a_t, size=3, mode="constant", cval=-np.inf)
+    expected = scipy_ndi.maximum_filter(a_np, size=3, mode="constant", cval=-np.inf)
+    _close(out, expected, atol=1e-5)
+
+
+def test_maximum_filter_3d(img_3d) -> None:
+    a_np, a_t = img_3d
+    out = torch_ndi.maximum_filter(a_t, size=3, mode="constant", cval=-np.inf)
+    expected = scipy_ndi.maximum_filter(a_np, size=3, mode="constant", cval=-np.inf)
+    _close(out, expected, atol=1e-5)
+
+
+def test_maximum_filter_per_axis_size(img_2d) -> None:
+    a_np, a_t = img_2d
+    out = torch_ndi.maximum_filter(a_t, size=(3, 5), mode="constant", cval=-np.inf)
+    expected = scipy_ndi.maximum_filter(a_np, size=(3, 5), mode="constant", cval=-np.inf)
+    _close(out, expected, atol=1e-5)
+
+
+def test_maximum_filter_with_output_arg(img_2d) -> None:
+    """Mirrors hu_tracking's ``ndi.maximum_filter(..., output=...)`` call."""
+    a_np, a_t = img_2d
+    out_buf = a_t.clone()
+    returned = torch_ndi.maximum_filter(
+        out_buf, size=3, output=out_buf, mode="reflect"
+    )
+    expected = scipy_ndi.maximum_filter(a_np, size=3, mode="reflect")
+    _close(out_buf, expected, atol=1e-5)
+    assert returned is out_buf
+
+
+# -----------------------------------------------------------------------------
+# minimum_filter
+# -----------------------------------------------------------------------------
+
+
+def test_minimum_filter_2d(img_2d) -> None:
+    a_np, a_t = img_2d
+    out = torch_ndi.minimum_filter(a_t, size=3, mode="constant", cval=np.inf)
+    expected = scipy_ndi.minimum_filter(a_np, size=3, mode="constant", cval=np.inf)
+    _close(out, expected, atol=1e-5)
+
+
+def test_minimum_filter_3d(img_3d) -> None:
+    a_np, a_t = img_3d
+    out = torch_ndi.minimum_filter(a_t, size=3, mode="constant", cval=np.inf)
+    expected = scipy_ndi.minimum_filter(a_np, size=3, mode="constant", cval=np.inf)
+    _close(out, expected, atol=1e-5)
+
+
+# -----------------------------------------------------------------------------
+# Structural ops (CPU round-trip)
+# -----------------------------------------------------------------------------
+
+
+def test_binary_opening_2d() -> None:
+    a = np.zeros((10, 10), dtype=bool)
+    a[2:8, 2:8] = True
+    a[5, 5] = False  # carve a hole
+    out = torch_ndi.binary_opening(torch.from_numpy(a))
+    expected = scipy_ndi.binary_opening(a)
+    np.testing.assert_array_equal(_to_numpy(out), expected)
+
+
+def test_binary_opening_3d() -> None:
+    a = np.zeros((6, 6, 6), dtype=bool)
+    a[1:5, 1:5, 1:5] = True
+    out = torch_ndi.binary_opening(torch.from_numpy(a))
+    expected = scipy_ndi.binary_opening(a)
+    np.testing.assert_array_equal(_to_numpy(out), expected)
+
+
+def test_binary_fill_holes_2d() -> None:
+    a = np.zeros((10, 10), dtype=bool)
+    a[2:8, 2:8] = True
+    a[4:6, 4:6] = False
+    out = torch_ndi.binary_fill_holes(torch.from_numpy(a))
+    expected = scipy_ndi.binary_fill_holes(a)
+    np.testing.assert_array_equal(_to_numpy(out), expected)
+
+
+def test_label_2d() -> None:
+    a = np.zeros((10, 10), dtype=bool)
+    a[1:3, 1:3] = True
+    a[6:8, 6:8] = True
+    labels, n = torch_ndi.label(torch.from_numpy(a))
+    expected_labels, expected_n = scipy_ndi.label(a)
+    np.testing.assert_array_equal(_to_numpy(labels), expected_labels)
+    assert n == expected_n
+
+
+def test_label_3d_with_structure() -> None:
+    a = np.zeros((6, 6, 6), dtype=bool)
+    a[1:3, 1:3, 1:3] = True
+    a[4:6, 4:6, 4:6] = True
+    structure = np.ones((3, 3, 3), dtype=bool)
+    labels, n = torch_ndi.label(
+        torch.from_numpy(a), structure=torch.from_numpy(structure)
+    )
+    expected_labels, expected_n = scipy_ndi.label(a, structure=structure)
+    np.testing.assert_array_equal(_to_numpy(labels), expected_labels)
+    assert n == expected_n

--- a/tests/test_torch_xp.py
+++ b/tests/test_torch_xp.py
@@ -1,0 +1,543 @@
+"""Always-on contract tests for the ``nellie.utils.torch_xp`` shim.
+
+These compare every implemented op to its numpy reference on small random
+inputs. They DON'T require an MPS device — they run torch on CPU (which
+is enough to verify the shim's API contract). When torch isn't installed
+the whole module skips, so default ``pytest`` stays green on installs
+that opted out of the ``mps`` extra.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+
+
+pytest.importorskip("torch")
+
+# Imported lazily after the importorskip so the module-load price is only
+# paid when torch is present.
+import torch  # noqa: E402
+
+from nellie.utils import torch_xp  # noqa: E402
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _to_numpy(t):
+    """Convert any torch.Tensor to numpy on CPU; pass numpy through unchanged."""
+    if isinstance(t, torch.Tensor):
+        return t.detach().cpu().numpy()
+    return np.asarray(t)
+
+
+def _close(actual, expected, rtol=1e-5, atol=1e-6):
+    np.testing.assert_allclose(_to_numpy(actual), expected, rtol=rtol, atol=atol)
+
+
+# -----------------------------------------------------------------------------
+# Aliases / dtype constants / class proxy
+# -----------------------------------------------------------------------------
+
+
+def test_newaxis_is_none() -> None:
+    """``xp.newaxis`` is ``None`` in both numpy and torch indexing."""
+    assert torch_xp.newaxis is None
+
+
+def test_inf_is_math_inf() -> None:
+    import math
+    assert torch_xp.inf == math.inf
+
+
+def test_ndarray_isinstance_matches_torch_tensor() -> None:
+    t = torch.zeros(3)
+    assert isinstance(t, torch_xp.ndarray)
+    assert not isinstance([1, 2, 3], torch_xp.ndarray)
+    assert not isinstance(np.zeros(3), torch_xp.ndarray)
+
+
+def test_ndarray_construction_raises() -> None:
+    with pytest.raises(TypeError, match="proxy"):
+        torch_xp.ndarray()
+
+
+def test_float32_resolves() -> None:
+    assert torch_xp.float32 == torch.float32
+
+
+def test_float16_resolves() -> None:
+    assert torch_xp.float16 == torch.float16
+
+
+def test_float64_silently_coerces_to_float32(caplog) -> None:
+    """Per the slice contract, float64 silently maps to float32 (one log msg)."""
+    # Reset the one-time flag so the next access re-emits the notice.
+    torch_xp._FLOAT64_NOTICE_EMITTED = False
+    with caplog.at_level(logging.INFO, logger="nellie.utils.torch_xp"):
+        # Touch the proxy to trigger the announcement.
+        resolved = torch_xp.float64._resolve()
+    assert resolved == torch.float32
+    assert any("float64 → float32 coercion" in rec.getMessage() for rec in caplog.records)
+
+
+def test_zeros_with_explicit_float64_dtype_returns_float32(caplog) -> None:
+    """Explicit ``zeros(shape, dtype=xp.float64)`` should also coerce."""
+    torch_xp._FLOAT64_NOTICE_EMITTED = False
+    with caplog.at_level(logging.INFO, logger="nellie.utils.torch_xp"):
+        out = torch_xp.zeros((4,), dtype=torch_xp.float64)
+    assert out.dtype == torch.float32
+
+
+# -----------------------------------------------------------------------------
+# Construction ops
+# -----------------------------------------------------------------------------
+
+
+def test_zeros() -> None:
+    a = torch_xp.zeros((2, 3))
+    assert a.shape == (2, 3)
+    assert a.dtype == torch.float32
+    np.testing.assert_array_equal(_to_numpy(a), np.zeros((2, 3)))
+
+
+def test_zeros_int_shape() -> None:
+    a = torch_xp.zeros(5)
+    assert a.shape == (5,)
+
+
+def test_zeros_with_bool_dtype() -> None:
+    a = torch_xp.zeros((3,), dtype=bool)
+    assert a.dtype == torch.bool
+
+
+def test_zeros_like() -> None:
+    src = torch.ones((2, 3))
+    a = torch_xp.zeros_like(src)
+    assert a.shape == src.shape
+    assert a.dtype == src.dtype
+    assert torch.all(a == 0)
+
+
+def test_zeros_like_with_dtype_override() -> None:
+    src = torch.ones((2, 3))
+    a = torch_xp.zeros_like(src, dtype=bool)
+    assert a.dtype == torch.bool
+
+
+def test_ones() -> None:
+    a = torch_xp.ones((2, 3))
+    np.testing.assert_array_equal(_to_numpy(a), np.ones((2, 3)))
+
+
+def test_ones_like() -> None:
+    src = torch.zeros((2, 3))
+    a = torch_xp.ones_like(src)
+    assert torch.all(a == 1)
+
+
+def test_full_like() -> None:
+    src = torch.zeros((4,))
+    a = torch_xp.full_like(src, 7.0)
+    assert torch.all(a == 7)
+
+
+def test_arange_stop_only() -> None:
+    _close(torch_xp.arange(5), np.arange(5))
+
+
+def test_arange_start_stop() -> None:
+    _close(torch_xp.arange(2, 7), np.arange(2, 7))
+
+
+def test_arange_with_dtype() -> None:
+    out = torch_xp.arange(3, dtype=torch.int32)
+    assert out.dtype == torch.int32
+
+
+def test_asarray_passthrough() -> None:
+    src = torch.zeros((2, 3))
+    out = torch_xp.asarray(src)
+    assert out is src
+
+
+def test_asarray_from_numpy() -> None:
+    arr = np.arange(6).reshape(2, 3).astype(np.float32)
+    out = torch_xp.asarray(arr)
+    assert isinstance(out, torch.Tensor)
+    np.testing.assert_array_equal(_to_numpy(out), arr)
+
+
+def test_asarray_from_numpy_with_dtype() -> None:
+    out = torch_xp.asarray([1.0, 2.0, 3.0], dtype=torch.float32)
+    assert out.dtype == torch.float32
+
+
+def test_meshgrid_xy_default() -> None:
+    """numpy meshgrid defaults to 'xy' indexing."""
+    x = torch.arange(3, dtype=torch.float32)
+    y = torch.arange(4, dtype=torch.float32)
+    xx, yy = torch_xp.meshgrid(x, y)
+    np_xx, np_yy = np.meshgrid(np.arange(3.0), np.arange(4.0))
+    _close(xx, np_xx)
+    _close(yy, np_yy)
+
+
+# -----------------------------------------------------------------------------
+# Element-wise math
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(seed=12345)
+
+
+@pytest.fixture
+def small_random(rng):
+    a = rng.standard_normal((4, 5)).astype(np.float32)
+    return a, torch.from_numpy(a)
+
+
+def test_abs(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.abs(a_t), np.abs(a_np))
+
+
+def test_sqrt(rng) -> None:
+    a = rng.uniform(0.1, 10.0, size=(4, 5)).astype(np.float32)
+    _close(torch_xp.sqrt(torch.from_numpy(a)), np.sqrt(a))
+
+
+def test_exp(rng) -> None:
+    a = rng.uniform(-2.0, 2.0, size=(4, 5)).astype(np.float32)
+    _close(torch_xp.exp(torch.from_numpy(a)), np.exp(a), rtol=1e-5)
+
+
+def test_log10(rng) -> None:
+    a = rng.uniform(0.1, 10.0, size=(4, 5)).astype(np.float32)
+    _close(torch_xp.log10(torch.from_numpy(a)), np.log10(a), rtol=1e-5)
+
+
+def test_cos(rng) -> None:
+    a = rng.uniform(-3.14, 3.14, size=(4, 5)).astype(np.float32)
+    _close(torch_xp.cos(torch.from_numpy(a)), np.cos(a))
+
+
+def test_arccos(rng) -> None:
+    a = rng.uniform(-0.99, 0.99, size=(4, 5)).astype(np.float32)
+    _close(torch_xp.arccos(torch.from_numpy(a)), np.arccos(a))
+
+
+def test_sign(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.sign(a_t), np.sign(a_np))
+
+
+def test_ceil(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.ceil(a_t), np.ceil(a_np))
+
+
+def test_clip(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.clip(a_t, -0.5, 0.5), np.clip(a_np, -0.5, 0.5))
+
+
+def test_isfinite() -> None:
+    a = np.array([1.0, np.inf, -np.inf, np.nan, 0.0], dtype=np.float32)
+    _close(torch_xp.isfinite(torch.from_numpy(a)), np.isfinite(a))
+
+
+def test_isinf() -> None:
+    a = np.array([1.0, np.inf, -np.inf, np.nan, 0.0], dtype=np.float32)
+    _close(torch_xp.isinf(torch.from_numpy(a)), np.isinf(a))
+
+
+def test_nan_to_num() -> None:
+    a = np.array([np.nan, 1.0, np.inf, -np.inf], dtype=np.float32)
+    _close(torch_xp.nan_to_num(torch.from_numpy(a)), np.nan_to_num(a))
+
+
+def test_maximum_two_arrays(rng) -> None:
+    a = rng.standard_normal((4, 5)).astype(np.float32)
+    b = rng.standard_normal((4, 5)).astype(np.float32)
+    _close(torch_xp.maximum(torch.from_numpy(a), torch.from_numpy(b)), np.maximum(a, b))
+
+
+def test_maximum_with_out(rng) -> None:
+    """The ``out=`` write-target convention used in Filter._compute_vesselness."""
+    a = rng.standard_normal((4, 5)).astype(np.float32)
+    b = rng.standard_normal((4, 5)).astype(np.float32)
+    a_t = torch.from_numpy(a.copy())
+    out = a_t.clone()
+    torch_xp.maximum(out, torch.from_numpy(b), out=out)
+    _close(out, np.maximum(a, b))
+
+
+# -----------------------------------------------------------------------------
+# Reductions and scans
+# -----------------------------------------------------------------------------
+
+
+def test_any_no_axis() -> None:
+    a = np.array([[False, False], [True, False]])
+    assert bool(torch_xp.any(torch.from_numpy(a))) == bool(np.any(a))
+
+
+def test_any_with_axis() -> None:
+    a = np.array([[True, False], [False, False]])
+    _close(torch_xp.any(torch.from_numpy(a), axis=1), np.any(a, axis=1))
+
+
+def test_sum_no_axis(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.sum(a_t), np.sum(a_np), rtol=1e-5)
+
+
+def test_sum_with_axis(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.sum(a_t, axis=0), np.sum(a_np, axis=0), rtol=1e-5)
+
+
+def test_sum_with_dtype(small_random) -> None:
+    a_np, a_t = small_random
+    out = torch_xp.sum(a_t, dtype=torch.float32)
+    _close(out, np.sum(a_np), rtol=1e-5)
+
+
+def test_nansum() -> None:
+    a = np.array([1.0, 2.0, np.nan, 3.0], dtype=np.float32)
+    _close(torch_xp.nansum(torch.from_numpy(a)), np.nansum(a), rtol=1e-5)
+
+
+def test_max_no_axis(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.max(a_t), np.max(a_np))
+
+
+def test_max_with_axis(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.max(a_t, axis=0), np.max(a_np, axis=0))
+
+
+def test_min_no_axis(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.min(a_t), np.min(a_np))
+
+
+def test_min_with_axis(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.min(a_t, axis=1), np.min(a_np, axis=1))
+
+
+def test_argmin_no_axis(small_random) -> None:
+    a_np, a_t = small_random
+    assert int(torch_xp.argmin(a_t)) == int(np.argmin(a_np))
+
+
+def test_argmin_with_axis(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.argmin(a_t, axis=0), np.argmin(a_np, axis=0))
+
+
+def test_argmax_with_axis(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.argmax(a_t, axis=1), np.argmax(a_np, axis=1))
+
+
+def test_cumsum(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.cumsum(a_t, axis=0), np.cumsum(a_np, axis=0), rtol=1e-5)
+
+
+def test_cumsum_no_axis_flattens(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.cumsum(a_t), np.cumsum(a_np), rtol=1e-5)
+
+
+def test_percentile(rng) -> None:
+    a = rng.standard_normal((20, 30)).astype(np.float32)
+    _close(torch_xp.percentile(torch.from_numpy(a), 25), np.percentile(a, 25), rtol=1e-3, atol=1e-3)
+
+
+# -----------------------------------------------------------------------------
+# Comparison / selection
+# -----------------------------------------------------------------------------
+
+
+def test_where_three_arg(rng) -> None:
+    cond = rng.integers(0, 2, size=(4, 5)).astype(bool)
+    a = rng.standard_normal((4, 5)).astype(np.float32)
+    b = rng.standard_normal((4, 5)).astype(np.float32)
+    _close(
+        torch_xp.where(torch.from_numpy(cond), torch.from_numpy(a), torch.from_numpy(b)),
+        np.where(cond, a, b),
+    )
+
+
+def test_where_one_arg() -> None:
+    """``where(cond)`` returns a tuple of 1-D index tensors per dim."""
+    cond = np.array([[True, False], [False, True]], dtype=bool)
+    out = torch_xp.where(torch.from_numpy(cond))
+    assert isinstance(out, tuple)
+    assert len(out) == 2
+    np_idx = np.where(cond)
+    for axis in range(2):
+        np.testing.assert_array_equal(_to_numpy(out[axis]), np_idx[axis])
+
+
+def test_argwhere() -> None:
+    cond = np.array([[True, False], [False, True]], dtype=bool)
+    _close(torch_xp.argwhere(torch.from_numpy(cond)), np.argwhere(cond))
+
+
+def test_flatnonzero() -> None:
+    a = np.array([0, 1, 0, 2, 3, 0], dtype=np.int64)
+    _close(torch_xp.flatnonzero(torch.from_numpy(a)), np.flatnonzero(a))
+
+
+def test_take_along_axis(rng) -> None:
+    arr = rng.standard_normal((3, 4)).astype(np.float32)
+    idx = np.argsort(arr, axis=1)
+    out = torch_xp.take_along_axis(torch.from_numpy(arr), torch.from_numpy(idx), axis=1)
+    _close(out, np.take_along_axis(arr, idx, axis=1))
+
+
+def test_argsort_default_axis(small_random) -> None:
+    a_np, a_t = small_random
+    _close(torch_xp.argsort(a_t), np.argsort(a_np, axis=-1))
+
+
+# -----------------------------------------------------------------------------
+# Combining / shape
+# -----------------------------------------------------------------------------
+
+
+def test_stack(rng) -> None:
+    a = rng.standard_normal((3,)).astype(np.float32)
+    b = rng.standard_normal((3,)).astype(np.float32)
+    out = torch_xp.stack([torch.from_numpy(a), torch.from_numpy(b)], axis=0)
+    _close(out, np.stack([a, b], axis=0))
+
+
+def test_concatenate(rng) -> None:
+    a = rng.standard_normal((2, 3)).astype(np.float32)
+    b = rng.standard_normal((4, 3)).astype(np.float32)
+    out = torch_xp.concatenate([torch.from_numpy(a), torch.from_numpy(b)], axis=0)
+    _close(out, np.concatenate([a, b], axis=0))
+
+
+def test_flip(rng) -> None:
+    a = rng.standard_normal((3, 4)).astype(np.float32)
+    _close(torch_xp.flip(torch.from_numpy(a), axis=0), np.flip(a, axis=0))
+
+
+# -----------------------------------------------------------------------------
+# Histogram / counting
+# -----------------------------------------------------------------------------
+
+
+def test_bincount() -> None:
+    a = np.array([0, 1, 1, 2, 2, 2, 3], dtype=np.int64)
+    _close(torch_xp.bincount(torch.from_numpy(a)), np.bincount(a))
+
+
+def test_histogram_with_range(rng) -> None:
+    a = rng.uniform(0, 10, size=200).astype(np.float32)
+    counts_xp, edges_xp = torch_xp.histogram(torch.from_numpy(a), bins=10, range=(0, 10))
+    counts_np, edges_np = np.histogram(a, bins=10, range=(0, 10))
+    np.testing.assert_array_equal(_to_numpy(counts_xp), counts_np)
+    _close(edges_xp, edges_np)
+
+
+# -----------------------------------------------------------------------------
+# Gradient
+# -----------------------------------------------------------------------------
+
+
+def test_gradient_axis_arg(rng) -> None:
+    """Single-axis path: ``xp.gradient(image, h, axis=0)``."""
+    a = rng.standard_normal((6, 7)).astype(np.float32)
+    out = torch_xp.gradient(torch.from_numpy(a), 0.5, axis=0)
+    expected = np.gradient(a, 0.5, axis=0)
+    _close(out, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_gradient_multi_axis_2d(rng) -> None:
+    """Multi-axis 2-D: ``xp.gradient(image, h0, h1)``."""
+    a = rng.standard_normal((6, 7)).astype(np.float32)
+    out = torch_xp.gradient(torch.from_numpy(a), 0.5, 0.7)
+    np_g = np.gradient(a, 0.5, 0.7)
+    assert isinstance(out, tuple) and len(out) == 2
+    for axis in range(2):
+        _close(out[axis], np_g[axis], rtol=1e-5, atol=1e-5)
+
+
+def test_gradient_multi_axis_3d(rng) -> None:
+    """Multi-axis 3-D: ``xp.gradient(image, h0, h1, h2)``."""
+    a = rng.standard_normal((4, 5, 6)).astype(np.float32)
+    out = torch_xp.gradient(torch.from_numpy(a), 0.5, 0.7, 1.1)
+    np_g = np.gradient(a, 0.5, 0.7, 1.1)
+    assert isinstance(out, tuple) and len(out) == 3
+    for axis in range(3):
+        _close(out[axis], np_g[axis], rtol=1e-5, atol=1e-5)
+
+
+# -----------------------------------------------------------------------------
+# Linalg
+# -----------------------------------------------------------------------------
+
+
+def test_linalg_eigvalsh(rng) -> None:
+    """Symmetric matrix eigenvalues match numpy.linalg.eigvalsh."""
+    n = 4
+    raw = rng.standard_normal((n, n)).astype(np.float32)
+    sym = (raw + raw.T) / 2
+    out = torch_xp.linalg.eigvalsh(torch.from_numpy(sym))
+    _close(out, np.linalg.eigvalsh(sym), rtol=1e-4, atol=1e-4)
+
+
+# -----------------------------------------------------------------------------
+# Misc helpers
+# -----------------------------------------------------------------------------
+
+
+def test_finfo() -> None:
+    info = torch_xp.finfo(torch.float32)
+    assert info.eps > 0
+    assert info.tiny > 0
+
+
+def test_finfo_from_lazy_dtype() -> None:
+    info = torch_xp.finfo(torch_xp.float32)
+    np_info = np.finfo(np.float32)
+    assert info.eps == pytest.approx(np_info.eps, rel=1e-3)
+
+
+def test_asnumpy_passes_through_numpy() -> None:
+    arr = np.array([1, 2, 3])
+    out = torch_xp.asnumpy(arr)
+    assert isinstance(out, np.ndarray)
+
+
+def test_asnumpy_converts_tensor() -> None:
+    t = torch.arange(5)
+    out = torch_xp.asnumpy(t)
+    assert isinstance(out, np.ndarray)
+    np.testing.assert_array_equal(out, np.arange(5))
+
+
+# -----------------------------------------------------------------------------
+# Unimplemented op trap
+# -----------------------------------------------------------------------------
+
+
+def test_missing_op_raises_clear_error() -> None:
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        torch_xp.totally_made_up_op_for_test


### PR DESCRIPTION
Closes #141 (parent PRD: #140).

## Summary

First slice of the Apple Silicon / MPS work. Lands the substrate so
that `device="mps"` is a recognized device on every pipeline stage and
`adaptive_run` knows how to dispatch to it — without onboarding any
specific stage to MPS yet (per-stage MPS work comes in slices
#142–#145).

## What's in

- **Two new shim modules**:
  - `nellie/utils/torch_xp.py` — numpy-API surface over PyTorch (38 ops).
    Lazy torch import, one-time float64→float32 coercion notice, and a
    `__getattr__` trap for unimplemented ops with a clear message.
  - `nellie/utils/torch_ndi.py` — scipy.ndimage-API surface (9 ops):
    convolutional ops via `torch.nn.functional.conv*` / `*_pool*`;
    structural ops (`binary_opening`, `binary_fill_holes`, `label`)
    round-trip to scipy on CPU.

- **`adaptive_run` extensions**:
  - `resolve_backend("mps")` returns `(torch_xp, torch_ndi, "mps")`.
  - `resolve_backend("gpu")` is platform-aware (MPS on Darwin, CUDA
    elsewhere) per ADR 0003.
  - `normalize_device` accepts `"mps"`.
  - New `device_cascade(device) → list[str]` is the single source of
    truth for retry order. `"auto"` / `"gpu"` resolve platform-aware;
    `"mps"` and `"cuda"` are no-fallback explicit pins; `"cpu"` is
    `["cpu"]`.
  - `get_mps_free_bytes()` approximates free MPS as
    `cpu_available - torch.mps.driver_allocated_memory()`, honoring
    `PYTORCH_MPS_HIGH_WATERMARK_RATIO`.
  - `_MEMORY_HEADROOM_BY_DEVICE`: 0.7 for CUDA, 0.5 for MPS.
  - `is_oom_error` recognizes `"MPS backend out of memory"`.
  - `is_gpu_unavailable_error` recognizes torch+MPS unavailable patterns
    AND the shim's `NotImplementedError` (so the cascade falls back to
    CPU when a non-onboarded stage hits an unimplemented op on MPS).

- **Cascade-caller refactor**: all 7 stages (filtering, labelling,
  networking, mocap_marking, hu_tracking, voxel_reassignment,
  hierarchical) replace inline `device_order = [...]` constructions
  with `adaptive_run.device_cascade(self.device)`. Inner OOM /
  unavailable retry conditions widened to `dev in ("gpu", "mps")` and
  `device_type in ("cuda", "mps")` so MPS is treated symmetrically
  with CUDA in the cascade plumbing.

- **Install / marker plumbing**: `pyproject.toml` adds
  `mps = ["torch"]` to `[project.optional-dependencies]` and registers
  an `mps` pytest marker (deselected by default via `addopts`,
  matching the existing `benchmark` pattern).

- **Cleanup**: dead commented `torch_xp` block removed from
  `nellie/__init__.py` (superseded per ADR 0002; static module-level
  dispatch stays numpy-on-Mac).

## What's out (deferred to slices #142–#145)

- Per-stage MPS-acceleration (no `arr.get()` rewrites in this slice).
- The four onboarded stages don't yet *use* the torch backend at
  runtime — when a Mac user passes `device="auto"` and torch+MPS is
  installed, the cascade will dispatch to MPS, hit an unimplemented op
  in the per-stage code, and fall back to CPU via the new
  `NotImplementedError` classifier path. This is intentional — the
  per-stage MPS support is on the next slice.
- MPS smoke / equivalence / benchmark tests (per slice).

## Test plan

- [x] Default `pytest` passes locally: **453 passed, 2 skipped, 7 deselected**.
  Skips: `test_torch_xp.py` and `test_torch_ndi.py` skip cleanly via
  `pytest.importorskip("torch")` when torch isn't installed (which is
  the default — torch is an optional extra).
- [x] `pytest -m mps` exits cleanly: **0 collected, 460 deselected, 2 skipped**.
  Per-stage MPS-marker tests come in slices #142–#145.
- MPS hardware validation deferred to the release-tag checklist per
  PRD #140 § Testing Decisions. The `mps` marker is opt-in and run
  locally on Mac before tagging an MPS-affecting release.

## Notes for the next slice

- The `torch_xp.linalg.eigvalsh` shim wraps `torch.linalg.eigvalsh` —
  the recent perf pass replaced LAPACK `eigvalsh` with a closed-form
  3×3 in `chunking.py`, and the closed-form path uses base `xp.*`
  primitives that the shim already covers. No follow-up needed at the
  shim level for the perf-pass code paths.
- The cascade-caller refactor preserved warning semantics for
  `device="gpu"`-with-no-GPU but only when the cascade returns
  `["cpu"]`. Explicit `device="mps"` on a Linux box (no MPS) hits the
  cascade's no-fallback path and raises a clean
  `is_gpu_unavailable_error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)