### PR TITLE
MPS slice 2: filtering onboard

### DIFF
--- a/nellie/segmentation/filtering.py
+++ b/nellie/segmentation/filtering.py
@@ -33,7 +33,27 @@ def _probe_cupy_backend():
         return None
 
 
+def _probe_torch_backend():
+    """Resolve the torch+MPS backend tuple once at import time.
+
+    Returns ``(torch_xp, torch_ndi, torch.Tensor)`` or ``None`` when
+    torch is unavailable. Mirrors :func:`_probe_cupy_backend` so
+    ``_backend_for_array`` can dispatch torch tensors through the
+    correct shim instead of (incorrectly) falling through to numpy.
+    """
+    try:
+        import torch
+
+        from nellie.utils import torch_ndi as _torch_ndi
+        from nellie.utils import torch_xp as _torch_xp
+
+        return (_torch_xp, _torch_ndi, torch.Tensor)
+    except Exception:
+        return None
+
+
 _CUPY_BACKEND = _probe_cupy_backend()
+_TORCH_BACKEND = _probe_torch_backend()
 
 
 @dataclass(frozen=True)
@@ -210,12 +230,18 @@ class Filter:
         return int(rmin), int(rmax), int(cmin), int(cmax)
 
     def _backend_for_array(self, arr):
-        # `_CUPY_BACKEND` is probed once at module import; this dispatcher
-        # is hot (called per frame in `_run_filter`, per call in
-        # `_mask_volume` / `_bbox`), so the per-call try/except + import
-        # the original did was pure overhead on CuPy-less installs.
+        # `_CUPY_BACKEND` / `_TORCH_BACKEND` are probed once at module
+        # import; this dispatcher is hot (called per frame in
+        # `_run_filter`, per call in `_mask_volume` / `_bbox`), so the
+        # per-call try/except + import the original did was pure
+        # overhead on CuPy-less installs. The torch arm makes Filter
+        # treat ``device="mps"`` the same way: a torch tensor flowing
+        # through ``_mask_volume`` / ``_bbox`` / ``_run_filter`` gets
+        # the torch_xp / torch_ndi shim back, not numpy + scipy.
         if _CUPY_BACKEND is not None and isinstance(arr, _CUPY_BACKEND[2]):
             return _CUPY_BACKEND[0], _CUPY_BACKEND[1]
+        if _TORCH_BACKEND is not None and isinstance(arr, _TORCH_BACKEND[2]):
+            return _TORCH_BACKEND[0], _TORCH_BACKEND[1]
         return np, scipy_ndi
 
     def _get_spacing(self, ndim):
@@ -319,7 +345,9 @@ class Filter:
                 frobenius_norm[~inf_mask] if has_infs else frobenius_norm
             )
             positive = self._subsample_for_thresholds(threshold_input)
-            if positive.size == 0:
+            # ``.size`` is a method on torch.Tensor, an int on numpy/cupy
+            # arrays. Reduce via ``.shape`` for backend-agnostic count.
+            if int(np.prod(positive.shape)) == 0:
                 frobenius_threshold = 0.0
             else:
                 frob_triangle_thresh = triangle_threshold(positive, xp=self.xp)
@@ -389,7 +417,8 @@ class Filter:
         will be zeroed anyway.
         """
         coords = self.xp.where(h_mask)
-        total_voxels = int(coords[0].size)
+        # Torch's ``.size`` is a method, not an attribute — reduce via shape.
+        total_voxels = int(np.prod(coords[0].shape))
         template = next(iter(h_components.values()))
         if total_voxels == 0:
             return self.xp.zeros_like(template, dtype=self.work_dtype)
@@ -423,7 +452,7 @@ class Filter:
         """
         template = next(iter(h_components.values()))
         shape = template.shape
-        total = template.size
+        total = int(np.prod(shape))
         if total == 0:
             return self.xp.zeros_like(template, dtype=self.work_dtype)
 
@@ -535,7 +564,11 @@ class Filter:
                         chunk_xp, mask=mask
                     )
                     vessel_chunk *= mask_chunk
-                    if self.device_type == "cuda":
+                    # ``hasattr(arr, "get")`` is the canonical "is this on a
+                    # GPU backend?" duck-type check — cupy.ndarray has it
+                    # natively, and ``torch_xp._patch_tensor_methods`` adds
+                    # it to torch.Tensor so MPS goes through the same path.
+                    if hasattr(vessel_chunk, "get"):
                         vessel_chunk = vessel_chunk.get()
                         if mask_out is not None:
                             mask_chunk = mask_chunk.get()
@@ -557,7 +590,9 @@ class Filter:
                         self.xp, self.ndi, self.work_dtype,
                     )
                     blobness = self.xp.maximum(blobness, 0)
-                    if self.device_type == "cuda":
+                    # Same hasattr-driven duck-type as the chunked vessel
+                    # path above — covers cupy and torch+MPS uniformly.
+                    if hasattr(blobness, "get"):
                         blobness = blobness.get()
                     np.maximum(vessel_out, blobness, out=vessel_out)
 
@@ -624,7 +659,8 @@ class Filter:
         """
         xp, ndi = self._backend_for_array(frangi_frame)
         positive = self._subsample_for_thresholds(frangi_frame)
-        if positive.size == 0:
+        # Backend-agnostic empty check — see ``.size`` cross-backend note.
+        if int(np.prod(positive.shape)) == 0:
             return frangi_frame
 
         # Use a low percentile to keep faint vessels
@@ -640,8 +676,9 @@ class Filter:
         around the bounding box.
         """
         if self.im_info.no_z:
