### PR TITLE
MPS slice 4: networking onboard

### DIFF
--- a/nellie/segmentation/networking.py
+++ b/nellie/segmentation/networking.py
@@ -159,11 +159,16 @@ class Network:
         """
         Convert an array to the backend array type (xp).
         """
-        # xp is numpy when running on CPU and cupy when on GPU.
+        # xp is numpy on CPU, cupy on CUDA, and the torch_xp shim on MPS.
         try:
             return self.xp.asarray(arr)
         except Exception as e:
-            if self.device_type == "cuda":
+            # Both GPU backends (cupy on CUDA, torch on MPS) are explicit
+            # device pins by the time control reaches here — silently
+            # falling back to numpy would lose GPU residency on a recoverable
+            # failure (e.g. a transient dtype mismatch). Re-raise on either
+            # GPU backend so the cascade in ``run`` can decide.
+            if self.device_type in ("cuda", "mps"):
                 raise
             logger.warning(f"xp.asarray failed; falling back to numpy. Error: {e}")
             return np.asarray(arr)
@@ -172,7 +177,12 @@ class Network:
         """
         Convert xp array to a numpy array. If already numpy, return as-is.
         """
-        if self.device_type == "cuda" and hasattr(arr, "get"):
+        # Duck-type the GPU round-trip: ``hasattr(arr, "get")`` fires on
+        # cupy.ndarray natively and on torch.Tensor via the shim's
+        # ``_patch_tensor_methods``. Brings the cuda and mps paths into sync —
+        # same idiom slice 2 used in ``filtering.py`` and slice 3 used in
+        # ``labelling.py``.
+        if hasattr(arr, "get"):
             return arr.get()
         return np.asarray(arr)
 
@@ -657,9 +667,16 @@ class Network:
         try:
             return self._run_frame_backend(t)
         except Exception as exc:
-            if self.device_type != "cuda" or not adaptive_run.is_oom_error(exc):
+            # Both GPU backends benefit from the per-frame CPU fallback on
+            # OOM: cupy on CUDA can run out of VRAM, torch on MPS shares
+            # the system RAM headroom and can hit the same wall. The
+            # cuda-only narrowing predates the MPS onboard.
+            if self.device_type not in ("cuda", "mps") or not adaptive_run.is_oom_error(exc):
                 raise
-            logger.warning("GPU OOM in networking; falling back to CPU for this frame.")
+            logger.warning(
+                "%s OOM in networking; falling back to CPU for this frame.",
+                self.device_type.upper(),
+            )
             adaptive_run.free_gpu_memory(self.xp)
             self._set_backend("cpu")
             return self._run_frame_backend(t)
@@ -677,7 +694,13 @@ class Network:
 
         skel_pre_cpu = (skel_clean > 0) * label_frame_cpu
 
-        if self.device_type == "cuda" and not self.low_memory:
+        # Both GPU backends route through the convolution-based pixel-class
+        # path: cupy on CUDA dispatches to its own ndimage; torch on MPS
+        # dispatches to ``torch.nn.functional.conv*`` via the shim. The
+        # structural ``ndi.label`` round-trips to scipy on both backends —
+        # see PRD #140 § Implementation Decisions for the
+        # convolutional-vs-structural split.
+        if self.device_type in ("cuda", "mps") and not self.low_memory:
             skel_pre = self._to_xp(skel_pre_cpu)
             pixel_class = self._get_pixel_class(skel_pre)
             branch_skel_labels = self._get_branch_skel_labels(pixel_class)
@@ -702,26 +725,24 @@ class Network:
 
             skel, pixel_class, skel_relabelled = self._run_frame(t)
 
+            # Duck-type the GPU round-trip: ``hasattr(arr, "get")`` fires on
+            # cupy.ndarray natively and on torch.Tensor via the shim's
+            # ``_patch_tensor_methods``. Avoids the cuda-only narrowing
+            # that was hiding ``skel`` / ``pixel_class`` torch tensors
+            # behind a numpy fast-path; see ``_to_cpu`` for the same idiom.
+            def _host(arr):
+                return arr.get() if hasattr(arr, "get") else arr
+
             if self.im_info.no_t or self.num_t == 1:
                 # Single frame or static image
