### PR TITLE
Slice 6: Backfill Network microbenchmarks (#159)

### DIFF
--- a/tests/test_networking_perf.py
+++ b/tests/test_networking_perf.py
@@ -14,14 +14,30 @@ the pattern in :mod:`tests.test_filtering_perf` and
    without torch+MPS so users on non-Mac hardware (or Macs without
    ``pip install 'nellie[mps]'``) still see green when they run
    ``pytest -m benchmark``.
+3. **Hot-path microbenchmarks** decompose the per-frame cost into
+   the dominant CPU-only ops surfaced by reading the source:
+   - ``_skeletonize`` (whole-frame) vs ``_skeletonize_per_object``
+     (low-memory variant) — pin the bulk-vs-per-object trade-off.
+   - ``_relabel_objects`` per-frame: total + ``find_objects`` setup
+     vs sum-of-per-object EDT — surfaces the many-small-objects
+     pathology.
+   - ``_remove_connected_label_pixels_impl`` max/min-filter
+     wall-clock — known CPU-only baseline.
 
-The interesting comparison is "MPS time vs CPU time on the same
+The interesting MPS comparison is "MPS time vs CPU time on the same
 fixture"; capturing both as side-by-side ``[perf]`` lines is sufficient
 — we don't gate on the absolute value because hardware varies and
 networking is a partial-acceleration story (see PRD #140 — only the
 convolutional ``ndi.convolve`` runs on MPS; the structural
 ``ndi.label``, ``binary_fill_holes``, skeletonization, distance
 transforms, and per-frame relabel pass all force-CPU).
+
+The microbenchmarks are **informational** (printed `[perf]` lines, no
+assertions). Filter's three assertions exist because each pinned a
+decision from a real perf pass; here no Network perf pass has happened
+yet, so assertions would be speculative. The prints scaffold the
+future perf pass — they show which CPU-only op dominates so an author
+can pick the right hot-path.
 """
 
 from __future__ import annotations
@@ -30,7 +46,9 @@ import gc
 import time
 from statistics import median
 
+import numpy as np
 import pytest
+import scipy.ndimage as scipy_ndi
 
 from nellie.segmentation.networking import Network, NetworkConfig
 from nellie.utils import adaptive_run
@@ -148,4 +166,154 @@ def test_network_run_baseline_prints_wall_clock_mps(
         print(
             f"\n[perf] Network.run() {dim} (mps) median over 3: "
             f"{elapsed * 1000:.1f} ms"
+        )
+
+
+# -------------------------------------------------------------------------
+# Hot-path microbenchmarks (informational; CPU only)
+# -------------------------------------------------------------------------
+
+@pytest.fixture(params=["2d", "3d"])
+def network_setup(request, make_network_imageinfo_2d, make_network_imageinfo_3d):
+    """Per-frame inputs for Network microbenchmarks (CPU).
+
+    Builds a Network instance, allocates memmaps, and extracts t=0
+    label + Frangi as numpy + a fresh skeleton via the production
+    ``_skeletonize`` so subsequent ops in the per-frame chain
+    (``_remove_connected_label_pixels``, ``_relabel_objects``) can be
+    driven directly without re-running upstream stages between
+    iterations.
+    """
+    factory = make_network_imageinfo_2d if request.param == "2d" else make_network_imageinfo_3d
+    info = factory()
+    net = Network(info, _CPU, num_t=2)
+    net._allocate_memory()
+
+    assert net.label_memmap is not None and net.im_frangi_memmap is not None
+    label_frame_cpu = np.asarray(net.label_memmap[0])
+    frangi_frame_cpu = np.asarray(net.im_frangi_memmap[0])
+
+    yield net, label_frame_cpu, frangi_frame_cpu, request.param
+
+    _release_network(net)
+
+
+def test_skeletonize_bulk_vs_per_object(network_setup, capsys) -> None:
+    """`_skeletonize` (whole-frame) vs `_skeletonize_per_object` (low-memory).
+
+    Pin the bulk-vs-per-object trade-off: the per-object loop pays a
+    crop+skeletonize cost per label and is what runs under
+    ``low_memory=True`` or after a bulk-skeletonize MemoryError.
+    """
+    net, label_frame, _frangi, dim = network_setup
+
+    # Warm up
+    net._skeletonize(label_frame)
+    net._skeletonize_per_object(label_frame)
+
+    t_bulk = _time_call(lambda: net._skeletonize(label_frame), iters=3)
+    t_per_obj = _time_call(
+        lambda: net._skeletonize_per_object(label_frame), iters=3
+    )
+
+    with capsys.disabled():
+        print(
+            f"\n[perf] Network skeletonize {dim}: "
+            f"bulk={t_bulk * 1000:.1f}ms per_object={t_per_obj * 1000:.1f}ms "
+            f"(per_object/bulk={t_per_obj / max(t_bulk, 1e-9):.2f}x)"
+        )
+
+
+def test_remove_connected_label_pixels_wall_clock(network_setup, capsys) -> None:
+    """`_remove_connected_label_pixels_impl` max/min-filter wall-clock.
+
+    Two 3×3(×3) neighborhood filters + boolean reductions. CPU-only
+    by design (the GPU branch was never worth exercising per the
+    source comment).
+    """
+    net, label_frame, _frangi, dim = network_setup
+    skel = net._skeletonize(label_frame)
+    skel_pre = (skel > 0) * label_frame
+
+    # Warm up
+    net._remove_connected_label_pixels_impl(skel_pre, np, scipy_ndi)
+
+    elapsed = _time_call(
+        lambda: net._remove_connected_label_pixels_impl(skel_pre, np, scipy_ndi),
+        iters=5,
+    )
+
+    with capsys.disabled():
+        print(
+            f"\n[perf] Network._remove_connected_label_pixels_impl {dim} "
+            f"median over 5: {elapsed * 1000:.1f} ms"
+        )
+
+
+def test_relabel_objects_decomposed_wall_clock(network_setup, capsys) -> None:
+    """`_relabel_objects` per-frame: total + find_objects vs sum-of-EDT.
+
+    The per-object EDT loop is the suspected many-small-objects
+    pathology. Print total + find_objects setup cost + sum of
+    per-object distance_transform_edt cost so the loop's contribution
+    is visible.
+    """
+    net, label_frame, _frangi, dim = network_setup
+    skel = net._skeletonize(label_frame)
+    skel_clean = net._remove_connected_label_pixels(skel)
+    skel_pre = (skel_clean > 0) * label_frame
+    pixel_class = net._get_pixel_class(skel_pre, force_cpu=True)
+    branch_skel_labels = net._get_branch_skel_labels(pixel_class, force_cpu=True)
+
+    # Warm up
+    net._relabel_objects(branch_skel_labels, label_frame)
+
+    t_total = _time_call(
+        lambda: net._relabel_objects(branch_skel_labels, label_frame),
+        iters=3,
+    )
+
+    # Decompose: time `find_objects` + sum of per-object EDT
+    labels_np = np.asarray(label_frame, dtype=np.int32)
+    branch_np = np.asarray(branch_skel_labels, dtype=np.int32)
+
+    scipy_ndi.find_objects(labels_np)
+    t_find = _time_call(lambda: scipy_ndi.find_objects(labels_np), iters=3)
+
+    slices = scipy_ndi.find_objects(labels_np)
+    max_label = int(labels_np.max())
+
+    def _sum_edts() -> None:
+        for lab in range(1, max_label + 1):
+            idx = lab - 1
+            if idx >= len(slices):
+                break
+            sl = slices[idx]
+            if sl is None:
+                continue
+            sub_labels = labels_np[sl]
+            sub_branch = branch_np[sl]
+            obj_mask = sub_labels == lab
+            if not obj_mask.any():
+                continue
+            seed_mask = (sub_branch > 0) & obj_mask
+            if not seed_mask.any():
+                continue
+            edt_input = np.logical_not(seed_mask)
+            scipy_ndi.distance_transform_edt(
+                edt_input,
+                sampling=net.scaling,
+                return_distances=False,
+                return_indices=True,
+            )
+
+    _sum_edts()
+    t_edt_sum = _time_call(_sum_edts, iters=3)
+
+    with capsys.disabled():
+        print(
+            f"\n[perf] Network._relabel_objects {dim} ({max_label} labels) "
+            f"total={t_total * 1000:.1f}ms; "
+            f"find_objects={t_find * 1000:.1f}ms "
+            f"sum_per_object_edt={t_edt_sum * 1000:.1f}ms"
         )


### PR DESCRIPTION
## Summary

- Closes #159 (PRD #153 slice 6 of 7).
- Adds 3 informational microbenchmarks to `tests/test_networking_perf.py`:
  - `_skeletonize` bulk vs `_skeletonize_per_object` (low-memory) trade-off
  - `_relabel_objects` decomposed (find_objects + sum-of-per-object EDT)
  - `_remove_connected_label_pixels_impl` 3×3(×3) max/min-filter baseline
- Existing CPU + MPS end-to-end tests unchanged.

## Test plan

- [x] `pytest -m benchmark tests/test_networking_perf.py -v` — 10 passed (was 4)
- [x] `pytest tests/test_networking.py -q` — 24 passed (no regression)
- [x] No changes to `nellie/segmentation/networking.py` or `tests/conftest.py`

## Sample output

```
[perf] Network skeletonize 3d: bulk=6.9ms per_object=2.4ms (per_object/bulk=0.34x)
[perf] Network._remove_connected_label_pixels_impl 3d median over 5: 12.3 ms
[perf] Network._relabel_objects 3d (2 labels) total=2.6ms; find_objects=1.5ms sum_per_object_edt=0.8ms
```

Surprise from the small fixture: `per_object < bulk` for skeletonize at this label count — the per-object loop's overhead amortizes when there are few labels. Real-world fixtures with many small labels will likely flip this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)