### PR TITLE
MPS slice 3: labelling onboard

### DIFF
--- a/nellie/segmentation/labelling.py
+++ b/nellie/segmentation/labelling.py
@@ -16,6 +16,34 @@ from nellie.utils.gpu_functions import otsu_threshold, triangle_threshold
 _UNSET = object()
 
 
+def _probe_torch_backend():
+    """Resolve the torch+MPS backend tuple once at import time.
+
+    Returns ``(torch_xp, torch_ndi, torch.Tensor)`` or ``None`` when
+    torch is unavailable. Mirrors the cupy probe used elsewhere in the
+    pipeline (see :func:`nellie.segmentation.filtering._probe_torch_backend`)
+    so :func:`Label._xp_for_array` can dispatch torch tensors back to
+    the ``torch_xp`` / ``torch_ndi`` shim instead of falling through to
+    numpy. Without this, helpers like
+    :func:`Label._compute_frangi_threshold` would call ``np.log10`` on a
+    torch tensor (and worse, hand the tensor to ``otsu_threshold`` /
+    ``triangle_threshold`` with the wrong ``xp=`` namespace), losing the
+    GPU residency.
+    """
+    try:
+        import torch
+
+        from nellie.utils import torch_ndi as _torch_ndi
+        from nellie.utils import torch_xp as _torch_xp
+
+        return (_torch_xp, _torch_ndi, torch.Tensor)
+    except Exception:
+        return None
+
+
+_TORCH_BACKEND = _probe_torch_backend()
+
+
 @dataclass(frozen=True)
 class LabelConfig:
     """Algorithm configuration for ``Label``.
@@ -266,6 +294,13 @@ class Label:
         return max(1, chunk_z)
 
     def _xp_for_array(self, arr):
+        # Check torch first since the per-call cupy import is more
+        # expensive than the cached ``isinstance`` test. Both arms use
+        # the module-load-time probes (see ``_TORCH_BACKEND``); per-call
+        # ``import cupy`` was the prior shape and is preserved as the
+        # fallback for legacy CuPy installs that the probe might miss.
+        if _TORCH_BACKEND is not None and isinstance(arr, _TORCH_BACKEND[2]):
+            return _TORCH_BACKEND[0]
         try:
             import cupy
             if isinstance(arr, cupy.ndarray):
@@ -305,7 +340,10 @@ class Label:
         sampled values only to avoid allocating a full-size mask.
         """
         flat = frame.reshape(-1)
-        if flat.size == 0:
+        # ``.size`` is an int on numpy/cupy but a method on torch.Tensor;
+        # reduce via ``.shape`` for backend-agnostic element-count checks
+        # (mirrors the pattern in :mod:`nellie.segmentation.filtering`).
+        if int(np.prod(flat.shape)) == 0:
             return flat
 
         mask_flat = None
@@ -318,7 +356,7 @@ class Label:
             mask_mode = "thresh"
 
         max_samples = max(1, int(self.threshold_sampling_pixels))