-                if self.device_type == "cuda":
-                    self.skel_memmap[:] = self._to_cpu(skel)
-                    self.pixel_class_memmap[:] = self._to_cpu(pixel_class)
-                    self.skel_relabelled_memmap[:] = self._to_cpu(skel_relabelled)
-                else:
-                    self.skel_memmap[:] = skel
-                    self.pixel_class_memmap[:] = pixel_class
-                    self.skel_relabelled_memmap[:] = skel_relabelled
+                self.skel_memmap[:] = _host(skel)
+                self.pixel_class_memmap[:] = _host(pixel_class)
+                self.skel_relabelled_memmap[:] = _host(skel_relabelled)
             else:
                 # Time series
-                if self.device_type == "cuda":
-                    self.skel_memmap[t] = self._to_cpu(skel)
-                    self.pixel_class_memmap[t] = self._to_cpu(pixel_class)
-                    self.skel_relabelled_memmap[t] = self._to_cpu(skel_relabelled)
-                else:
-                    self.skel_memmap[t] = skel
-                    self.pixel_class_memmap[t] = pixel_class
-                    self.skel_relabelled_memmap[t] = skel_relabelled
+                self.skel_memmap[t] = _host(skel)
+                self.pixel_class_memmap[t] = _host(pixel_class)
+                self.skel_relabelled_memmap[t] = _host(skel_relabelled)
 
     # -------------------------------------------------------------------------
     # Public entry point

--- a/tests/test_mps_equivalence.py
+++ b/tests/test_mps_equivalence.py
@@ -33,6 +33,7 @@ import pytest
 
 from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label, LabelConfig
+from nellie.segmentation.networking import Network, NetworkConfig
 from nellie.utils import adaptive_run
 
 
@@ -76,6 +77,21 @@ def _release_label(lbl: Label) -> None:
     lbl.instance_label_memmap = None
     lbl.frangi_memmap = None
     lbl.im_memmap = None
+    gc.collect()
+
+
+def _release_network(net: Network) -> None:
+    """Drop a Network's memmap references and force gc.
+
+    Mirrors :func:`_release_label` — same Windows file-lock concern,
+    six memmap handles to release (three inputs, three outputs).
+    """
+    net.skel_memmap = None
+    net.pixel_class_memmap = None
+    net.skel_relabelled_memmap = None
+    net.label_memmap = None
+    net.im_memmap = None
+    net.im_frangi_memmap = None
     gc.collect()
 
 
@@ -350,4 +366,183 @@ def test_label_equivalence_cpu_vs_mps_2d(make_label_imageinfo_2d, capsys) -> Non
         f"2D Label mean IoU between CPU and MPS dropped to "
         f"{stats['mean_iou']:.3f}; expected >= 0.95 per PRD #140 "
         f"§ Testing Decisions."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Network equivalence