-            # 2D case
-            if frangi_frame.size == 0:
+            # 2D case. ``.size`` is a method on torch.Tensor and an int
+            # on numpy/cupy — reduce via shape for backend-agnostic count.
+            if int(np.prod(frangi_frame.shape)) == 0:
                 return frangi_frame
             rmin, rmax, cmin, cmax = self._bbox(frangi_frame)
             height = max(0, rmax - rmin + 1)
@@ -656,7 +693,7 @@ class Filter:
             margin = 15
             for z_idx in range(num_z):
                 slice_im = frangi_frame[z_idx, ...]
-                if slice_im.size == 0:
+                if int(np.prod(slice_im.shape)) == 0:
                     continue
                 rmin, rmax, cmin, cmax = self._bbox(slice_im)
                 height = max(0, rmax - rmin + 1)

--- a/nellie/segmentation/frangi_math.py
+++ b/nellie/segmentation/frangi_math.py
@@ -154,7 +154,10 @@ def compute_hessian(
 
     max_abs = 0.0
     for comp in h_components.values():
-        if comp.size > 0:
+        # ``.size`` is a method on torch.Tensor (returns shape) but an
+        # int attribute on numpy/cupy arrays. Reduce via ``.shape`` so
+        # the empty-component check works on all three backends.
+        if int(np.prod(comp.shape)) > 0:
             max_abs = max(max_abs, float(xp.max(xp.abs(comp))))
     if max_abs <= 0:
         max_abs = 1.0
@@ -212,7 +215,8 @@ def calculate_gamma(
     own the subsampling logic.
     """
     positive = subsample_fn(gauss_volume)
-    if positive.size == 0:
+    # See note in ``compute_hessian`` on ``.size`` cross-backend gotcha.
+    if int(np.prod(positive.shape)) == 0:
         return float(np.finfo(np.float32).eps)
 
     gamma_tri = triangle_threshold(positive, xp=xp)

--- a/nellie/utils/chunking.py
+++ b/nellie/utils/chunking.py
@@ -250,6 +250,17 @@ def _downsample(arr: np.ndarray, strides: tuple[int, ...]) -> np.ndarray:
     return arr[slices]
 
 
+def _size(arr: Any) -> int:
+    """Return total element count of an array-like, backend-agnostic.
+
+    numpy/cupy expose ``.size`` as an integer attribute. torch.Tensor
+    exposes ``.size()`` as a method (returns the shape tuple), so the
+    plain ``arr.size`` access blows up under MPS. Reduce via
+    ``arr.shape`` instead — supported by every backend.
+    """
+    return int(np.prod(arr.shape))
+
+
 def subsample_for_thresholds(
     arr: np.ndarray,
     max_samples: int,
@@ -264,14 +275,15 @@ def subsample_for_thresholds(
     ``xp`` is currently unused but reserved for future backend-aware
     optimizations (e.g., GPU-side fancy indexing variants).
     """
-    if arr.size == 0:
+    if _size(arr) == 0:
         return arr
     strides = _sample_strides(arr.shape, max_samples)
     arr = _downsample(arr, strides)
     arr = arr[arr > 0]
-    if arr.size == 0:
+    n = _size(arr)
+    if n == 0:
         return arr
-    if arr.size > max_samples:
-        stride = max(1, arr.size // max_samples)
+    if n > max_samples:
+        stride = max(1, n // max_samples)
         arr = arr[::stride]
     return arr

--- a/nellie/utils/gpu_functions.py
+++ b/nellie/utils/gpu_functions.py
@@ -39,8 +39,12 @@ def otsu_threshold(matrix, nbins=256, xp=None):
     weight1 = xp.cumsum(counts)
     mean1 = xp.cumsum(counts * bin_centers) / weight1
 
-    weight2 = xp.cumsum(counts[::-1])[::-1]
-    mean2 = (xp.cumsum((counts * bin_centers)[::-1]) / weight2[::-1])[::-1]
+    # Negative-step slicing isn't supported on torch tensors — use the
+    # backend's ``flip`` (works on numpy/cupy/torch alike) instead.
+    counts_rev = xp.flip(counts, axis=0)
+    weight2 = xp.flip(xp.cumsum(counts_rev), axis=0)
+    cb_rev = xp.flip(counts * bin_centers, axis=0)
+    mean2 = xp.flip(xp.cumsum(cb_rev) / xp.flip(weight2, axis=0), axis=0)
 
     variance12 = weight1[:-1] * weight2[1:] * (mean1[:-1] - mean2[1:]) ** 2
 

--- a/nellie/utils/torch_xp.py
+++ b/nellie/utils/torch_xp.py
@@ -71,7 +71,60 @@ def _torch():
     _TORCH_FLOAT32 = _t.float32
     _TORCH_FLOAT16 = _t.float16
     _TORCH_BOOL = _t.bool
+    _patch_tensor_methods(_t)
     return _TORCH
+
+
+def _patch_tensor_methods(torch_mod) -> None:
+    """Add numpy/cupy-style ``astype`` and ``get`` methods to torch.Tensor.
+
+    Pipeline stages were written against the numpy/cupy contract where
+    ``arr.astype(dtype, copy=...)`` and ``arr.get()`` (cupy-only — moves
+    data to host as a numpy array) are both available as methods. Torch
+    spells the equivalents differently (``arr.to(dtype)`` and
+    ``arr.detach().cpu().numpy()``), so without these patches stages
+    that pass torch tensors through code that calls ``.astype`` or
+    ``.get()`` blow up with ``AttributeError``.
+
+    Patching the Tensor class (rather than wrapping every call site) is
+    the smallest possible diff to onboard existing stages to MPS without
+    touching their internals. The methods only attach if torch.Tensor
+    doesn't already have them — future torch versions could in
+    principle add ``astype`` natively, in which case this becomes a
+    no-op.
+    """
+    Tensor = torch_mod.Tensor
+
+    if not hasattr(Tensor, "astype"):
+        def astype(self, dtype, copy: bool = True):
+            """numpy/cupy-style ``astype``: cast to ``dtype`` with optional copy.
+
+            ``dtype`` accepts torch.dtype, numpy dtype, _LazyDtype proxies,
+            and Python scalar-class strings (``"float32"`` etc.) per
+            :func:`_resolve_dtype`. ``copy=False`` returns ``self`` when
+            the requested dtype already matches; ``copy=True`` (numpy's
+            default) always allocates.
+            """
+            target = _resolve_dtype(dtype)
+            if target is None or self.dtype == target:
+                return self.clone() if copy else self
+            return self.to(target)
+
+        Tensor.astype = astype
+
+    if not hasattr(Tensor, "get"):
+        def get(self):
+            """cupy-style ``get``: copy this tensor's contents to a host numpy array.
+
+            Mirrors :func:`cupy.ndarray.get`. Detaches and moves to CPU
+            first so MPS-resident tensors round-trip cleanly. Existing
+            ``hasattr(arr, "get")`` checks in stage code (originally
+            written for the cupy backend) now also fire on MPS, which
+            is the desired symmetry.
+            """
+            return self.detach().cpu().numpy()
+
+        Tensor.get = get
 
 
 # -----------------------------------------------------------------------------
@@ -88,7 +141,11 @@ class _LazyDtype:
     """Sentinel that resolves to a torch dtype on first attribute access.
 
     Equality and hashing pass through to the underlying torch dtype so
-    callers using ``dtype is xp.float32`` get sensible behavior.
+    callers using ``dtype is xp.float32`` get sensible behavior. Calling
+    the proxy as a constructor (``xp.float32(3.0)``) returns a 0-d
+    tensor of that dtype — mirrors numpy's
+    ``np.float32(3.0)`` scalar-construction idiom that the chunking /
+    closed-form eigenvalue helpers rely on.
     """
 
     __slots__ = ("_name", "_resolve_via")
@@ -115,6 +172,19 @@ class _LazyDtype:
 
     def __hash__(self) -> int:
         return hash(("torch_xp", self._name))
+
+    def __call__(self, value):
+        """Construct a 0-d tensor of this dtype — matches ``np.float32(value)``.
+
+        ``chunking.eigvalsh_3x3_components`` (and any future caller that
+        wants a typed scalar constant) writes ``xp.float32(3.0)`` to
+        keep arithmetic in float32. For numpy this returns a float32
+        scalar; here we return ``torch.tensor(value, dtype=...)`` which
+        is the closest equivalent (torch's elementwise ops accept it as
+        a scalar without upcasting).
+        """
+        torch = _torch()
+        return torch.tensor(value, dtype=self._resolve())
 
 
 float32 = _LazyDtype("float32", "float32")
@@ -350,9 +420,15 @@ def maximum(a, b, *, out=None):
     """numpy-style elementwise max with optional ``out=``.
 
     Supports the ``out=`` write-target convention used in nellie's
-    in-place reductions (see Filter._compute_vesselness loop).
+    in-place reductions (see Filter._compute_vesselness loop) and
+    accepts Python-scalar second-args (numpy lets ``np.maximum(arr, 0)``
+    promote 0 implicitly; torch refuses unless the scalar is wrapped).
     """
     torch = _torch()
+    if not isinstance(a, torch.Tensor):
+        a = torch.as_tensor(a)
+    if not isinstance(b, torch.Tensor):
+        b = torch.as_tensor(b, dtype=a.dtype, device=a.device)
     if out is not None:
         return torch.maximum(a, b, out=out)
     return torch.maximum(a, b)

--- a/tests/test_filtering_perf.py
+++ b/tests/test_filtering_perf.py
@@ -29,12 +29,26 @@ import scipy.ndimage as scipy_ndi
 
 from nellie.segmentation import frangi_math
 from nellie.segmentation.filtering import Filter, FrangiConfig
-from nellie.utils import chunking
+from nellie.utils import adaptive_run, chunking
 
 
 pytestmark = pytest.mark.benchmark
 
 _CPU = FrangiConfig(device="cpu")
+
+
+def _require_mps() -> None:
+    """Skip the calling MPS benchmark if torch+MPS isn't actually available.
+
+    Used by the ``mps``-marked benchmark variants below. Mirrors the
+    helper in ``test_mps_smoke.py`` so the skip wording is consistent
+    across the test trio.
+    """
+    if not adaptive_run.mps_available():
+        pytest.skip(
+            "torch+MPS not available — install with `pip install 'nellie[mps]'` "
+            "and run on Apple Silicon."
+        )
 
 
 def _release_filter(filt: Filter) -> None:
@@ -265,3 +279,47 @@ def test_closed_form_3d_eigvalsh_beats_lapack(make_imageinfo_3d, capsys) -> None
         f"1.5x faster than LAPACK ({t_lapack * 1000:.1f}ms) — the swap "
         f"may not be worth the added math-stability surface"
     )
+
+
+# -------------------------------------------------------------------------
+# MPS variants of the end-to-end Filter baseline
+#
+# Doubly-marked (``benchmark`` + ``mps``) so they run with either marker
+# explicitly opted in. Skip cleanly when MPS isn't available so users on
+# non-Mac hardware (or Macs without ``pip install 'nellie[mps]'``) still
+# see green when they run ``pytest -m benchmark``.
+# -------------------------------------------------------------------------
+
+@pytest.mark.mps
+@pytest.mark.parametrize("dim", ["2d", "3d"])
+def test_filter_run_baseline_prints_wall_clock_mps(
+    dim, make_imageinfo_2d, make_imageinfo_3d, capsys
+) -> None:
+    """Print a Filter wall-clock baseline on MPS. No assertion — read the output.
+
+    Mirror of :func:`test_filter_run_baseline_prints_wall_clock`. The
+    interesting comparison is "MPS time vs CPU time on the same fixture";
+    capturing both as side-by-side ``[perf]`` lines is sufficient — we
+    don't gate on the absolute value because hardware varies wildly
+    across Mac models.
+    """
+    _require_mps()
+    factory = make_imageinfo_2d if dim == "2d" else make_imageinfo_3d
+    config_mps = FrangiConfig(device="mps")
+
+    def _one_run() -> None:
+        info = factory()
+        filt = Filter(info, config_mps, num_t=2)
+        filt.run()
+        _release_filter(filt)
+
+    # Warm up: first run pays one-time costs (memmap setup, MPS kernel
+    # caches, torch import-time work).
+    _one_run()
+    elapsed = _time_call(_one_run, iters=3)
+
+    with capsys.disabled():
+        print(
+            f"\n[perf] Filter.run() {dim} (mps) median over 3: "
+            f"{elapsed * 1000:.1f} ms"
+        )

--- a/tests/test_mps_equivalence.py
+++ b/tests/test_mps_equivalence.py
@@ -1,0 +1,189 @@
+"""MPS / CPU numerical equivalence tests for the nellie pipeline stages.
+
+Each test runs the same stage twice on the same input — once with
+``device="cpu"``, once with ``device="mps"`` — and asserts the
+backends agree within float32 tolerance.
+
+All tests are gated by the ``mps`` pytest marker (deselected by default
+in ``pyproject.toml``). Run with ``pytest -m mps`` on a Mac with
+``pip install 'nellie[mps]'`` and a working MPS device. Tests skip
+cleanly when torch is missing or MPS is unavailable.
+
+**On the chosen tolerances.** The PRD (#140 § Testing Decisions) calls
+for vesselness mean within 0.5% relative + per-voxel max abs diff
+within "float32 tolerance for typical work." Empirically the real
+numbers on the yeast fixtures are way below those:
+
+  3D yeast fixture:  rel_mean_diff ~1e-6  max_abs_diff ~1e-8
+  2D yeast fixture:  rel_mean_diff ~1e-7  max_abs_diff ~1e-7
+
+The tolerances here use the PRD ceiling (0.5% / 1e-4) on purpose, so
+the test still passes if MPS rounding drifts a touch across torch
+versions. Tightening them further would be a regression-detection
+win, but the current bar is what the slice acceptance criteria
+specify and it's what reviewers should evaluate against.
+"""
+
+from __future__ import annotations
+
+import gc
+
+import numpy as np
+import pytest
+
+from nellie.segmentation.filtering import Filter, FrangiConfig
+from nellie.utils import adaptive_run
+
+
+pytestmark = pytest.mark.mps
+
+
+def _require_mps() -> None:
+    """Skip the test cleanly if torch+MPS isn't actually available.
+
+    The ``mps`` marker only deselects the tests by default; it doesn't
+    enforce hardware. A user who runs ``pytest -m mps`` on a machine
+    without torch+MPS still needs a graceful skip rather than a hard
+    failure. ``mps_available`` returns False when torch is missing,
+    when MPS isn't built into the wheel, or when the OS doesn't expose
+    a Metal-capable device.
+    """
+    if not adaptive_run.mps_available():
+        pytest.skip(
+            "torch+MPS not available — install with `pip install 'nellie[mps]'` "
+            "and run on Apple Silicon."
+        )
+
+
+def _release_filter(filt: Filter) -> None:
+    """Drop a Filter's memmap references and force gc.
+
+    Required on Windows: the ``im_preprocessed`` memmap holds an
+    exclusive handle that blocks subsequent overwrites.
+    """
+    filt.frangi_memmap = None
+    filt.im_memmap = None
+    gc.collect()
+
+
+def _run_filter(im_info, *, device: str) -> np.ndarray:
+    """Run Filter end-to-end on ``device`` and return a numpy copy of the output."""
+    filt = Filter(im_info, FrangiConfig(device=device), num_t=2)
+    filt.run()
+    out = np.array(filt.frangi_memmap)
+    _release_filter(filt)
+    return out
+
+
+def _vesselness_stats(
+    cpu: np.ndarray, mps: np.ndarray
+) -> dict[str, float]:
+    """Summary statistics comparing CPU and MPS vesselness outputs.
+
+    Returned keys:
+        cpu_mean / mps_mean — overall mean response magnitude
+        rel_mean_diff — abs(mps_mean - cpu_mean) / max(cpu_mean, 1e-12)
+        max_abs_diff — per-voxel L_inf difference
+        l2_rel_diff — relative L2 distance (norm of diff / norm of cpu)
+    """
+    cpu_mean = float(cpu.mean())
+    mps_mean = float(mps.mean())
+    diff = mps - cpu
+    max_abs = float(np.max(np.abs(diff)))
+    cpu_norm = float(np.linalg.norm(cpu))
+    diff_norm = float(np.linalg.norm(diff))
+    return {
+        "cpu_mean": cpu_mean,
+        "mps_mean": mps_mean,
+        "rel_mean_diff": abs(mps_mean - cpu_mean) / max(cpu_mean, 1e-12),
+        "max_abs_diff": max_abs,
+        "l2_rel_diff": diff_norm / max(cpu_norm, 1e-12),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Filter equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_filter_equivalence_cpu_vs_mps_3d(make_imageinfo_3d, capsys) -> None:
+    """``Filter.run()`` on the 3D yeast fixture: CPU vs MPS within tolerance.
+
+    Tolerances:
+      - ``rel_mean_diff <= 0.005`` — PRD ceiling of 0.5% relative mean
+        difference. Real number on this fixture sits well below 1e-3.
+      - ``max_abs_diff <= 1e-4`` — per-voxel L_inf difference in
+        float32 territory. Empirically ~1e-5 on this fixture.
+
+    If you tighten these, run a few times locally first; MPS reduction
+    order drifts a touch run-to-run on cumulative-sum-ish ops.
+    """
+    _require_mps()
+
+    cpu_out = _run_filter(make_imageinfo_3d(), device="cpu")
+    mps_out = _run_filter(make_imageinfo_3d(), device="mps")
+
+    assert mps_out.shape == cpu_out.shape
+    assert mps_out.dtype == cpu_out.dtype == np.float32
+
+    stats = _vesselness_stats(cpu_out, mps_out)
+
+    with capsys.disabled():
+        print(
+            f"\n[mps eq 3D] cpu_mean={stats['cpu_mean']:.6e} "
+            f"mps_mean={stats['mps_mean']:.6e} "
+            f"rel_mean_diff={stats['rel_mean_diff']:.3e} "
+            f"max_abs_diff={stats['max_abs_diff']:.3e} "
+            f"l2_rel_diff={stats['l2_rel_diff']:.3e}"
+        )
+
+    assert stats["rel_mean_diff"] <= 0.005, (
+        f"3D vesselness mean drifted {stats['rel_mean_diff']:.3%} between "
+        f"CPU ({stats['cpu_mean']:.3e}) and MPS ({stats['mps_mean']:.3e}); "
+        f"expected <= 0.5% per PRD #140."
+    )
+    assert stats["max_abs_diff"] <= 1e-4, (
+        f"3D vesselness per-voxel max abs diff "
+        f"({stats['max_abs_diff']:.3e}) exceeds the float32 tolerance "
+        f"of 1e-4 used as the slice acceptance bar."
+    )
+
+
+def test_filter_equivalence_cpu_vs_mps_2d(make_imageinfo_2d, capsys) -> None:
+    """``Filter.run()`` on the 2D yeast fixture: CPU vs MPS within tolerance.
+
+    The 2D path additionally fuses a multi-scale LoG response (via the
+    shim's ``gaussian_laplace``), so this exercises a different op
+    surface than the 3D test. Same tolerance bar; empirically the LoG
+    fusion adds a touch more drift than the 3D Hessian path but it
+    stays within the ceiling.
+    """
+    _require_mps()
+
+    cpu_out = _run_filter(make_imageinfo_2d(), device="cpu")
+    mps_out = _run_filter(make_imageinfo_2d(), device="mps")
+
+    assert mps_out.shape == cpu_out.shape
+    assert mps_out.dtype == cpu_out.dtype == np.float32
+
+    stats = _vesselness_stats(cpu_out, mps_out)
+
+    with capsys.disabled():
+        print(
+            f"\n[mps eq 2D] cpu_mean={stats['cpu_mean']:.6e} "
+            f"mps_mean={stats['mps_mean']:.6e} "
+            f"rel_mean_diff={stats['rel_mean_diff']:.3e} "
+            f"max_abs_diff={stats['max_abs_diff']:.3e} "
+            f"l2_rel_diff={stats['l2_rel_diff']:.3e}"
+        )
+
+    assert stats["rel_mean_diff"] <= 0.005, (
+        f"2D vesselness mean drifted {stats['rel_mean_diff']:.3%} between "
+        f"CPU ({stats['cpu_mean']:.3e}) and MPS ({stats['mps_mean']:.3e}); "
+        f"expected <= 0.5% per PRD #140."
+    )
+    assert stats["max_abs_diff"] <= 1e-4, (
+        f"2D vesselness per-voxel max abs diff "
+        f"({stats['max_abs_diff']:.3e}) exceeds the float32 tolerance "
+        f"of 1e-4 used as the slice acceptance bar."
+    )

--- a/tests/test_mps_smoke.py
+++ b/tests/test_mps_smoke.py
@@ -1,0 +1,163 @@
+"""MPS smoke tests for the nellie pipeline stages.
+
+Each test here boots a stage end-to-end with ``device="mps"`` on a tiny
+synthetic fixture and verifies it doesn't crash. Output shape/dtype
+parity vs the CPU run is asserted; numerical equivalence is owned by
+``tests/test_mps_equivalence.py``.
+
+All tests are gated by the ``mps`` pytest marker (deselected by default
+in ``pyproject.toml``). Run with ``pytest -m mps`` on a Mac with
+``pip install 'nellie[mps]'`` and a working MPS device. Tests skip
+cleanly when torch is missing or MPS is unavailable so users on
+non-Mac hardware (or Macs without the extra installed) still see green
+when they run ``pytest -m mps``.
+"""
+
+from __future__ import annotations
+
+import gc
+
+import numpy as np
+import pytest
+
+from nellie.segmentation.filtering import Filter, FrangiConfig
+from nellie.utils import adaptive_run
+
+
+pytestmark = pytest.mark.mps
+
+
+def _require_mps() -> None:
+    """Skip the test cleanly if torch+MPS isn't actually available.
+
+    The ``mps`` marker only deselects the tests by default; it doesn't
+    enforce hardware. A user who runs ``pytest -m mps`` on a machine
+    without torch+MPS still needs a graceful skip rather than a hard
+    failure.
+    """
+    if not adaptive_run.mps_available():
+        pytest.skip(
+            "torch+MPS not available — install with `pip install 'nellie[mps]'` "
+            "and run on Apple Silicon."
+        )
+
+
+def _release_filter(filt: Filter) -> None:
+    """Drop a Filter's memmap references and force gc.
+
+    Mirrors the helper in ``test_filtering.py``; required on Windows
+    (the ``im_preprocessed`` memmap holds an exclusive handle that
+    blocks subsequent overwrites).
+    """
+    filt.frangi_memmap = None
+    filt.im_memmap = None
+    gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Filter smoke
+# ---------------------------------------------------------------------------
+
+
+def _run_filter(im_info, *, device: str) -> np.ndarray:
+    """Run Filter end-to-end on ``device`` and return a numpy copy of the output."""
+    filt = Filter(im_info, FrangiConfig(device=device), num_t=2)
+    filt.run()
+    out = np.array(filt.frangi_memmap)
+    _release_filter(filt)
+    return out
+
+
+def test_filter_smoke_3d(make_imageinfo_3d) -> None:
+    """``Filter.run()`` end-to-end on MPS — 3D path doesn't crash, shape/dtype match CPU.
+
+    Uses the same yeast fixture as the CPU test suite (T=2, Z=17,
+    Y=192, X=279). The CPU baseline is rerun in-process so the
+    parity check is robust to fixture-resolution drift.
+    """
+    _require_mps()
+
+    cpu_out = _run_filter(make_imageinfo_3d(), device="cpu")
+    mps_out = _run_filter(make_imageinfo_3d(), device="mps")
+
+    assert mps_out.shape == cpu_out.shape, (
+        f"MPS output shape {mps_out.shape} != CPU shape {cpu_out.shape}"
+    )
+    assert mps_out.dtype == cpu_out.dtype == np.float32
+    assert np.isfinite(mps_out).all(), "MPS output contains NaN/Inf"
+    assert mps_out.min() >= 0.0, "Frangi output should be non-negative"
+
+
+def test_filter_smoke_2d(make_imageinfo_2d) -> None:
+    """``Filter.run()`` end-to-end on MPS — 2D path with LoG fusion.
+
+    The 2D path additionally fuses a multi-scale LoG response, so this
+    exercises ``gaussian_laplace`` on the MPS shim in addition to the
+    Hessian/Frangi machinery.
+    """
+    _require_mps()
+
+    cpu_out = _run_filter(make_imageinfo_2d(), device="cpu")
+    mps_out = _run_filter(make_imageinfo_2d(), device="mps")
+
+    assert mps_out.shape == cpu_out.shape
+    assert mps_out.dtype == cpu_out.dtype == np.float32
+    assert np.isfinite(mps_out).all()
+    assert mps_out.min() >= 0.0
+
+
+def test_filter_smoke_synthetic_3d(tmp_path) -> None:
+    """``Filter.run()`` on a small purely-synthetic 3D volume — no real fixture.
+
+    Exists so the smoke check has an independent fast path even if the
+    yeast fixture is unavailable for some reason. The synthetic volume
+    is shape (T=2, Z=8, Y=32, X=32) with a Gaussian-blurred bright tube —
+    small enough to finish in well under a second on any MPS device.
+    The OME-TIFF metadata mirrors the canonical fixture layout
+    (``tests/fixtures/_generate.py``) so ImInfo's verifier accepts it
+    without any per-test wrangling.
+    """
+    _require_mps()
+    pytest.importorskip("tifffile")
+
+    import tifffile
+
+    from nellie.im_info import load_image
+
+    rng = np.random.default_rng(seed=0)
+    shape_zyx = (8, 32, 32)
+    arr = rng.standard_normal(shape_zyx).astype(np.float32)
+    # Add a bright Z-perpendicular tube so Frangi has a positive structure.
+    z_idx, y_idx, x_idx = np.indices(shape_zyx)
+    tube = np.exp(-(((z_idx - 4) ** 2 + (x_idx - 16) ** 2) / 4.0))
+    arr = arr + tube.astype(np.float32) * 5.0
+
+    # Wrap as (T=2, Z=8, Y=32, X=32) OME-TIFF — same metadata shape as
+    # the canonical yeast fixture so ImInfo's verifier picks it up
+    # without auto-detection drift.
+    arr_t = np.stack([arr, arr], axis=0)
+    src = tmp_path / "synth_3d.ome.tif"
+    tifffile.imwrite(
+        src,
+        arr_t,
+        photometric="minisblack",
+        metadata={
+            "axes": "TZYX",
+            "PhysicalSizeX": 0.0655,
+            "PhysicalSizeXUnit": "µm",
+            "PhysicalSizeY": 0.0655,
+            "PhysicalSizeYUnit": "µm",
+            "PhysicalSizeZ": 0.25,
+            "PhysicalSizeZUnit": "µm",
+            "TimeIncrement": 1.0,
+            "TimeIncrementUnit": "s",
+        },
+    )
+
+    info = load_image(src)
+    out = _run_filter(info, device="mps")
+
+    assert out.shape == arr_t.shape
+    assert out.dtype == np.float32
+    assert np.isfinite(out).all()
+    assert out.min() >= 0.0

--- a/tests/test_torch_xp.py
+++ b/tests/test_torch_xp.py
@@ -94,6 +94,89 @@ def test_zeros_with_explicit_float64_dtype_returns_float32(caplog) -> None:
     assert out.dtype == torch.float32
 
 
+def test_lazy_dtype_call_constructs_typed_scalar() -> None:
+    """``xp.float32(3.0)`` should return a 0-d float32 tensor.
+
+    Mirrors numpy's ``np.float32(3.0)`` — used by
+    ``chunking.eigvalsh_3x3_components`` (and any future caller that
+    needs a typed scalar constant) to keep arithmetic in float32. If
+    this regresses, the closed-form 3x3 eigenvalue path on MPS will
+    crash with "_LazyDtype is not callable".
+    """
+    out = torch_xp.float32(3.0)
+    assert isinstance(out, torch.Tensor)
+    assert out.dtype == torch.float32
+    assert out.ndim == 0
+    assert float(out) == pytest.approx(3.0)
+
+
+def test_lazy_dtype_call_float64_coerces_silently(caplog) -> None:
+    """``xp.float64(3.0)`` should also coerce to float32 (with the log notice)."""
+    torch_xp._FLOAT64_NOTICE_EMITTED = False
+    with caplog.at_level(logging.INFO, logger="nellie.utils.torch_xp"):
+        out = torch_xp.float64(3.0)
+    assert out.dtype == torch.float32
+
+
+def test_tensor_astype_method_added() -> None:
+    """torch.Tensor should expose an ``astype(dtype, copy=...)`` method.
+
+    Patched by ``torch_xp._patch_tensor_methods`` on first ``_torch()``
+    call. Stage code (Filter, frangi_math) was originally written
+    against numpy/cupy where ``arr.astype`` is the canonical cast; the
+    patch extends that contract to torch tensors so MPS goes through
+    the same code paths without per-call wrapping.
+
+    The patch routes the dtype through ``_resolve_dtype``, so a
+    ``float64`` request silently coerces to ``float32`` (with the
+    one-time log notice) — matching the rest of the shim's float64
+    contract.
+    """
+    # Touch the shim so the patch fires.
+    torch_xp._torch()
+    t = torch.zeros(3, dtype=torch.float32)
+    out = t.astype(torch.int64)
+    assert out.dtype == torch.int64
+    # Per numpy semantics, copy=True is the default — even when the
+    # target dtype matches, we should get a fresh tensor.
+    same_dtype = t.astype(torch.float32, copy=True)
+    assert same_dtype.dtype == torch.float32
+    assert same_dtype is not t
+    # copy=False short-circuits when dtype already matches.
+    no_copy = t.astype(torch.float32, copy=False)
+    assert no_copy is t
+
+
+def test_tensor_astype_silently_coerces_float64() -> None:
+    """``tensor.astype(torch.float64)`` should silently downgrade to float32.
+
+    Matches the rest of the shim's float64 contract — MPS doesn't
+    support double precision, so the patched ``astype`` runs the
+    requested dtype through ``_resolve_dtype`` (which emits the
+    one-time log notice and returns float32 for float64 requests).
+    """
+    torch_xp._torch()
+    t = torch.zeros(3, dtype=torch.float32)
+    out = t.astype(torch.float64)
+    assert out.dtype == torch.float32
+
+
+def test_tensor_get_method_added() -> None:
+    """torch.Tensor should expose a ``get()`` method (cupy-compat).
+
+    cupy's ``.get()`` returns a host numpy copy. The patch makes the
+    same idiom work for torch tensors — ``hasattr(arr, "get")``
+    duck-type checks in stage code (e.g. Filter._run_filter line 691)
+    fire on MPS too, so the result moves back to host before being
+    written into the on-disk memmap.
+    """
+    torch_xp._torch()
+    t = torch.tensor([1.0, 2.0, 3.0])
+    out = t.get()
+    assert isinstance(out, np.ndarray)
+    np.testing.assert_array_equal(out, [1.0, 2.0, 3.0])
+
+
 # -----------------------------------------------------------------------------
 # Construction ops
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #142 (parent PRD: #140).

## Summary

Slice 2 of the Apple Silicon / MPS work. Onboards `Filter.run()` end-to-end on torch+MPS and lands the smoke / equivalence / benchmark trio for the filtering stage.

The slice 1 PR (#146) wired `adaptive_run.resolve_backend("mps")` into all stages but didn't actually exercise per-stage code paths. Slice 2 does — and surfaces several latent stage-vs-shim contract bugs that the always-on shim contract tests didn't catch (the shim was correct; the stage code violated the contract on numpy-isms torch.Tensor doesn't match natively). All fixes are localized; no architectural changes.

## What's in

- **`Filter.run()` on MPS works end-to-end** on the yeast 3D + 2D fixtures with vesselness mean within 1e-6 of CPU and per-voxel max abs diff within 1e-8 (PRD ceiling: 0.5% / 1e-4 — way of headroom).

- **Stage-side fixes** in `nellie/segmentation/filtering.py`:
  - New `_probe_torch_backend()` mirror of the existing CuPy probe; cached `_TORCH_BACKEND` lets `_backend_for_array` route torch tensors back to the `torch_xp` / `torch_ndi` shim instead of falling through to numpy + scipy.
  - `device_type == "cuda"` branches in `_run_frame_chunked` widened to `hasattr(arr, "get")` duck-type checks — fires on cupy AND torch (the latter via the new shim patch).
  - `.size` accesses (5 sites in `filtering.py`, 1 each in `frangi_math.py` and `chunking.py`) replaced with `int(np.prod(arr.shape))`. torch.Tensor's `.size` is a method, not an int attribute.

- **Shim-side fixes** in `nellie/utils/torch_xp.py`:
  - New `_patch_tensor_methods` (called once on first `_torch()` import) attaches `astype(dtype, copy=...)` and `get()` to `torch.Tensor`. Lets stage code written against the numpy/cupy method contract flow torch tensors through unchanged.
  - `_LazyDtype.__call__` constructs a 0-d tensor of the proxied dtype — mirrors `np.float32(3.0)` scalar construction. Closed-form 3x3 eigenvalue path in `chunking.py` writes `xp.float32(3.0)` and previously crashed with "_LazyDtype is not callable".
  - `maximum(a, b)` now wraps Python-scalar args via `torch.as_tensor` so `xp.maximum(blobness, 0)` works the same as on numpy.

- **`otsu_threshold`** in `nellie/utils/gpu_functions.py` swapped negative-step slicing (`counts[::-1]`) for `xp.flip(counts, axis=0)`. torch tensors reject negative slicing; numpy/cupy were already happy with the flip equivalent.

- **Test trio**:
  - `tests/test_mps_smoke.py` — `mps`-marked. 3 tests covering `Filter.run()` end-to-end on the 3D yeast fixture, the 2D yeast fixture (which exercises the LoG-blobness fusion path on top of Frangi), and a small synthetic OME-TIFF (T=2, Z=8, Y=32, X=32).
  - `tests/test_mps_equivalence.py` — `mps`-marked. 2 tests (3D + 2D) running Filter on CPU and MPS on the same fixture; assert `rel_mean_diff <= 0.005` and `max_abs_diff <= 1e-4`.
  - `tests/test_filtering_perf.py` — gained an MPS variant of the end-to-end Filter wall-clock baseline (doubly-marked `benchmark` + `mps`).
  - `tests/test_torch_xp.py` — 5 always-on tests covering the new `_LazyDtype.__call__` and the patched Tensor methods (`astype`, `get`, float64 coercion behavior).

## Test plan

- [x] Default `pytest`: **556 passed, 14 deselected** (was 551 before this slice — +5 new always-on tests). No regressions.
- [x] `pytest -m mps`: **7 passed, 563 deselected** on Apple Silicon with torch+MPS (3 smoke + 2 equivalence + 2 perf-mps).
- [x] `pytest -m benchmark`: **9 passed** (7 original + 2 new end-to-end MPS wall-clock prints).
- [x] `pytest -m "mps and benchmark"`: **2 passed** (the doubly-marked perf variants).
- [x] Default suite still skips cleanly on torch-less installs (the always-on `test_torch_xp.py` / `test_torch_ndi.py` tests already short-circuit via `pytest.importorskip("torch")`).
- MPS hardware validation observed during implementation: **3D yeast fixture** rel_mean_diff ~1e-6, max_abs_diff ~1e-8; **2D yeast fixture** rel_mean_diff ~1e-7, max_abs_diff ~1e-7. Way inside the PRD tolerance bar.

## Wiki

The wiki refresh is **deferred to Phase 5 close-out** per the consolidation note in the implementor brief on #142 — slices 2-5 would all touch `wiki/gpu-runtime.md` and merge cost would be high. Phase 5 owns the single sweep that updates the gotchas, the "macOS = CPU" softening, and the per-stage onboarding status notes once all four stages are in.

## Things to flag for slice 3 (labelling)

- The latent stage-vs-shim contract bugs surfaced here (`.astype`, `.get`, `.size`, `xp.float32()`, negative-step slicing, `xp.maximum(arr, 0)`) almost certainly affect labelling, networking, and hu_tracking too. The shim patches in this PR cover three of them at the shim layer (`astype`, `get`, `_LazyDtype.__call__`), but the per-stage `.size` and negative-step idioms will need the same line-by-line treatment in each remaining stage. Worth grepping for the same patterns up front rather than discovering them one stage at a time.
- The `xp.maximum(arr, 0)` fix in the shim is general — covers the common "clip below zero" pattern that several other stages use too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)