### PR TITLE
napari: surface backend in status + torch_ndi getattr trap for non-onboarded stages

### DIFF
--- a/nellie/utils/torch_ndi.py
+++ b/nellie/utils/torch_ndi.py
@@ -633,3 +633,27 @@ def label(input, structure=None, output=None):  # noqa: A002 - matches scipy API
         output.copy_(labels_out if hasattr(output, "copy_") else labels_np)
         return output, num_features
     return labels_out, num_features
+
+
+def __getattr__(name: str) -> Any:
+    """Trap unknown ``ndi.*`` access with a clear ``NotImplementedError``.
+
+    The shim covers the 9 ``scipy.ndimage`` ops used by the four
+    MPS-onboarded stages (filtering, labelling, networking, hu_tracking).
+    Anything else fires this trap. ``adaptive_run.is_gpu_unavailable_error``
+    recognizes the ``"torch_ndi"`` substring in the message and treats it
+    as "stage not MPS-onboarded yet" so the cascade falls back to CPU
+    rather than crashing.
+
+    Used by Markers (``binary_dilation``, ``distance_transform_edt``),
+    Hierarchy, and VoxelReassigner — none of which are v1-onboarded.
+
+    Only fires for names that aren't already module attributes (Python
+    only consults ``__getattr__`` after the normal lookup fails).
+    """
+    raise NotImplementedError(
+        f"torch_ndi.{name} is not implemented. The MPS shim only covers the "
+        f"9 scipy.ndimage ops used by the four onboarded stages "
+        f"(filtering, labelling, networking, hu_tracking). If you're "
+        f"onboarding a new stage to MPS, add the op here. See PRD #140."
+    )

--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -323,14 +323,18 @@ class NellieProcessor(QWidget):
             Optional per-step override for number of timepoints.
         """
         for im_num, im_info in enumerate(im_info_list):
-            show_info(f"Nellie is running: Preprocessing file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            Filter(
+            stage = Filter(
                 im_info=self.current_im_info,
                 config=config,
                 viewer=self.viewer,
                 num_t=num_t,
-            ).run()
+            )
+            show_info(
+                f"Nellie is running: Preprocessing file {im_num + 1}/{len(im_info_list)} "
+                f"on {stage.device_type.upper()}"
+            )
+            stage.run()
 
     def run_preprocessing(self):
         """
@@ -372,20 +376,26 @@ class NellieProcessor(QWidget):
             Optional per-step override for Network's number of timepoints.
         """
         for im_num, im_info in enumerate(im_info_list):
-            show_info(f"Nellie is running: Segmentation file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            Label(
+            label_stage = Label(
                 im_info=self.current_im_info,
                 config=label_config,
                 viewer=self.viewer,
                 num_t=label_num_t,
-            ).run()
-            Network(
+            )
+            network_stage = Network(
                 im_info=self.current_im_info,
                 config=network_config,
                 viewer=self.viewer,
                 num_t=network_num_t,
-            ).run()
+            )
+            show_info(
+                f"Nellie is running: Segmentation file {im_num + 1}/{len(im_info_list)} "
+                f"on {label_stage.device_type.upper()} (label) + "
+                f"{network_stage.device_type.upper()} (network)"
+            )
+            label_stage.run()
+            network_stage.run()
 
     def run_segmentation(self):
         """
@@ -421,14 +431,18 @@ class NellieProcessor(QWidget):
             Optional per-step override for number of timepoints.
         """
         for im_num, im_info in enumerate(im_info_list):
-            show_info(f"Nellie is running: Mocap Marking file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            Markers(
+            stage = Markers(
                 im_info=self.current_im_info,
                 config=config,
                 viewer=self.viewer,
                 num_t=num_t,
-            ).run()
+            )
+            show_info(
+                f"Nellie is running: Mocap Marking file {im_num + 1}/{len(im_info_list)} "
+                f"on {stage.device_type.upper()}"
+            )
+            stage.run()
 
     def run_mocap(self):
         """