+# ---------------------------------------------------------------------------
+
+
+def _run_network(im_info, *, device: str) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Run Network end-to-end on ``device``, return ``(skel, pixel_class, skel_relabelled)`` numpy copies.
+
+    The factory fixtures (``make_network_imageinfo_*``) pre-populate the
+    Frangi and Label memmaps from a session cache, so this only pays the
+    Network cost — not Filter + Label on top.
+    """
+    net = Network(im_info, NetworkConfig(device=device), num_t=2)
+    net.run()
+    skel = np.asarray(net.skel_memmap).copy()
+    pc = np.asarray(net.pixel_class_memmap).copy()
+    relab = np.asarray(net.skel_relabelled_memmap).copy()
+    _release_network(net)
+    return skel, pc, relab
+
+
+def _network_diagnostics(
+    cpu: tuple[np.ndarray, np.ndarray, np.ndarray],
+    mps: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> dict[str, float]:
+    """Summary stats for diagnosing CPU vs MPS Network drift.
+
+    Inputs are ``(skel, pixel_class, skel_relabelled)`` triples.
+
+    Returned keys:
+        skel_jaccard — Jaccard of the binary skeleton mask
+            (``skel > 0``). Acceptance bar; PRD #140 § Testing Decisions
+            calls for "Jaccard > 0.95".
+        junctions_cpu / junctions_mps — count of pixel_class == 4 (junction)
+            voxels. Acceptance bar; PRD asks for exact match on junction
+            count for typical inputs.
+        skel_array_equal — whether the int32 skeleton labels match
+            byte-for-byte. Empirically True on the yeast fixtures (the
+            structural ``ndi.label`` round-trips to scipy on CPU on both
+            backends).
+        pc_array_equal — whether the uint8 pixel-class image matches
+            byte-for-byte. Empirically True on the yeast fixtures.
+        relab_jaccard — Jaccard of the relabelled skeleton mask. Same
+            byte-identical empirical result on the yeast fixtures.
+    """
+    skel_cpu, pc_cpu, relab_cpu = cpu
+    skel_mps, pc_mps, relab_mps = mps
+
+    cpu_mask = skel_cpu > 0
+    mps_mask = skel_mps > 0
+    inter = int((cpu_mask & mps_mask).sum())
+    union = int((cpu_mask | mps_mask).sum())
+    skel_jacc = inter / union if union else 1.0
+
+    relab_cpu_mask = relab_cpu > 0
+    relab_mps_mask = relab_mps > 0
+    relab_inter = int((relab_cpu_mask & relab_mps_mask).sum())
+    relab_union = int((relab_cpu_mask | relab_mps_mask).sum())
+    relab_jacc = relab_inter / relab_union if relab_union else 1.0
+
+    return {
+        "skel_jaccard": skel_jacc,
+        "junctions_cpu": float(int((pc_cpu == 4).sum())),
+        "junctions_mps": float(int((pc_mps == 4).sum())),
+        "skel_array_equal": float(np.array_equal(skel_cpu, skel_mps)),
+        "pc_array_equal": float(np.array_equal(pc_cpu, pc_mps)),
+        "relab_jaccard": relab_jacc,
+    }
+
+
+def test_network_equivalence_cpu_vs_mps_3d(make_network_imageinfo_3d, capsys) -> None:
+    """``Network.run()`` on the 3D yeast fixture: CPU vs MPS within tolerance.
+
+    Tolerances:
+      - ``skel_jaccard >= 0.95`` — PRD #140 § Testing Decisions bar for
+        the binary skeleton mask.
+      - ``junctions_cpu == junctions_mps`` — PRD asks for exact match on
+        junction count for typical inputs.
+
+    Note on tightness: the only convolutional op in Network is
+    ``ndi.convolve`` inside ``_get_pixel_class_impl`` (a 3×3×3 kernel of
+    ones over a uint8 binary mask). That's integer arithmetic over a
+    small kernel, so the float32-rounding-cascade story that surfaces
+    in Filter doesn't apply here. The skeletonization, structural
+    ``ndi.label``, and per-object distance transforms all force-CPU.
+    Empirically the entire ``(skel, pixel_class, skel_relabelled)``
+    triple is byte-identical to CPU on this hardware (skel_jaccard =
+    1.0, byte-equal labels); the > 0.95 bar leaves headroom for any
+    future drift introduced by torch's MPS conv path picking a different
+    accumulation order on borderline values.
+    """
+    _require_mps()
+
+    cpu_outs = _run_network(make_network_imageinfo_3d(), device="cpu")
+    mps_outs = _run_network(make_network_imageinfo_3d(), device="mps")
+
+    skel_cpu, pc_cpu, relab_cpu = cpu_outs
+    skel_mps, pc_mps, relab_mps = mps_outs
+    assert skel_mps.shape == skel_cpu.shape
+    assert pc_mps.shape == pc_cpu.shape
+    assert relab_mps.shape == relab_cpu.shape
+    assert skel_mps.dtype == skel_cpu.dtype == np.int32
+    assert pc_mps.dtype == pc_cpu.dtype == np.uint8
+    assert relab_mps.dtype == relab_cpu.dtype == np.uint32
+
+    stats = _network_diagnostics(cpu_outs, mps_outs)
+
+    with capsys.disabled():
+        print(
+            f"\n[mps eq net 3D] skel_jaccard={stats['skel_jaccard']:.4f} "
+            f"junctions_cpu={int(stats['junctions_cpu'])} "
+            f"junctions_mps={int(stats['junctions_mps'])} "
+            f"skel_array_equal={bool(stats['skel_array_equal'])} "
+            f"pc_array_equal={bool(stats['pc_array_equal'])} "
+            f"relab_jaccard={stats['relab_jaccard']:.4f}"
+        )
+
+    assert stats["skel_jaccard"] >= 0.95, (
+        f"3D Network skeleton mask Jaccard between CPU and MPS dropped "
+        f"to {stats['skel_jaccard']:.3f}; expected >= 0.95 per PRD "
+        f"#140 § Testing Decisions."
+    )
+    assert stats["junctions_cpu"] == stats["junctions_mps"], (
+        f"3D Network junction count differs between CPU "
+        f"({int(stats['junctions_cpu'])}) and MPS "
+        f"({int(stats['junctions_mps'])}); PRD #140 asks for exact "
+        f"match on junction count for typical inputs."
+    )
+
+
+def test_network_equivalence_cpu_vs_mps_2d(make_network_imageinfo_2d, capsys) -> None:
+    """``Network.run()`` on the 2D yeast fixture: CPU vs MPS within tolerance.
+
+    Same > 0.95 / exact-junction bar as the 3D test. The 2D path uses a
+    (3, 3) convolution kernel instead of (3, 3, 3) — different shim
+    dispatch (``conv2d`` vs ``conv3d``) but same arithmetic story.
+    Empirically the 2D yeast fixture has zero junctions on both
+    backends, which is itself an exact match (the > 0.95 skeleton
+    Jaccard bar still applies).
+    """
+    _require_mps()
+
+    cpu_outs = _run_network(make_network_imageinfo_2d(), device="cpu")
+    mps_outs = _run_network(make_network_imageinfo_2d(), device="mps")
+
+    skel_cpu, pc_cpu, relab_cpu = cpu_outs
+    skel_mps, pc_mps, relab_mps = mps_outs
+    assert skel_mps.shape == skel_cpu.shape
+    assert pc_mps.shape == pc_cpu.shape
+    assert relab_mps.shape == relab_cpu.shape
+    assert skel_mps.dtype == skel_cpu.dtype == np.int32
+    assert pc_mps.dtype == pc_cpu.dtype == np.uint8
+    assert relab_mps.dtype == relab_cpu.dtype == np.uint32
+
+    stats = _network_diagnostics(cpu_outs, mps_outs)
+
+    with capsys.disabled():
+        print(
+            f"\n[mps eq net 2D] skel_jaccard={stats['skel_jaccard']:.4f} "
+            f"junctions_cpu={int(stats['junctions_cpu'])} "
+            f"junctions_mps={int(stats['junctions_mps'])} "
+            f"skel_array_equal={bool(stats['skel_array_equal'])} "
+            f"pc_array_equal={bool(stats['pc_array_equal'])} "
+            f"relab_jaccard={stats['relab_jaccard']:.4f}"
+        )
+
+    assert stats["skel_jaccard"] >= 0.95, (
+        f"2D Network skeleton mask Jaccard between CPU and MPS dropped "
+        f"to {stats['skel_jaccard']:.3f}; expected >= 0.95 per PRD "
+        f"#140 § Testing Decisions."
+    )
+    assert stats["junctions_cpu"] == stats["junctions_mps"], (
+        f"2D Network junction count differs between CPU "
+        f"({int(stats['junctions_cpu'])}) and MPS "
+        f"({int(stats['junctions_mps'])}); PRD #140 asks for exact "
+        f"match on junction count for typical inputs."
     )

--- a/tests/test_mps_smoke.py
+++ b/tests/test_mps_smoke.py
@@ -22,6 +22,7 @@ import pytest
 
 from nellie.segmentation.filtering import Filter, FrangiConfig
 from nellie.segmentation.labelling import Label, LabelConfig
+from nellie.segmentation.networking import Network, NetworkConfig
 from nellie.utils import adaptive_run
 
 
@@ -64,6 +65,22 @@ def _release_label(lbl: Label) -> None:
     lbl.instance_label_memmap = None
     lbl.frangi_memmap = None
     lbl.im_memmap = None
+    gc.collect()
+
+
+def _release_network(net: Network) -> None:
+    """Drop a Network's memmap references and force gc.
+
+    Mirrors :func:`_release_label` — same Windows file-lock concern, six
+    memmap handles to release (three inputs that ``Network._allocate_memory``
+    opens as read-only and three outputs).
+    """
+    net.skel_memmap = None
+    net.pixel_class_memmap = None
+    net.skel_relabelled_memmap = None
+    net.label_memmap = None
+    net.im_memmap = None
+    net.im_frangi_memmap = None
     gc.collect()
 
 
@@ -237,3 +254,97 @@ def test_label_smoke_2d(make_label_imageinfo_2d) -> None:
     assert mps_out.dtype == cpu_out.dtype == np.int32
     assert mps_out.min() == 0
     assert (mps_out == 0).any()
+
+
+# ---------------------------------------------------------------------------
+# Network smoke
+# ---------------------------------------------------------------------------
+
+
+def _run_network(im_info, *, device: str) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Run Network end-to-end on ``device`` and return numpy copies of the three outputs.
+
+    Returns ``(skel, pixel_class, skel_relabelled)``. The factory
+    fixtures (``make_network_imageinfo_*``) pre-populate the Frangi and
+    Label memmaps from a session cache, so this only pays the Network
+    cost — not Filter + Label on top.
+    """
+    net = Network(im_info, NetworkConfig(device=device), num_t=2)
+    net.run()
+    skel = np.asarray(net.skel_memmap).copy()
+    pc = np.asarray(net.pixel_class_memmap).copy()
+    relab = np.asarray(net.skel_relabelled_memmap).copy()
+    _release_network(net)
+    return skel, pc, relab
+
+
+def test_network_smoke_3d(make_network_imageinfo_3d) -> None:
+    """``Network.run()`` end-to-end on MPS — 3D path doesn't crash, shape/dtype match CPU.
+
+    Exercises the convolutional ``ndi.convolve`` call inside
+    ``_get_pixel_class_impl`` on the MPS shim, alongside the structural
+    ``ndi.label`` call inside ``_get_branch_skel_labels`` (which
+    round-trips to scipy on CPU via the shim). Per PRD #140 §
+    Implementation Decisions, networking is a *partial-acceleration*
+    story: only the convolutional ops run on MPS; the structural
+    ``label``, ``binary_fill_holes``, and skeletonization round-trip to
+    scipy on CPU.
+
+    The CPU baseline is rerun in-process so the parity check is robust
+    to fixture-resolution drift across machines / torch versions.
+    """
+    _require_mps()
+
+    skel_cpu, pc_cpu, relab_cpu = _run_network(
+        make_network_imageinfo_3d(), device="cpu"
+    )
+    skel_mps, pc_mps, relab_mps = _run_network(
+        make_network_imageinfo_3d(), device="mps"
+    )
+
+    # Skeleton image: int32 labels, background = 0.
+    assert skel_mps.shape == skel_cpu.shape, (
+        f"MPS skel shape {skel_mps.shape} != CPU shape {skel_cpu.shape}"
+    )
+    assert skel_mps.dtype == skel_cpu.dtype == np.int32
+
+    # Pixel-class image: uint8 with values in {0, 1, 2, 3, 4}
+    # (background, isolated, tip, edge, junction-clipped).
+    assert pc_mps.shape == pc_cpu.shape
+    assert pc_mps.dtype == pc_cpu.dtype == np.uint8
+    assert pc_mps.min() == 0
+    assert pc_mps.max() <= 4
+
+    # Skeleton relabelled image: uint32, background = 0.
+    assert relab_mps.shape == relab_cpu.shape
+    assert relab_mps.dtype == relab_cpu.dtype == np.uint32
+    assert relab_mps.min() == 0
+
+
+def test_network_smoke_2d(make_network_imageinfo_2d) -> None:
+    """``Network.run()`` end-to-end on MPS — 2D path.
+
+    The 2D path uses a (3, 3) convolution kernel instead of (3, 3, 3),
+    so it exercises a slightly different shim dispatch (``conv2d`` vs
+    ``conv3d``). Same shape/dtype contract.
+    """
+    _require_mps()
+
+    skel_cpu, pc_cpu, relab_cpu = _run_network(
+        make_network_imageinfo_2d(), device="cpu"
+    )
+    skel_mps, pc_mps, relab_mps = _run_network(
+        make_network_imageinfo_2d(), device="mps"
+    )
+
+    assert skel_mps.shape == skel_cpu.shape
+    assert skel_mps.dtype == skel_cpu.dtype == np.int32
+
+    assert pc_mps.shape == pc_cpu.shape
+    assert pc_mps.dtype == pc_cpu.dtype == np.uint8
+    assert pc_mps.min() == 0
+    assert pc_mps.max() <= 4
+
+    assert relab_mps.shape == relab_cpu.shape
+    assert relab_mps.dtype == relab_cpu.dtype == np.uint32
+    assert relab_mps.min() == 0

