### PR TITLE
perf(networking): thread _relabel_objects per-object EDTs (Slice 2 of #173)

### DIFF
--- a/nellie/segmentation/networking.py
+++ b/nellie/segmentation/networking.py
@@ -5,6 +5,8 @@ This module provides the Network class for skeletonizing network-like structures
 and analyzing their topology with optimized CPU/GPU processing.
 """
 import itertools
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 
 import numpy as np
@@ -397,17 +399,24 @@ class Network:
     # Branch relabeling using per-object distance transforms
     # -------------------------------------------------------------------------
     def _relabel_objects(self, branch_skel_labels, label_frame):
-        """
-        Relabels skeleton pixels by propagating labels to nearby unlabeled pixels.
+        """Relabel skeleton pixels by propagating branch labels via per-object EDT.
 
-        This implementation operates per object instance to reduce memory usage.
-        For each object label in `label_frame`, it:
+        For each object label in ``label_frame``, runs a distance transform on
+        its bounding-box crop to find the nearest skeleton-branch seed for
+        every object voxel. Per-object EDTs run in parallel via
+        :class:`~concurrent.futures.ThreadPoolExecutor` (scipy's
+        ``distance_transform_edt`` releases the GIL); writeback to the shared
+        output array is serialized via ``as_completed`` to handle the race
+        surface on overlapping bounding boxes (one object's bbox can contain
+        another object's voxels even when their masks are disjoint).
 
-          1. Extracts a bounding-box crop containing that object.
-          2. Uses the skeleton branch labels inside the crop as seeds.
-          3. Runs a distance transform in the crop to find the nearest seed for
-             each voxel of the object.
-          4. Assigns branch labels to all voxels of the object accordingly.
+        ``self.low_memory=True`` forces the serial path (no executor). Worker
+        count is capped at ``min(cpu_count, len(work), 8)`` — EDT scaling is
+        memory-bandwidth-bound past 4-8 threads on typical hardware.
+
+        See ``wiki/decisions/0005-relabel-objects-serialized-writeback.md``
+        for the writeback-serialization, ``low_memory`` gating, and worker-cap
+        rationale.
 
         Parameters
         ----------
@@ -419,7 +428,7 @@ class Network:
         Returns
         -------
         numpy.ndarray
-            Relabeled skeleton for the entire frame.
+            Relabeled skeleton for the entire frame (uint32).
         """
         # Work on CPU for distance transforms; SciPy's EDT is very efficient.
         labels_np = self._to_cpu(label_frame).astype(np.int32, copy=False)
@@ -436,57 +445,61 @@ class Network:
         if slices is None:
             return relabelled_np
 
-        for lab in range(1, max_label + 1):
-            idx = lab - 1
-            if idx >= len(slices):
-                break
-            sl = slices[idx]
-            if sl is None:
-                continue
+        work = [
+            (lab, slices[lab - 1])
+            for lab in range(1, max_label + 1)
+            if lab - 1 < len(slices) and slices[lab - 1] is not None
+        ]
 
+        def _worker(item):
+            lab, sl = item
             sub_labels = labels_np[sl]
-            sub_branch = branch_np[sl]
-
-            obj_mask = (sub_labels == lab)
+            obj_mask = sub_labels == lab
             if not obj_mask.any():
-                continue
-
-            # Seeds are branch labels (>0) inside this object crop
+                return None
+            sub_branch = branch_np[sl]
+            # Seeds are branch labels (>0) inside this object crop.
             seed_mask = (sub_branch > 0) & obj_mask
-            if not (seed_mask & obj_mask).any():
-                # No skeleton seeds for this object; leave unlabeled
-                continue
-
-            # For EDT, zeros are considered seeds. We invert the seed mask:
-            # seed_mask True -> 0, False -> 1
-            edt_input = np.logical_not(seed_mask)
-
-            # Distance transform with indices: returns coordinates of nearest seed voxel.
-            # We do not need distances, only indices.
+            if not seed_mask.any():
+                # No skeleton seeds for this object; leave unlabeled.
+                return None
             try:
                 indices = ndi_cpu.distance_transform_edt(
-                    edt_input,
+                    np.logical_not(seed_mask),
                     sampling=self.scaling,
                     return_distances=False,
                     return_indices=True,
                 )
-            except Exception as e:
+            except Exception as exc:
                 logger.warning(
                     f"Distance transform failed for label {lab}. "
-                    f"Leaving object unlabeled. Error: {e}"
+                    f"Leaving object unlabeled. Error: {exc}"
                 )
-                continue
+                return None
+            nearest = sub_branch[tuple(indices)]
+            return (sl, obj_mask, nearest[obj_mask].astype(np.uint32, copy=False))
 
-            # indices has shape (ndim, ...) and points into sub_branch
-            nearest_labels = sub_branch[tuple(indices)]
+        # low_memory forces serial; single-item work has no parallelism upside.
+        if self.low_memory or len(work) <= 1:
+            for item in work:
+                result = _worker(item)
+                if result is None:
+                    continue
+                sl, obj_mask, values = result
+                relabelled_np[sl][obj_mask] = values
+            return relabelled_np
 
-            # Restrict to the object mask: outside the object remains zero
-            nearest_labels[~obj_mask] = 0
-
-            # Merge into global relabelled array.
-            relabelled_sub = relabelled_np[sl]
-            relabelled_sub[obj_mask] = nearest_labels[obj_mask].astype(np.uint32, copy=False)
-            relabelled_np[sl] = relabelled_sub
+        max_workers = min(os.cpu_count() or 1, len(work), 8)
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futures = [ex.submit(_worker, item) for item in work]
+            for fut in as_completed(futures):
+                result = fut.result()
+                if result is None:
+                    continue
+                sl, obj_mask, values = result
+                # Serialized writeback on the main thread — required for
+                # correctness on overlapping bboxes (see ADR 0005).
+                relabelled_np[sl][obj_mask] = values
 
         return relabelled_np
 

--- a/tests/test_networking.py
+++ b/tests/test_networking.py
@@ -808,6 +808,55 @@ def test_relabel_objects_object_with_no_seeds_3d(
     )
 
 
+def test_relabel_objects_serial_vs_threaded_equivalence_3d(
+    make_network_imageinfo_3d,
+) -> None:
+    """Threading must not perturb output: serial and threaded paths produce byte-identical results.
+
+    Runs the upstream pipeline on the test machine to get realistic
+    ``(label_frame, branch_skel_labels)`` inputs, then calls
+    ``_relabel_objects`` twice — once with ``low_memory=True`` (forces
+    serial), once with ``low_memory=False`` (uses ``ThreadPoolExecutor``
+    when ``len(work) > 1``). Asserts ``np.array_equal`` between the two
+    outputs.
+
+    Intra-platform deterministic by construction: both calls run on the
+    same machine with the same scipy build, so any EDT tie-break
+    non-determinism affects both equally. This is the regression bar
+    that no cross-platform snapshot can be (see
+    ``wiki/decisions/0005-relabel-objects-serialized-writeback.md``
+    Consequences).
+    """
+    info = make_network_imageinfo_3d()
+    net = _build_cpu_network(info, low_memory=False)
+    assert net.label_memmap is not None
+    assert net.im_frangi_memmap is not None
+
+    # Run the upstream pipeline mirror of _run_frame_backend to get realistic input.
+    label_frame = np.asarray(net.label_memmap[0]).copy()
+    frangi_frame = np.asarray(net.im_frangi_memmap[0])
+    skel = net._skeletonize(label_frame)
+    skel = net._remove_connected_label_pixels(skel)
+    skel = net._add_missing_skeleton_labels(skel, label_frame, frangi_frame)
+    skel_pre_cpu = (skel > 0) * label_frame
+    pixel_class = net._get_pixel_class(skel_pre_cpu, force_cpu=True)
+    branch_skel_labels = net._get_branch_skel_labels(pixel_class, force_cpu=True)
+
+    # Run both paths on the same machine.
+    net.low_memory = True
+    serial_output = net._relabel_objects(branch_skel_labels, label_frame)
+    net.low_memory = False
+    threaded_output = net._relabel_objects(branch_skel_labels, label_frame)
+    _release_network(net)
+
+    assert np.array_equal(serial_output, threaded_output), (
+        "Threaded _relabel_objects output diverged from serial output. "
+        "This indicates the threading rewrite perturbed observable behavior — "
+        "verify that the writeback is still serialized through as_completed "
+        "(see wiki/decisions/0005-relabel-objects-serialized-writeback.md)."
+    )
+
+
 # -------------------------------------------------------------------------
 # 2D path
 # -------------------------------------------------------------------------

--- a/tests/test_networking_perf.py
+++ b/tests/test_networking_perf.py
@@ -251,13 +251,18 @@ def test_remove_connected_label_pixels_wall_clock(network_setup, capsys) -> None
 
 
 def test_relabel_objects_decomposed_wall_clock(network_setup, capsys) -> None:
-    """`_relabel_objects` per-frame: total + find_objects vs sum-of-EDT.
+    """`_relabel_objects` per-frame: serial vs threaded + find_objects + sum-of-EDT.
 
-    The per-object EDT loop is the suspected many-small-objects
-    pathology. Print total + find_objects setup cost + sum of
-    per-object distance_transform_edt cost so the loop's contribution
-    is visible.
+    The per-object EDT loop is the parallelism target — scipy's
+    ``distance_transform_edt`` releases the GIL, so the per-object loop
+    threads cleanly via ``ThreadPoolExecutor`` (see ADR 0005). This test
+    times both the serial path (forced via ``low_memory=True``) and the
+    threaded path (default), prints the speedup, and keeps the
+    ``find_objects`` decomposition print line so the per-frame setup cost
+    stays visible.
     """
+    import os
+
     net, label_frame, _frangi, dim = network_setup
     skel = net._skeletonize(label_frame)
     skel_clean = net._remove_connected_label_pixels(skel)
@@ -265,10 +270,21 @@ def test_relabel_objects_decomposed_wall_clock(network_setup, capsys) -> None:
     pixel_class = net._get_pixel_class(skel_pre, force_cpu=True)
     branch_skel_labels = net._get_branch_skel_labels(pixel_class, force_cpu=True)
 
-    # Warm up
+    # Warm up (threaded path)
+    net.low_memory = False
     net._relabel_objects(branch_skel_labels, label_frame)
 
-    t_total = _time_call(
+    # Threaded path (default)
+    net.low_memory = False
+    t_threaded = _time_call(
+        lambda: net._relabel_objects(branch_skel_labels, label_frame),
+        iters=3,
+    )
+
+    # Serial path (forced via low_memory=True)
+    net.low_memory = True
+    net._relabel_objects(branch_skel_labels, label_frame)  # warm up
+    t_serial = _time_call(
         lambda: net._relabel_objects(branch_skel_labels, label_frame),
         iters=3,
     )
@@ -310,10 +326,25 @@ def test_relabel_objects_decomposed_wall_clock(network_setup, capsys) -> None:
     _sum_edts()
     t_edt_sum = _time_call(_sum_edts, iters=3)
 
+    # Mirror the worker-cap logic from _relabel_objects so the print line
+    # reports the actual worker count used (min(cpu_count, len(work), 8)).
+    work_len = sum(
+        1
+        for lab in range(1, max_label + 1)
+        if lab - 1 < len(slices) and slices[lab - 1] is not None
+    )
+    workers = min(os.cpu_count() or 1, max(work_len, 1), 8)
+    speedup = t_serial / max(t_threaded, 1e-9)
+
     with capsys.disabled():
         print(
             f"\n[perf] Network._relabel_objects {dim} ({max_label} labels) "
-            f"total={t_total * 1000:.1f}ms; "
+            f"serial={t_serial * 1000:.1f}ms "
+            f"threaded({workers}workers)={t_threaded * 1000:.1f}ms "
+            f"speedup={speedup:.2f}x"
+        )
+        print(
+            f"[perf] Network._relabel_objects {dim} decomposition: "
             f"find_objects={t_find * 1000:.1f}ms "
             f"sum_per_object_edt={t_edt_sum * 1000:.1f}ms"
         )

--- a/wiki/segmentation/networking.md
+++ b/wiki/segmentation/networking.md
@@ -3,7 +3,6 @@ created: 2026-05-06
 modified: 2026-05-11
 ---
 
-
 # Networking
 
 Skeletonize each instance, classify each skeleton voxel (background / isolated / tip / edge / junction), label branches, and propagate branch IDs back to fill each object's volume. Outputs: `im_skel` (int32, branch ID at non-junction skel voxels; 0 at junction voxels and off-skeleton), `im_pixel_class` (uint8 ∈ {0,1,2,3,4}), `im_skel_relabelled` (uint32, every voxel of an object gets a branch ID).
@@ -21,7 +20,7 @@ Topology — branches, junctions, tips — is what enables network metrics (leng
 3. **Patch missing** (`_add_missing_skeleton_labels`) — for any label whose skeleton vanished, plant one seed at the Frangi-maximum voxel inside that label.
 4. **Classify** (`_get_pixel_class`) — 3×3(×3) convolution counts neighbors per skel voxel; clipped at 4.
 5. **Identify branches** (`_get_branch_skel_labels`) — connected components on non-junction skel voxels.
-6. **Project to volume** (`_relabel_objects`) — per-object EDT (anisotropic, on a bounding-box crop) assigns every object voxel the label of its nearest branch seed.
+6. **Project to volume** (`_relabel_objects`) — per-object EDT (anisotropic, on a bounding-box crop) assigns every object voxel the label of its nearest branch seed. Per-object EDTs run in parallel via `ThreadPoolExecutor` (scipy's EDT releases the GIL); writeback is serialized via `as_completed` to handle overlapping bboxes safely. `low_memory=True` forces the serial path; otherwise `min(cpu_count, len(work), 8)` workers. See [[decisions/0005-relabel-objects-serialized-writeback|ADR 0005]] for the writeback-serialization, `low_memory` gating, and worker-cap rationale.
 
 ## Interactions
 


### PR DESCRIPTION
## Summary
- Replaces serial per-object loop with ThreadPoolExecutor over per-object EDTs
- Writeback serialized via as_completed (handles overlapping bboxes safely - see ADR 0005)
- Worker cap: min(cpu_count, len(work), 8)
- low_memory=True forces serial path
- Output bit-for-bit identical to serial impl (pinned by synthetic suite + new serial-vs-threaded equivalence test)
- Wiki article wiki/segmentation/networking.md updated with threading note + ADR 0005 link

Refs #173, closes #175.

## Perf

Captured on this hardware before and after via:
`pytest tests/test_networking_perf.py -m benchmark -k relabel_objects -s`

**Before (serial):**
```
[perf] Network._relabel_objects 2d (2 labels) total=0.2ms; find_objects=0.1ms sum_per_object_edt=0.1ms
[perf] Network._relabel_objects 3d (2 labels) total=2.6ms; find_objects=1.4ms sum_per_object_edt=0.9ms
```

**After (serial-vs-threaded comparison on the same call):**
```
[perf] Network._relabel_objects 2d (2 labels) serial=0.2ms threaded(2workers)=0.4ms speedup=0.56x
[perf] Network._relabel_objects 2d decomposition: find_objects=0.1ms sum_per_object_edt=0.1ms
[perf] Network._relabel_objects 3d (2 labels) serial=2.6ms threaded(2workers)=2.5ms speedup=1.02x
[perf] Network._relabel_objects 3d decomposition: find_objects=1.5ms sum_per_object_edt=0.8ms
```

Note: the yeast test fixture only contains 2 labels, which is why the worker cap pins at 2 and the per-object work is too small to amortize the pool startup cost (2D shows the worst case at 0.56x — pure overhead with two trivial objects). The threading payoff is on label-heavy frames where `len(work)` saturates the 8-worker cap; the design grilling cited in ADR 0005 measured 3.0x on `(200,200,200)` inputs from 4 workers. The serial path is preserved bit-for-bit (and forced via `low_memory=True`) for users who prefer it.

## Test plan
- [x] `pytest tests/test_networking.py -k relabel_objects -v` - 8 tests pass (Slice 1's 7 + new equivalence test)
- [x] `pytest tests/test_networking.py -v` - full file passes (37 tests)
- [x] `pytest tests/test_networking_perf.py -m benchmark -k relabel_objects -s` - runs, prints serial-vs-threaded comparison
- [x] Wiki article updated with threading note and ADR 0005 link

[Generated with Claude Code](https://claude.com/claude-code)