@@ -459,14 +473,18 @@ class NellieProcessor(QWidget):
             Optional per-step override for number of timepoints.
         """
         for im_num, im_info in enumerate(im_info_list):
-            show_info(f"Nellie is running: Tracking file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            HuMomentTracking(
+            stage = HuMomentTracking(
                 im_info=self.current_im_info,
                 config=config,
                 viewer=self.viewer,
                 num_t=num_t,
-            ).run()
+            )
+            show_info(
+                f"Nellie is running: Tracking file {im_num + 1}/{len(im_info_list)} "
+                f"on {stage.device_type.upper()}"
+            )
+            stage.run()
 
     def run_tracking(self):
         """
@@ -502,14 +520,18 @@ class NellieProcessor(QWidget):
             Optional per-step override for number of timepoints.
         """
         for im_num, im_info in enumerate(im_info_list):
-            show_info(f"Nellie is running: Voxel Reassignment file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            VoxelReassigner(
+            stage = VoxelReassigner(
                 im_info=self.current_im_info,
                 config=config,
                 viewer=self.viewer,
                 num_t=num_t,
-            ).run()
+            )
+            show_info(
+                f"Nellie is running: Voxel Reassignment file {im_num + 1}/{len(im_info_list)} "
+                f"on {stage.device_type.upper()}"
+            )
+            stage.run()
 
     def run_reassign(self):
         """
@@ -545,13 +567,17 @@ class NellieProcessor(QWidget):
             Whether to remove intermediate files after each Hierarchy run.
         """
         for im_num, im_info in enumerate(im_info_list):
-            show_info(f"Nellie is running: Feature export file {im_num + 1}/{len(im_info_list)}")
             self.current_im_info = im_info
-            Hierarchy(
+            stage = Hierarchy(
                 im_info=self.current_im_info,
                 config=config,
                 viewer=self.viewer,
-            ).run()
+            )
+            show_info(
+                f"Nellie is running: Feature export file {im_num + 1}/{len(im_info_list)} "
+                f"on {stage.device_type.upper()}"
+            )
+            stage.run()
             if remove_intermediates_checked:
                 try:
                     self.current_im_info.remove_intermediates()


### PR DESCRIPTION
## What

Two small Mac-GUI fixes shipping together:

### 1. Backend visible in per-stage status notifications

Each \`show_info()\` in \`nellie_processor.py\` now reports the resolved backend (CPU / CUDA / MPS) the stage actually picked after \`device_cascade\` resolution. Answers \"is it actually using my GPU?\" without tailing the Python console.

Before: \`Nellie is running: Preprocessing file 1/3\`
After: \`Nellie is running: Preprocessing file 1/3 on MPS\`

The segmentation runner shows both stages: \`...Segmentation file 1/3 on MPS (label) + MPS (network)\`.

### 2. \`torch_ndi.__getattr__\` trap so non-onboarded stages cascade gracefully

User hit: \`Error during mocap marking: module 'nellie.utils.torch_ndi' has no attribute 'binary_dilation'\`.

Root cause: Markers/mocap (and Hierarchy, VoxelReassigner) aren't MPS-onboarded in v1 — they use ndi ops the shim doesn't implement. When a Mac user picks \`device=\"auto\"\` or \`\"gpu\"\` and one of these stages hits a missing op, Python's default \`AttributeError\` surfaces — the cascade doesn't catch it because \`is_gpu_unavailable_error\` only recognizes \`NotImplementedError\` with the \`\"torch_ndi\"\` marker (slice 1 design).

Fix: mirror \`torch_xp\`'s existing \`__getattr__\` trap. Any unknown \`torch_ndi.<op>\` access raises \`NotImplementedError(\"torch_ndi.<op> is not implemented...\")\` with the \`\"torch_ndi\"\` substring the cascade pattern-matches. Markers now transparently runs on CPU when invoked with \`device=\"auto\"/\"gpu\"\` on a Mac with torch+MPS installed.

Verified locally:
\`\`\`
>>> torch_ndi.binary_dilation
NotImplementedError: torch_ndi.binary_dilation is not implemented...
>>> adaptive_run.is_gpu_unavailable_error(exc)
True
\`\`\`

## Test plan

- [x] Default \`pytest\`: 561 passed (no regression).
- [x] Manual repro of the trap in REPL.
- [ ] Manual verification in napari: re-run mocap step on a Mac with MPS env, confirm it falls back to CPU silently and finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)