--- a/tests/test_networking_perf.py
+++ b/tests/test_networking_perf.py
@@ -1,0 +1,151 @@
+"""Opt-in performance tests for ``nellie.segmentation.networking.Network``.
+
+Skipped by default — invoke with ``pytest -m benchmark`` to run. Mirrors
+the pattern in :mod:`tests.test_filtering_perf` and
+:mod:`tests.test_labelling_perf`:
+
+1. **End-to-end CPU baseline** prints a Network wall-clock baseline so a
+   future regression on the yeast fixture is visible relative to a
+   prior commit. No assertion: there is no canonical baseline checked
+   in (hardware varies wildly across dev machines).
+2. **End-to-end MPS variant** prints the same wall-clock baseline but
+   on torch+MPS. Doubly marked ``benchmark`` + ``mps`` so it runs with
+   either marker explicitly opted in. Skips cleanly on hardware
+   without torch+MPS so users on non-Mac hardware (or Macs without
+   ``pip install 'nellie[mps]'``) still see green when they run
+   ``pytest -m benchmark``.
+
+The interesting comparison is "MPS time vs CPU time on the same
+fixture"; capturing both as side-by-side ``[perf]`` lines is sufficient
+— we don't gate on the absolute value because hardware varies and
+networking is a partial-acceleration story (see PRD #140 — only the
+convolutional ``ndi.convolve`` runs on MPS; the structural
+``ndi.label``, ``binary_fill_holes``, skeletonization, distance
+transforms, and per-frame relabel pass all force-CPU).
+"""
+
+from __future__ import annotations
+
+import gc
+import time
+from statistics import median
+
+import pytest
+
+from nellie.segmentation.networking import Network, NetworkConfig
+from nellie.utils import adaptive_run
+
+
+pytestmark = pytest.mark.benchmark
+
+_CPU = NetworkConfig(device="cpu")
+
+
+def _require_mps() -> None:
+    """Skip the calling MPS benchmark if torch+MPS isn't actually available.
+
+    Mirrors the helper in :mod:`tests.test_mps_smoke` so the skip
+    wording is consistent across the test trio.
+    """
+    if not adaptive_run.mps_available():
+        pytest.skip(
+            "torch+MPS not available — install with `pip install 'nellie[mps]'` "
+            "and run on Apple Silicon."
+        )
+
+
+def _release_network(net: Network) -> None:
+    net.skel_memmap = None
+    net.pixel_class_memmap = None
+    net.skel_relabelled_memmap = None
+    net.label_memmap = None
+    net.im_memmap = None
+    net.im_frangi_memmap = None
+    gc.collect()
+
+
+def _time_call(fn, *, iters: int) -> float:
+    """Median wall-clock of ``iters`` invocations, in seconds."""
+    samples: list[float] = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        samples.append(time.perf_counter() - start)
+    return median(samples)
+
+
+# -------------------------------------------------------------------------
+# End-to-end Network baseline (CPU; informational; no assertion)
+# -------------------------------------------------------------------------
+
+@pytest.mark.parametrize("dim", ["2d", "3d"])
+def test_network_run_baseline_prints_wall_clock(
+    dim, make_network_imageinfo_2d, make_network_imageinfo_3d, capsys
+) -> None:
+    """Print a Network wall-clock baseline. No assertion — read the output.
+
+    Runs against the yeast fixtures via the per-test factory (which
+    pre-populates ``im_preprocessed`` and ``im_instance_label`` from a
+    session cache, so this only pays the Network cost — not Filter +
+    Label on top).
+    """
+    factory = make_network_imageinfo_2d if dim == "2d" else make_network_imageinfo_3d
+
+    def _one_run() -> None:
+        info = factory()
+        net = Network(info, _CPU, num_t=2)
+        net.run()
+        _release_network(net)
+
+    # Warm up: first run pays one-time costs (memmap setup, scipy caches).
+    _one_run()
+    elapsed = _time_call(_one_run, iters=3)
+
+    with capsys.disabled():
+        print(f"\n[perf] Network.run() {dim} median over 3: {elapsed * 1000:.1f} ms")
+
+
+# -------------------------------------------------------------------------
+# MPS variant of the end-to-end Network baseline
+#
+# Doubly-marked (``benchmark`` + ``mps``) so it runs with either marker
+# explicitly opted in. Skip cleanly when MPS isn't available so users on
+# non-Mac hardware still see green when they run ``pytest -m benchmark``.
+# -------------------------------------------------------------------------
+
+@pytest.mark.mps
+@pytest.mark.parametrize("dim", ["2d", "3d"])
+def test_network_run_baseline_prints_wall_clock_mps(
+    dim, make_network_imageinfo_2d, make_network_imageinfo_3d, capsys
+) -> None:
+    """Print a Network wall-clock baseline on MPS. No assertion — read the output.
+
+    Mirror of :func:`test_network_run_baseline_prints_wall_clock`. The
+    interesting comparison is "MPS time vs CPU time on the same fixture";
+    we don't gate on the absolute value because hardware varies wildly
+    across Mac models and networking's MPS speedup is bounded by the
+    structural-op CPU round-trips (skeletonization, ``ndi.label``, the
+    per-object distance transforms in ``_relabel_objects``, and the
+    boundary-stripped 3×3(×3) min/max neighborhood filters in
+    ``_remove_connected_label_pixels`` — see PRD #140).
+    """
+    _require_mps()
+    factory = make_network_imageinfo_2d if dim == "2d" else make_network_imageinfo_3d
+    config_mps = NetworkConfig(device="mps")
+
+    def _one_run() -> None:
+        info = factory()
+        net = Network(info, config_mps, num_t=2)
+        net.run()
+        _release_network(net)
+
+    # Warm up: first run pays one-time costs (memmap setup, MPS kernel
+    # caches, torch import-time work).
+    _one_run()
+    elapsed = _time_call(_one_run, iters=3)
+
+    with capsys.disabled():
+        print(
+            f"\n[perf] Network.run() {dim} (mps) median over 3: "
+            f"{elapsed * 1000:.1f} ms"
+        )