-        step = max(int(flat.size) // max_samples, 1)
+        step = max(int(np.prod(flat.shape)) // max_samples, 1)
         offsets = (0, step // 2) if step > 1 and step // 2 > 0 else (0,)
 
         values = flat[:0]
@@ -333,7 +371,7 @@ class Label:
             else:
                 values = sample[sample > 0]
 
-            if values.size > 0 or step == 1:
+            if int(np.prod(values.shape)) > 0 or step == 1:
                 return values
 
         try:
@@ -356,7 +394,8 @@ class Label:
         Compute a combined triangle/Otsu threshold for a given frame (Frangi).
         """
         values = self._sample_nonzero(frame, mask_frame=mask_frame, mask_thresh=mask_thresh)
-        if values.size == 0:
+        # Backend-agnostic element-count check — see ``.size`` note above.
+        if int(np.prod(values.shape)) == 0:
             return None
 
         # work in log10 domain to match original logic
@@ -373,7 +412,8 @@ class Label:
         Compute Otsu threshold on the original intensity frame using sampling.
         """
         values = self._sample_nonzero(frame)
-        if values.size == 0:
+        # Backend-agnostic element-count check — see ``.size`` note above.
+        if int(np.prod(values.shape)) == 0:
             return None
         thresh, _ = otsu_threshold(values, nbins=self.histogram_nbins)
         return thresh
@@ -398,12 +438,14 @@ class Label:
         # Connected component labeling
         labels, _ = self.ndi.label(mask, structure=self.footprint)
 
-        # Remove very small objects using bincount + lookup table
-        if labels.size == 0:
+        # Remove very small objects using bincount + lookup table.
+        # ``.size`` is a method on torch.Tensor (an int on numpy/cupy);
+        # reduce via ``.shape`` for backend-agnostic count semantics.
+        if int(np.prod(labels.shape)) == 0:
             return mask, labels
 
         areas = self.xp.bincount(labels.ravel())
-        if areas.size <= 1:
+        if int(np.prod(areas.shape)) <= 1:
             return mask, labels
 
         areas[0] = 0  # ignore background
@@ -465,12 +507,16 @@ class Label:
             _, labels = self._get_labels(frangi_in_mem, frangi_thresh=frangi_thresh)
             return labels
         except Exception as exc:
-            if adaptive_run.is_oom_error(exc) and self.device_type == "cuda":
+            # Inner cascade fires for any GPU backend (cupy on CUDA, torch on
+            # MPS) — both can OOM on the full-volume Frangi load and benefit
+            # from the chunked-Z fallback / CPU switch below.
+            if adaptive_run.is_oom_error(exc) and self.device_type in ("cuda", "mps"):
                 adaptive_run.free_gpu_memory(self.xp)
                 if not self.im_info.no_z:
                     logger.warning(
-                        "CUDA OOM during full-volume labeling; "
-                        "falling back to chunked Z processing."
+                        "%s OOM during full-volume labeling; "
+                        "falling back to chunked Z processing.",
+                        self.device_type.upper(),
                     )
                     self._run_frame_chunked_z(
                         t,
@@ -481,7 +527,10 @@ class Label:
                         initial_chunk=frangi_view.shape[0],
                     )
                     return None
-                logger.warning("CUDA OOM during full-volume labeling; switching to CPU.")
+                logger.warning(
+                    "%s OOM during full-volume labeling; switching to CPU.",
+                    self.device_type.upper(),
+                )
                 self._set_backend("cpu")
                 return self._run_frame_full_volume(
                     t,
@@ -503,7 +552,12 @@ class Label:
             # No Z dimension: fall back to full-volume 2D processing
             labels = self._run_frame_full_volume(t, original_view, frangi_view, intensity_thresh, frangi_thresh)
             if labels is not None:
-                if self.device_type == 'cuda':
+                # Duck-type the GPU round-trip: ``hasattr(arr, "get")``
+                # fires on cupy.ndarray natively and on torch.Tensor via
+                # the shim's ``_patch_tensor_methods``. Brings the cuda
+                # and mps paths into sync — same idiom slice 2 used in
+                # ``filtering.py`` ``_run_frame_chunked``.
+                if hasattr(labels, "get"):
                     labels = labels.get()
                 self.instance_label_memmap[t, ...] = labels
             return
@@ -543,8 +597,10 @@ class Label:
                 # Labeling on Frangi chunk
                 _, labels_chunk = self._get_labels(frangi_chunk, frangi_thresh=frangi_thresh)
 
-                # Offset labels to make them unique within the frame
-                if labels_chunk.size > 0:
+                # Offset labels to make them unique within the frame.
+                # ``.size`` is a method on torch.Tensor — count via shape
+                # for backend-agnostic semantics.
+                if int(np.prod(labels_chunk.shape)) > 0:
                     max_label_chunk = int(labels_chunk.max())
                 else:
                     max_label_chunk = 0
@@ -554,8 +610,11 @@ class Label:
                     labels_chunk[labels_chunk > 0] += frame_label_offset
                     frame_label_offset += max_label_chunk
 
-                # Move to host if on CUDA and write to memmap
-                if self.device_type == 'cuda':
+                # Move to host on any GPU backend (cupy on CUDA, torch
+                # on MPS via shim) so the union-find boundary stitching
+                # below operates on numpy. Same duck-type idiom slice 2
+                # used in ``filtering.py``.
+                if hasattr(labels_chunk, "get"):
                     labels_chunk = labels_chunk.get()
 
                 if prev_boundary is not None and labels_chunk.size > 0:
@@ -589,7 +648,10 @@ class Label:
                             f'reducing chunk_z to {current_chunk}.'
                         )
                         continue
-                    if self.device_type == "cuda":
+                    # Both GPU backends (cupy on CUDA, torch on MPS)
+                    # benefit from the chunk_z=1 → CPU escape hatch; the
+                    # cuda-only narrowing predates the MPS onboard.
+                    if self.device_type in ("cuda", "mps"):
                         logger.warning('OOM even with chunk_z=1; switching to CPU.')
                         self._set_backend("cpu")
                         continue
@@ -635,7 +697,9 @@ class Label:
                     frangi_thresh,
                 )
                 if labels is not None:
-                    if self.device_type == 'cuda':
+                    # Duck-type GPU round-trip — cupy.ndarray.get() and
+                    # torch.Tensor.get() (via shim) both return numpy.
+                    if hasattr(labels, "get"):
                         labels = labels.get()
                     self.instance_label_memmap[t, ...] = labels
 

--- a/tests/test_labelling_perf.py
+++ b/tests/test_labelling_perf.py
@@ -1,0 +1,143 @@
+"""Opt-in performance tests for ``nellie.segmentation.labelling.Label``.
+
+Skipped by default — invoke with ``pytest -m benchmark`` to run. Mirrors
+the pattern in :mod:`tests.test_filtering_perf`:
+
+1. **End-to-end CPU baseline** prints a Label wall-clock baseline so a
+   future regression on the yeast fixture is visible relative to a
+   prior commit. No assertion: there is no canonical baseline checked
+   in (hardware varies wildly across dev machines).
+2. **End-to-end MPS variant** prints the same wall-clock baseline but
+   on torch+MPS. Doubly marked ``benchmark`` + ``mps`` so it runs with
+   either marker explicitly opted in. Skips cleanly on hardware
+   without torch+MPS so users on non-Mac hardware (or Macs without
+   ``pip install 'nellie[mps]'``) still see green when they run
+   ``pytest -m benchmark``.
+
+The interesting comparison is "MPS time vs CPU time on the same
+fixture"; capturing both as side-by-side ``[perf]`` lines is sufficient
+— we don't gate on the absolute value because hardware varies and
+labelling is a partial-acceleration story (see PRD #140 — only the
+``uniform_filter`` runs on MPS; the structural ``binary_fill_holes`` /
+``label`` ops round-trip to scipy on CPU).
+"""
+
+from __future__ import annotations
+
+import gc
+import time
+from statistics import median
+
+import pytest
+
+from nellie.segmentation.labelling import Label, LabelConfig
+from nellie.utils import adaptive_run
+
+
+pytestmark = pytest.mark.benchmark
+
+_CPU = LabelConfig(device="cpu")
+
+
+def _require_mps() -> None:
+    """Skip the calling MPS benchmark if torch+MPS isn't actually available.
+
+    Mirrors the helper in :mod:`tests.test_mps_smoke` so the skip
+    wording is consistent across the test trio.
+    """
+    if not adaptive_run.mps_available():
+        pytest.skip(
+            "torch+MPS not available — install with `pip install 'nellie[mps]'` "
+            "and run on Apple Silicon."
+        )
+
+
+def _release_label(lbl: Label) -> None:
+    lbl.instance_label_memmap = None
+    lbl.frangi_memmap = None
+    lbl.im_memmap = None
+    gc.collect()
+
+
+def _time_call(fn, *, iters: int) -> float:
+    """Median wall-clock of ``iters`` invocations, in seconds."""
+    samples: list[float] = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        samples.append(time.perf_counter() - start)
+    return median(samples)
+
+
+# -------------------------------------------------------------------------
+# End-to-end Label baseline (CPU; informational; no assertion)
+# -------------------------------------------------------------------------
+
+@pytest.mark.parametrize("dim", ["2d", "3d"])
+def test_label_run_baseline_prints_wall_clock(
+    dim, make_label_imageinfo_2d, make_label_imageinfo_3d, capsys
+) -> None:
+    """Print a Label wall-clock baseline. No assertion — read the output.
+
+    Runs against the yeast fixtures via the per-test factory (which
+    pre-populates ``im_preprocessed`` from a session cache, so this only
+    pays the Label cost — not Filter on top).
+    """
+    factory = make_label_imageinfo_2d if dim == "2d" else make_label_imageinfo_3d
+
+    def _one_run() -> None:
+        info = factory()
+        lbl = Label(info, _CPU, num_t=2)
+        lbl.run()
+        _release_label(lbl)
+
+    # Warm up: first run pays one-time costs (memmap setup, scipy caches).
+    _one_run()
+    elapsed = _time_call(_one_run, iters=3)
+
+    with capsys.disabled():
+        print(f"\n[perf] Label.run() {dim} median over 3: {elapsed * 1000:.1f} ms")
+
+
+# -------------------------------------------------------------------------
+# MPS variant of the end-to-end Label baseline
+#
+# Doubly-marked (``benchmark`` + ``mps``) so it runs with either marker
+# explicitly opted in. Skip cleanly when MPS isn't available so users on
+# non-Mac hardware still see green when they run ``pytest -m benchmark``.
+# -------------------------------------------------------------------------
+
+@pytest.mark.mps
+@pytest.mark.parametrize("dim", ["2d", "3d"])
+def test_label_run_baseline_prints_wall_clock_mps(
+    dim, make_label_imageinfo_2d, make_label_imageinfo_3d, capsys
+) -> None:
+    """Print a Label wall-clock baseline on MPS. No assertion — read the output.
+
+    Mirror of :func:`test_label_run_baseline_prints_wall_clock`. The
+    interesting comparison is "MPS time vs CPU time on the same fixture";
+    we don't gate on the absolute value because hardware varies wildly
+    across Mac models and labelling's MPS speedup is bounded by the
+    structural-op CPU round-trips (binary_fill_holes + two label calls
+    per frame — see PRD #140).
+    """
+    _require_mps()
+    factory = make_label_imageinfo_2d if dim == "2d" else make_label_imageinfo_3d
+    config_mps = LabelConfig(device="mps")
+
+    def _one_run() -> None:
+        info = factory()
+        lbl = Label(info, config_mps, num_t=2)
+        lbl.run()
+        _release_label(lbl)
+
+    # Warm up: first run pays one-time costs (memmap setup, MPS kernel
+    # caches, torch import-time work).
+    _one_run()
+    elapsed = _time_call(_one_run, iters=3)
+
+    with capsys.disabled():
+        print(
+            f"\n[perf] Label.run() {dim} (mps) median over 3: "
+            f"{elapsed * 1000:.1f} ms"
+        )

--- a/tests/test_mps_equivalence.py
+++ b/tests/test_mps_equivalence.py
@@ -32,6 +32,7 @@ import numpy as np
 import pytest
 
 from nellie.segmentation.filtering import Filter, FrangiConfig
+from nellie.segmentation.labelling import Label, LabelConfig
 from nellie.utils import adaptive_run
 
 
@@ -63,6 +64,18 @@ def _release_filter(filt: Filter) -> None:
     """
     filt.frangi_memmap = None
     filt.im_memmap = None
+    gc.collect()
+
+
+def _release_label(lbl: Label) -> None:
+    """Drop a Label's memmap references and force gc.
+
+    Mirrors :func:`_release_filter` — same Windows file-lock concern,
+    extra ``instance_label_memmap`` handle to release.
+    """
+    lbl.instance_label_memmap = None
+    lbl.frangi_memmap = None
+    lbl.im_memmap = None
     gc.collect()
 
 
@@ -186,4 +199,155 @@ def test_filter_equivalence_cpu_vs_mps_2d(make_imageinfo_2d, capsys) -> None:
         f"2D vesselness per-voxel max abs diff "
         f"({stats['max_abs_diff']:.3e}) exceeds the float32 tolerance "
         f"of 1e-4 used as the slice acceptance bar."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Label equivalence
+# ---------------------------------------------------------------------------
+
+
+def _run_label(im_info, *, device: str) -> np.ndarray:
+    """Run Label end-to-end on ``device`` and return a numpy copy of the labels."""
+    lbl = Label(im_info, LabelConfig(device=device), num_t=2)
+    lbl.run()
+    out = np.asarray(lbl.instance_label_memmap).copy()
+    _release_label(lbl)
+    return out
+
+
+def _label_iou_max_match(cpu: np.ndarray, mps: np.ndarray) -> float:
+    """Return the mean IoU after matching each MPS label to its best CPU overlap.
+
+    For each foreground id in the MPS frame, find the CPU id with the
+    largest spatial overlap, then compute IoU = |A ∩ B| / |A ∪ B|. Return
+    the mean across MPS ids (background id 0 excluded). MPS ids that
+    don't overlap any CPU foreground voxel score 0.0.
+
+    The PRD #140 § Testing Decisions bar for labelling is "label IoU >
+    0.95". Empirically on this fixture the labels are byte-identical
+    (the structural ``ndi.label`` round-trips to scipy on CPU in both
+    backends; only the upstream ``uniform_filter`` mask thresholding
+    can drift), so this score sits at exactly 1.0 — the > 0.95 bar
+    leaves slack for any future drift introduced by float32 rounding
+    cascading through the mask threshold.
+    """
+    cpu_ids = np.unique(cpu)
+    cpu_ids = cpu_ids[cpu_ids != 0]
+    mps_ids = np.unique(mps)
+    mps_ids = mps_ids[mps_ids != 0]
+    if mps_ids.size == 0:
+        # No foreground in MPS output: return 1.0 if CPU also has no
+        # foreground (perfect agreement on empty), else 0.0.
+        return 1.0 if cpu_ids.size == 0 else 0.0
+
+    ious: list[float] = []
+    for mid in mps_ids:
+        m_mask = mps == int(mid)
+        # Pick the CPU id with the largest overlap with this MPS id.
+        overlaps_with_cpu_ids = cpu[m_mask]
+        overlaps_with_cpu_ids = overlaps_with_cpu_ids[overlaps_with_cpu_ids != 0]
+        if overlaps_with_cpu_ids.size == 0:
+            ious.append(0.0)
+            continue
+        best_cpu = int(np.bincount(overlaps_with_cpu_ids).argmax())
+        c_mask = cpu == best_cpu
+        intersection = int((m_mask & c_mask).sum())
+        union = int((m_mask | c_mask).sum())
+        ious.append(intersection / union if union > 0 else 0.0)
+    return float(np.mean(ious))
+
+
+def _label_diagnostics(cpu: np.ndarray, mps: np.ndarray) -> dict[str, float]:
+    """Summary stats for diagnosing CPU vs MPS Label drift.
+
+    Returned keys:
+        cpu_count / mps_count — total foreground component count
+        cpu_voxels / mps_voxels — total foreground voxel count
+        mean_iou — mean per-MPS-label IoU vs best CPU match
+    """
+    cpu_ids = np.unique(cpu)
+    mps_ids = np.unique(mps)
+    return {
+        "cpu_count": float((cpu_ids != 0).sum()),
+        "mps_count": float((mps_ids != 0).sum()),
+        "cpu_voxels": float((cpu != 0).sum()),
+        "mps_voxels": float((mps != 0).sum()),
+        "mean_iou": _label_iou_max_match(cpu, mps),
+    }
+
+
+def test_label_equivalence_cpu_vs_mps_3d(make_label_imageinfo_3d, capsys) -> None:
+    """``Label.run()`` on the 3D yeast fixture: CPU vs MPS within IoU tolerance.
+
+    Tolerances:
+      - ``mean_iou >= 0.95`` — PRD #140 § Testing Decisions bar.
+
+    Note on tightness: the structural ``ndi.label`` and
+    ``binary_fill_holes`` ops round-trip to scipy on CPU in both
+    backends, so the only source of CPU/MPS drift is the convolutional
+    ``uniform_filter`` (and the upstream Frangi memmap they share —
+    which is precomputed once on CPU by the conftest cache, so it's
+    byte-identical here). Empirically labels come out byte-identical on
+    this hardware (mean_iou = 1.0); the > 0.95 bar leaves headroom for
+    any future drift that float32 ``uniform_filter`` rounding might
+    cascade through the mask threshold.
+    """
+    _require_mps()
+
+    cpu_out = _run_label(make_label_imageinfo_3d(), device="cpu")
+    mps_out = _run_label(make_label_imageinfo_3d(), device="mps")
+
+    assert mps_out.shape == cpu_out.shape
+    assert mps_out.dtype == cpu_out.dtype == np.int32
+
+    stats = _label_diagnostics(cpu_out, mps_out)
+
+    with capsys.disabled():
+        print(
+            f"\n[mps eq label 3D] cpu_count={int(stats['cpu_count'])} "
+            f"mps_count={int(stats['mps_count'])} "
+            f"cpu_voxels={int(stats['cpu_voxels'])} "
+            f"mps_voxels={int(stats['mps_voxels'])} "
+            f"mean_iou={stats['mean_iou']:.4f}"
+        )
+
+    assert stats["mean_iou"] >= 0.95, (
+        f"3D Label mean IoU between CPU and MPS dropped to "
+        f"{stats['mean_iou']:.3f}; expected >= 0.95 per PRD #140 "
+        f"§ Testing Decisions."
+    )
+
+
+def test_label_equivalence_cpu_vs_mps_2d(make_label_imageinfo_2d, capsys) -> None:
+    """``Label.run()`` on the 2D yeast fixture: CPU vs MPS within IoU tolerance.
+
+    Same > 0.95 bar as the 3D test. The 2D path skips
+    ``binary_fill_holes`` (only 3D fills holes — see
+    ``Label._get_labels``) so the op surface exercised here is even
+    smaller; expect equally tight or tighter agreement.
+    """
+    _require_mps()
+
+    cpu_out = _run_label(make_label_imageinfo_2d(), device="cpu")
+    mps_out = _run_label(make_label_imageinfo_2d(), device="mps")
+
+    assert mps_out.shape == cpu_out.shape
+    assert mps_out.dtype == cpu_out.dtype == np.int32
+
+    stats = _label_diagnostics(cpu_out, mps_out)
+
+    with capsys.disabled():
+        print(
+            f"\n[mps eq label 2D] cpu_count={int(stats['cpu_count'])} "
+            f"mps_count={int(stats['mps_count'])} "
+            f"cpu_voxels={int(stats['cpu_voxels'])} "
+            f"mps_voxels={int(stats['mps_voxels'])} "
+            f"mean_iou={stats['mean_iou']:.4f}"
+        )
+
+    assert stats["mean_iou"] >= 0.95, (
+        f"2D Label mean IoU between CPU and MPS dropped to "
+        f"{stats['mean_iou']:.3f}; expected >= 0.95 per PRD #140 "
+        f"§ Testing Decisions."
     )

--- a/tests/test_mps_smoke.py
+++ b/tests/test_mps_smoke.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 
 from nellie.segmentation.filtering import Filter, FrangiConfig
+from nellie.segmentation.labelling import Label, LabelConfig
 from nellie.utils import adaptive_run
 
 
@@ -51,6 +52,18 @@ def _release_filter(filt: Filter) -> None:
     """
     filt.frangi_memmap = None
     filt.im_memmap = None
+    gc.collect()
+
+
+def _release_label(lbl: Label) -> None:
+    """Drop a Label's memmap references and force gc.
+
+    Mirrors :func:`_release_filter` — same Windows file-lock concern,
+    extra ``instance_label_memmap`` handle to release.
+    """
+    lbl.instance_label_memmap = None
+    lbl.frangi_memmap = None
+    lbl.im_memmap = None
     gc.collect()
 
 
@@ -161,3 +174,66 @@ def test_filter_smoke_synthetic_3d(tmp_path) -> None:
     assert out.dtype == np.float32
     assert np.isfinite(out).all()
     assert out.min() >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Label smoke
+# ---------------------------------------------------------------------------
+
+
+def _run_label(im_info, *, device: str) -> np.ndarray:
+    """Run Label end-to-end on ``device`` and return a numpy copy of the labels.
+
+    The factory fixtures (``make_label_imageinfo_*``) pre-populate the
+    Frangi memmap from a session cache, so this only pays the Label
+    cost — not Filter on top.
+    """
+    lbl = Label(im_info, LabelConfig(device=device), num_t=2)
+    lbl.run()
+    out = np.asarray(lbl.instance_label_memmap).copy()
+    _release_label(lbl)
+    return out
+
+
+def test_label_smoke_3d(make_label_imageinfo_3d) -> None:
+    """``Label.run()`` end-to-end on MPS — 3D path doesn't crash, shape/dtype match CPU.
+
+    Exercises the convolutional ``uniform_filter`` call inside
+    ``_get_labels`` on the MPS shim, alongside the structural
+    ``binary_fill_holes`` and ``label`` round-trips back to scipy on
+    CPU. Per PRD #140 § Implementation Decisions, labelling is a
+    *partial-acceleration* story: only ``uniform_filter`` runs on MPS.
+
+    The CPU baseline is rerun in-process so the parity check is robust
+    to fixture-resolution drift across machines / torch versions.
+    """
+    _require_mps()
+
+    cpu_out = _run_label(make_label_imageinfo_3d(), device="cpu")
+    mps_out = _run_label(make_label_imageinfo_3d(), device="mps")
+
+    assert mps_out.shape == cpu_out.shape, (
+        f"MPS labels shape {mps_out.shape} != CPU shape {cpu_out.shape}"
+    )
+    assert mps_out.dtype == cpu_out.dtype == np.int32
+    # Labels are non-negative integer IDs — background is 0, foreground IDs > 0.
+    assert mps_out.min() == 0
+    assert (mps_out == 0).any(), "Expected at least some background voxels"
+
+
+def test_label_smoke_2d(make_label_imageinfo_2d) -> None:
+    """``Label.run()`` end-to-end on MPS — 2D path.
+
+    The 2D path skips ``binary_fill_holes`` (only 3D fills holes —
+    see ``Label._get_labels``) so it exercises a slightly smaller op
+    surface than the 3D smoke. Same shape/dtype contract.
+    """
+    _require_mps()
+
+    cpu_out = _run_label(make_label_imageinfo_2d(), device="cpu")
+    mps_out = _run_label(make_label_imageinfo_2d(), device="mps")
+
+    assert mps_out.shape == cpu_out.shape
+    assert mps_out.dtype == cpu_out.dtype == np.int32
+    assert mps_out.min() == 0
+    assert (mps_out == 0).any()


### PR DESCRIPTION
Closes #143 (parent PRD: #140).

## Summary

Slice 3 of the Apple Silicon / MPS work. Onboards `Label.run()`
end-to-end on torch+MPS and lands the smoke / equivalence / benchmark
trio for the labelling stage.

Mirrors the slice 2 (#147) shape exactly: same six categories of
stage-vs-shim contract bugs (`.size`, `device_type == "cuda"`,
`_xp_for_array` torch dispatch, OOM cascade widening, `.get()`
round-trip duck-typing), all localized to `labelling.py`. No
shim-side changes were needed — the patches slice 2 added
(`_patch_tensor_methods` for `astype`/`get`, `_LazyDtype.__call__`,
`xp.maximum(arr, scalar)`) all carry over unchanged.

Per PRD #140 § Implementation Decisions, labelling is a
*partial-acceleration* story: only the convolutional `uniform_filter`
runs on MPS; the structural `binary_fill_holes` and two `label` calls
round-trip to scipy on CPU per frame. Round-trip cost on Apple
Silicon's unified memory is small.

## What's in

- **`Label.run()` on MPS works end-to-end** on the yeast 3D + 2D
  fixtures. Empirically labels are byte-identical to CPU
  (mean_iou = 1.0 on both fixtures), since the structural `ndi.label`
  round-trips to scipy on CPU in both backends.

- **Stage-side fixes** in `nellie/segmentation/labelling.py`:
  - New `_probe_torch_backend()` mirrors slice 2's filtering probe;
    cached `_TORCH_BACKEND` lets `Label._xp_for_array` route torch
    tensors back to the `torch_xp` shim. Without this,
    `_compute_frangi_threshold` / `_compute_intensity_otsu_threshold`
    would call numpy ops on torch tensors and lose GPU residency.
  - `device_type == "cuda"` widened in two ways:
    - `.get()` round-trip sites (3 of them) become
      `hasattr(arr, "get")` duck-type checks — same idiom slice 2
      used in filtering. Fires on cupy.ndarray natively and on
      torch.Tensor via the shim's `_patch_tensor_methods`.
    - OOM cascade (full → chunked-Z, chunk_z=1 → CPU) widens to
      `self.device_type in ("cuda", "mps")`. Both GPU backends
      benefit from the chunked-Z fallback.
  - `.size` accesses replaced with `int(np.prod(arr.shape))` at 7
    sites in labelling.py. torch.Tensor's `.size` is a method, not
    an int attribute. Sites that fire AFTER the `hasattr(arr, "get")`
    round-trip already operate on numpy and need no change.

- **Test trio**:
  - `tests/test_mps_smoke.py` — gained `test_label_smoke_3d` and
    `test_label_smoke_2d`. Each runs `Label.run()` on yeast (3D / 2D
    respectively) on both CPU and MPS; asserts shape/dtype (int32) /
    background invariants.
  - `tests/test_mps_equivalence.py` — gained
    `test_label_equivalence_cpu_vs_mps_3d/_2d`. Each runs Label on
    CPU and MPS on the same fixture, computes per-MPS-label IoU vs
    the best-matching CPU label by spatial overlap, and asserts mean
    IoU >= 0.95 (PRD #140 § Testing Decisions bar). Empirically
    labels come out byte-identical on this hardware
    (mean_iou = 1.0); the > 0.95 bar leaves headroom for any future
    drift that float32 `uniform_filter` rounding might cascade
    through the mask threshold.
  - `tests/test_labelling_perf.py` — **new file**, mirrors
    `test_filtering_perf.py`. Two CPU baseline tests
    (parametrized 2d/3d, `benchmark`-marked) plus two MPS variants
    (doubly-marked `benchmark` + `mps`). Print-only; no assertions.

## Test plan

- [x] Default `pytest`: **556 passed, 22 deselected** (was 556 passed,
  14 deselected — 8 new opt-in tests added: 2 smoke + 2 equivalence +
  4 perf, of which 2 are doubly-marked).
- [x] `pytest -m mps`: **13 passed, 565 deselected** on Apple Silicon
  with torch+MPS (was 7 — added 2 smoke + 2 equivalence + 2 doubly-marked
  perf-mps).
- [x] `pytest -m benchmark`: **13 passed, 565 deselected** (was 9 —
  added 2 CPU baseline + 2 doubly-marked perf-mps).
- [x] `pytest -m "mps and benchmark"`: **4 passed** (was 2 — added 2
  doubly-marked Label perf-mps variants).
- [x] All slice 2 MPS tests still pass; no regression in
  shape/dtype/IoU on either filtering fixture.
- MPS hardware validation observed during implementation:
  - 3D yeast Label mean IoU = 1.0000 (byte-identical labels)
  - 2D yeast Label mean IoU = 1.0000
  - 3D `Label.run()` median: ~143 ms CPU vs ~205 ms MPS on this
    hardware (MPS slower; expected — labelling is partial
    acceleration with structural ops on CPU)
  - 2D `Label.run()` median: ~77 ms CPU vs ~73 ms MPS

## Wiki

The wiki refresh is **deferred to Phase 5 close-out** per the
consolidation note in the implementor brief on #143 — slices 2-5
would all touch `wiki/gpu-runtime.md` and merge cost would be high.
Phase 5 owns the single sweep that softens the "macOS = CPU" gotcha
and adds the per-stage onboarding status notes once all four stages
are in.

## Things flagged for slice 4+

- **No new shim patches were needed for this slice.** All slice 2
  shim patches (`_patch_tensor_methods` for `astype`/`get`,
  `_LazyDtype.__call__`, `xp.maximum(arr, scalar)`) carried over to
  labelling unchanged. The shim is exactly as sufficient as slice 2
  predicted.
- **The `.size` / `device_type == "cuda"` / `_xp_for_array`-torch
  patterns are likely also present** in `nellie/segmentation/networking.py`
  and `nellie/tracking/hu_tracking.py`. Pre-grep there before slice 4 /
  slice 5 rather than discovering one stage at a time — see slice 2's
  PR body for the same advice.
- **MPS speedup on the small yeast fixture is small/negative vs CPU**
  for labelling (~205 ms MPS vs ~143 ms CPU on 3D). The structural-op
  CPU round-trips (`binary_fill_holes` + two `label` calls per frame)
  dominate at this volume size. Worth re-measuring on production-sized
  volumes during Phase 5 to confirm the partial-acceleration story
  still pays off.
- **Chunked-Z MPS path is wired up but not directly tested** by the new
  smoke / equivalence trio (the yeast fixture runs full-volume by
  default). The OOM cascade widening (`("cuda", "mps")`) and `.get()`
  duck-typing are exercised on the surface but the chunked-Z control
  flow itself isn't. Slice 4+ stages with explicit chunking parameters
  (or a dedicated chunked-Z MPS smoke addition during Phase 5) would
  cover this gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)