### PR DESCRIPTION
Closes #144 (parent PRD: #140).

## Summary

Slice 4 of the Apple Silicon / MPS work. Onboards `Network.run()`
end-to-end on torch+MPS and lands the smoke / equivalence / benchmark
trio for the networking stage.

Mirrors the slice 2 (#147) and slice 3 (#148) shape: same five
categories of stage-vs-shim contract bugs (`device_type == "cuda"`
narrowing in the OOM/availability cascades, `.get()` round-trip
duck-typing for memmap writeback, GPU pixel-class branch widening),
all localized to `networking.py`. **No shim-side changes were needed**
— the shim patches slice 2 added (`_patch_tensor_methods` for
`astype`/`get`, `_LazyDtype.__call__`, `xp.maximum(arr, scalar)`)
all carry over unchanged. The `.size` audits in `networking.py` came
up clean: every `.size` site already operates on
`np.asarray()`-wrapped arrays.

Per PRD #140 § Implementation Decisions, networking is more ndi-heavy
than labelling: the convolutional `ndi.convolve` (3×3 or 3×3×3 kernel
of ones) inside `_get_pixel_class_impl` runs on MPS via the shim's
`torch.nn.functional.conv*` dispatch. The structural `ndi.label`
round-trips to scipy on CPU per frame, and the skeletonization,
distance-transform-based per-object relabelling, and 3×3(×3) min/max
neighborhood filters in `_remove_connected_label_pixels` all force-CPU.

## What's in

- **`Network.run()` on MPS works end-to-end** on the yeast 3D + 2D
  fixtures. Empirically all three Network outputs (`im_skel`,
  `im_pixel_class`, `im_skel_relabelled`) are byte-identical to CPU
  on both fixtures (skel_jaccard = 1.0, skel_array_equal = True,
  pc_array_equal = True, exact junction count match). The 3×3(×3)
  binary convolution inside `_get_pixel_class_impl` is integer
  arithmetic over a small kernel, so the float32-rounding-cascade
  story that surfaces in Filter doesn't apply here.

- **Stage-side fixes** in `nellie/segmentation/networking.py`:
  - `_to_xp` widens `device_type == "cuda"` to
    `device_type in ("cuda", "mps")` for the re-raise on
    `xp.asarray` failure, so an explicit MPS pin doesn't silently
    lose GPU residency on a recoverable error.
  - `_to_cpu` drops the `device_type == "cuda"` predicate entirely
    in favor of a duck-type `hasattr(arr, "get")` check — same
    idiom slice 2 used in `filtering.py` and slice 3 used in
    `labelling.py`.
  - `_run_frame`'s outer OOM cascade widens to
    `device_type in ("cuda", "mps")` so torch+MPS OOMs trigger the
    per-frame CPU fallback (cupy on CUDA: VRAM; torch on MPS:
    system RAM headroom).
  - `_run_frame_backend`'s "GPU pixel-class path" widens to
    `device_type in ("cuda", "mps") and not self.low_memory` so
    `_get_pixel_class` / `_get_branch_skel_labels` actually
    dispatch through the shim on MPS, exercising `ndi.convolve`
    on the GPU.
  - `_run_networking`'s memmap writeback collapses the cuda-only
    `_to_cpu` branches to a single duck-typed `_host(arr)` helper.
    The cuda-only narrowing was hiding `skel` / `pixel_class`
    torch tensors behind a numpy fast-path that would have errored
    on `memmap[:] = torch_tensor` writes.

- **Test trio**:
  - `tests/test_mps_smoke.py` — gained `test_network_smoke_3d` and
    `test_network_smoke_2d`. Each runs `Network.run()` on yeast
    (3D / 2D respectively) on both CPU and MPS; asserts shape /
    dtype invariants on all three outputs (`im_skel` int32,
    `im_pixel_class` uint8 in {0..4}, `im_skel_relabelled` uint32).
  - `tests/test_mps_equivalence.py` — gained
    `test_network_equivalence_cpu_vs_mps_3d/_2d`. Each runs Network
    on CPU and MPS on the same fixture; asserts skeleton-mask
    Jaccard >= 0.95 and exact junction-count match (PRD #140 §
    Testing Decisions bar). Empirically all three outputs come out
    byte-identical on this hardware; the > 0.95 / exact-junction
    bar leaves headroom for any future drift introduced by torch's
    MPS conv path picking a different accumulation order on
    borderline values.
  - `tests/test_networking_perf.py` — **new file**, mirrors
    `test_filtering_perf.py` and `test_labelling_perf.py`. Two CPU
    baseline tests (parametrized 2d/3d, `benchmark`-marked) plus
    two MPS variants (doubly-marked `benchmark` + `mps`).
    Print-only; no assertions.

## Test plan

- [x] Default `pytest`: **556 passed, 30 deselected** (was 556 passed,
  22 deselected — 8 new opt-in tests added: 2 smoke + 2 equivalence
  + 4 perf, of which 2 are doubly-marked).
- [x] `pytest -m mps`: **19 passed, 567 deselected** on Apple Silicon
  with torch+MPS (was 13 — added 2 smoke + 2 equivalence + 2
  doubly-marked perf-mps).
- [x] `pytest -m benchmark`: **17 passed, 569 deselected** (was 13 —
  added 2 CPU baseline + 2 doubly-marked perf-mps).
- [x] `pytest -m "mps and benchmark"`: **6 passed, 580 deselected**
  (was 4 — added 2 doubly-marked Network perf-mps variants).
- [x] All slice 2 + 3 MPS tests still pass; no regression in
  shape/dtype/Jaccard on either filtering or labelling fixture.
- MPS hardware validation observed during implementation:
  - 3D yeast Network skel_jaccard = 1.0000 (byte-identical),
    junctions_cpu == junctions_mps == 3, all three outputs
    array-equal.
  - 2D yeast Network skel_jaccard = 1.0000 (byte-identical),
    junctions_cpu == junctions_mps == 0, all three outputs
    array-equal.
  - 3D `Network.run()` median: ~183 ms CPU vs ~165 ms MPS on this
    hardware (modest ~10% MPS speedup on the 3D path; better than
    labelling's slight regression — PRD #140 predicted "meaningful
    end-to-end speedup despite the unavoidable structural-op CPU
    bounce").
  - 2D `Network.run()` median: ~80 ms CPU vs ~91 ms MPS (slight
    slow-down on the small fixture; MPS dispatch overhead dominates
    on a single 192×279 frame).

## Wiki

The wiki refresh is **deferred to Phase 5 close-out** per the
consolidation note in the implementor brief on #144 — slices 2-5
would all touch `wiki/gpu-runtime.md` and merge cost would be high.
Phase 5 owns the single sweep that softens the "macOS = CPU" gotcha
and adds the per-stage onboarding status notes once all four stages
are in.

## Things flagged for slice 5+

- **No new shim patches were needed for this slice**, mirroring slice
  3's experience. All slice 2 shim patches carried over to networking
  unchanged. The shim is exactly as sufficient as slices 2 and 3
  predicted, which is encouraging for slice 5 (hu_tracking) — though
  hu_tracking has the documented float64-coercion gotcha for the
  moment-distance matrix that slice 4 didn't have to worry about.

- **The `.size` / `[::-1]` slicing patterns came up clean** in
  `networking.py` (every `.size` site already operates on
  `np.asarray()`-wrapped arrays; no negative-step slicing). Slice 5
  should still pre-grep `nellie/tracking/hu_tracking.py` for the same
  patterns up front, since hu_tracking has more numpy-isms in its
  per-frame moment computation than networking did.

- **MPS speedup on the 3D Network path is modest (~10%) on the small
  yeast fixture.** The structural-op CPU round-trips
  (skeletonization, two `ndi.label` calls per frame, the per-object
  EDT in `_relabel_objects`, and the boundary-stripped 3×3(×3) min/max
  in `_remove_connected_label_pixels`) bound the speedup. Worth
  re-measuring on production-sized volumes during Phase 5 to confirm
  the partial-acceleration story scales — the convolutional pixel-class
  pass should grow more dominant as the volume grows.

- **Chunked low-memory MPS path is wired up but not directly tested**
  by the new smoke / equivalence trio (the yeast fixture runs
  full-volume by default with `low_memory=False`). The OOM cascade
  widening (`("cuda", "mps")` in `_run_frame`) is exercised on the
  surface but the chunked control flow itself isn't. Slice 5+ stages
  with explicit chunking parameters (or a dedicated chunked-Z MPS
  smoke addition during Phase 5) would cover this gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)