### PR TITLE
tests(mocap_marking): pin _remove_close_peaks behavior + ADR 0006 (Slice 1 of #179)

### DIFF
--- a/tests/test_mocap_marking.py
+++ b/tests/test_mocap_marking.py
@@ -673,3 +673,166 @@ def test_markers_config_rejects_inverted_radius_range() -> None:
 
 def test_markers_config_equal_radii_ok() -> None:
     MarkersConfig(min_radius_um=0.5, max_radius_um=0.5)
+
+
+# -------------------------------------------------------------------------
+# Synthetic NMS tests for _remove_close_peaks (Slice 1 of #179)
+#
+# Pin the behavior of `Markers._remove_close_peaks` against the current
+# morphological max-filter implementation so PRD #179 Slice 2 can rewrite
+# it byte-identically with `scipy.spatial.cKDTree`. Inputs are
+# constructed directly (no fixture / no upstream pipeline), so each test
+# is platform-stable and isolates the NMS contract from `_local_max_peak`'s
+# SIMD-sensitive `gaussian_laplace`. See [[decisions/0006-mocap-marking-sparse-nms|ADR 0006]].
+# -------------------------------------------------------------------------
+
+import scipy.ndimage as scipy_ndi
+
+
+def _make_bare_markers(peak_min_distance: int = 2) -> Markers:
+    """Bare Markers stub for unit-testing `_remove_close_peaks` only.
+
+    The method only depends on `self.peak_min_distance`, `self.xp`, and
+    `self.ndi` (and indirectly `self.max_chunk_voxels` if the chunked
+    branch fires; we never set `low_memory=True` in these tests so it
+    never does).
+    """
+    m = Markers.__new__(Markers)
+    m.peak_min_distance = peak_min_distance
+    m.xp = np
+    m.ndi = scipy_ndi
+    m.low_memory = False
+    m.max_chunk_voxels = int(1e6)
+    return m
+
+
+def _coords_set(arr: np.ndarray) -> set:
+    """Return coords as a set of tuples (order-agnostic comparison)."""
+    return {tuple(int(x) for x in row) for row in arr.tolist()}
+
+
+def _intensity_at(shape: tuple, coord_to_intensity: dict) -> np.ndarray:
+    """Build a float32 intensity volume with given values at given coords."""
+    im = np.zeros(shape, dtype=np.float32)
+    for coord, val in coord_to_intensity.items():
+        im[coord] = val
+    return im
+
+
+@pytest.mark.parametrize("ndim", [2, 3])
+def test_remove_close_peaks_empty_input(ndim: int) -> None:
+    """`coords.shape[0] == 0` → empty output (no error)."""
+    m = _make_bare_markers()
+    shape = (20,) * ndim
+    coords = np.zeros((0, ndim), dtype=int)
+    intensity = np.zeros(shape, dtype=np.float32)
+    result = m._remove_close_peaks(coords, intensity, low_memory=False)
+    assert result.shape[0] == 0
+
+
+@pytest.mark.parametrize("ndim", [2, 3])
+def test_remove_close_peaks_single_peak(ndim: int) -> None:
+    """A single peak survives unchanged."""
+    m = _make_bare_markers()
+    shape = (20,) * ndim
+    coord = (10,) * ndim
+    coords = np.array([coord], dtype=int)
+    intensity = _intensity_at(shape, {coord: 5.0})
+    result = m._remove_close_peaks(coords, intensity, low_memory=False)
+    assert _coords_set(result) == {coord}
+
+
+@pytest.mark.parametrize("ndim", [2, 3])
+def test_remove_close_peaks_two_peaks_far_apart(ndim: int) -> None:
+    """Chebyshev distance > peak_min_distance → both survive."""
+    m = _make_bare_markers(peak_min_distance=2)
+    shape = (30,) * ndim
+    c1 = (5,) * ndim
+    c2 = (15,) * ndim  # Chebyshev = 10 along every axis
+    intensity = _intensity_at(shape, {c1: 5.0, c2: 7.0})
+    coords = np.array([c1, c2], dtype=int)
+    result = m._remove_close_peaks(coords, intensity, low_memory=False)
+    assert _coords_set(result) == {c1, c2}
+
+
+@pytest.mark.parametrize("ndim", [2, 3])
+def test_remove_close_peaks_two_close_different_intensity(ndim: int) -> None:
+    """Chebyshev ≤ peak_min_distance, different intensities → higher wins."""
+    m = _make_bare_markers(peak_min_distance=2)
+    shape = (20,) * ndim
+    c1 = (10,) * ndim
+    # Offset along axis 0 only: Chebyshev = 1
+    c2 = tuple(10 + 1 if i == 0 else 10 for i in range(ndim))
+    intensity = _intensity_at(shape, {c1: 10.0, c2: 5.0})
+    coords = np.array([c1, c2], dtype=int)
+    result = m._remove_close_peaks(coords, intensity, low_memory=False)
+    assert _coords_set(result) == {c1}
+
+
+@pytest.mark.parametrize("ndim", [2, 3])
+def test_remove_close_peaks_two_close_equal_intensity(ndim: int) -> None:
+    """Chebyshev ≤ peak_min_distance, identical intensities → both survive.
+
+    Morphological NMS keeps both peaks in this case (both equal the local
+    max in their respective windows). The sparse cKDTree rewrite must
+    preserve this — only suppress when strictly less.
+    """
+    m = _make_bare_markers(peak_min_distance=2)
+    shape = (20,) * ndim
+    c1 = (10,) * ndim
+    c2 = tuple(10 + 1 if i == 0 else 10 for i in range(ndim))
+    intensity = _intensity_at(shape, {c1: 10.0, c2: 10.0})
+    coords = np.array([c1, c2], dtype=int)
+    result = m._remove_close_peaks(coords, intensity, low_memory=False)
+    assert _coords_set(result) == {c1, c2}
+
+
+@pytest.mark.parametrize("ndim", [2, 3])
+def test_remove_close_peaks_chebyshev_corner(ndim: int) -> None:
+    """Peak at offset (peak_min_distance, ..., peak_min_distance) — Chebyshev = peak_min_distance, in window.
+
+    Both peaks at this offset are in each other's morphological window
+    (size = 2*peak_min_distance + 1 = 5; the offset-2 corner is the
+    last cell of the centered 5-wide window). Lower-intensity is
+    suppressed.
+    """
+    m = _make_bare_markers(peak_min_distance=2)
+    shape = (20,) * ndim
+    c1 = (10,) * ndim
+    c2 = tuple(10 + 2 for _ in range(ndim))  # Chebyshev = 2
+    intensity = _intensity_at(shape, {c1: 10.0, c2: 5.0})
+    coords = np.array([c1, c2], dtype=int)
+    result = m._remove_close_peaks(coords, intensity, low_memory=False)
+    assert _coords_set(result) == {c1}
+
+
+@pytest.mark.parametrize("ndim", [2, 3])
+def test_remove_close_peaks_chebyshev_just_outside(ndim: int) -> None:
+    """Peak at offset (peak_min_distance + 1, 0, ...) — Chebyshev > peak_min_distance, both survive."""
+    m = _make_bare_markers(peak_min_distance=2)
+    shape = (30,) * ndim
+    c1 = (10,) * ndim
+    c2 = tuple(10 + 3 if i == 0 else 10 for i in range(ndim))  # Chebyshev = 3
+    intensity = _intensity_at(shape, {c1: 10.0, c2: 5.0})
+    coords = np.array([c1, c2], dtype=int)
+    result = m._remove_close_peaks(coords, intensity, low_memory=False)
+    assert _coords_set(result) == {c1, c2}
+
+
+@pytest.mark.parametrize("ndim", [2, 3])
+def test_remove_close_peaks_three_peak_chain(ndim: int) -> None:
+    """A-B-C chain along axis 0 with spacing 1 — all within Chebyshev ≤ peak_min_distance.
+
+    Chebyshev distances: A↔B = 1, B↔C = 1, A↔C = 2 (all ≤ 2). All three
+    pairs compete in the morphological window. The highest-intensity
+    peak (B) is the only survivor.
+    """
+    m = _make_bare_markers(peak_min_distance=2)
+    shape = (30,) * ndim
+    a = (10,) * ndim
+    b = tuple(10 + 1 if i == 0 else 10 for i in range(ndim))
+    c = tuple(10 + 2 if i == 0 else 10 for i in range(ndim))
+    intensity = _intensity_at(shape, {a: 5.0, b: 10.0, c: 7.0})
+    coords = np.array([a, b, c], dtype=int)
+    result = m._remove_close_peaks(coords, intensity, low_memory=False)
+    assert _coords_set(result) == {b}

--- a/wiki/decisions/0006-mocap-marking-sparse-nms.md
+++ b/wiki/decisions/0006-mocap-marking-sparse-nms.md
@@ -1,0 +1,134 @@
+---
+created: 2026-05-11
+modified: 2026-05-11
+---
+
+# `Markers._remove_close_peaks` switches from morphological max-filter to sparse cKDTree
+
+`Markers._remove_close_peaks` (in `nellie/segmentation/mocap_marking.py`)
+performs non-max suppression on the post-LoG peak coordinates. The
+original implementation allocated a full-volume float32 `score_img`,
+sparsely assigned peak intensities into it, and ran
+`maximum_filter(size=2*peak_min_distance + 1)` over the entire volume
+— cost `O(volume × size^d)`, regardless of how many peaks survived
+`_local_max_peak`. On a `(200,200,200)` frame with the default
+`peak_min_distance=2`, that's ~1B ops per frame for a few thousand
+peaks.
+
+PRD #179 replaces the morphological path with a sparse-coordinate
+approach using `scipy.spatial.cKDTree(coords).query_pairs(r, p=∞)`
+(Chebyshev metric). Memory becomes `O(P)` instead of `O(N)`; cost
+becomes `O(P log P + |pairs|)` rather than `O(N × size^d)`. Two
+coupled decisions in the design need to be pinned ahead of the
+rewrite in Slice 2 (#181): (1) the chunked path
+(`_remove_close_peaks_chunked` + `_nms_halo`) is deleted entirely
+because sparse memory is `O(P)` and chunking served only the
+full-volume score_img allocation, and (2) the wiki article's "chosen
+for GPU-friendliness" framing (`wiki/segmentation/mocap-marking.md`
+line 23) is reversed because the GPU rationale was theoretical
+(Markers is not MPS-onboarded; the CUDA path is unvalidated per
+`wiki/now.md` watch list). Status: **Accepted (preventive)** —
+documents non-obvious decisions ahead of the rewrite in Slice 2 (#181).
+
+## Considered Options
+
+- **Sparse cKDTree with Chebyshev metric (chosen).** `cKDTree(coords)`
+  build + `query_pairs(r=peak_min_distance, p=np.inf)` returns exactly
+  the pairs the morphological max-filter would have considered
+  competing — the Chebyshev box of width `2*peak_min_distance + 1` is
+  the same neighborhood as the L∞ ball of radius `peak_min_distance`.
+  For each pair, the lower-intensity peak is suppressed; ties are
+  preserved on both sides (matches morphological "both equal the local
+  max" behavior). Bit-equivalent semantics modulo coord ordering
+  (sort row-major to match `xp.argwhere`).
+- **Sparse with Euclidean metric (rejected).** Would change the
+  neighborhood definition: a peak at offset `(2, 2, 0)` is at
+  Chebyshev distance 2 (in the morphological window at
+  `peak_min_distance=2`) but Euclidean distance √8 ≈ 2.83 (outside
+  the L2 ball of radius 2). Rejected because preserving the
+  morphological semantics is non-negotiable — existing
+  characterization tests (`test_low_memory_matches_full_*`,
+  `test_markers_inside_objects_*`) depend on it.
+- **Bounding-box morphological (rejected).** Keep the morphological
+  path but only apply `maximum_filter` within the bounding box of all
+  peak coordinates. Saves the volume cost outside the bbox but is
+  still `O(bbox_volume × size^d)` — no asymptotic improvement, and
+  for a label-heavy frame the peak bbox covers most of the volume
+  anyway.
+- **Keep morphological as fallback for very dense peaks (rejected).**
+  Adds a code path with no realistic trigger. cKDTree's per-pair cost
+  scales with `|pairs|`, which on densely-packed peaks could in
+  principle exceed `O(N)`, but `peak_min_distance` is small (default
+  2) and post-LoG peaks are spatially separated by construction.
+  Rejected to keep the implementation single-path; if a future
+  workload demonstrates morphological wins, that's a separate PRD
+  with its own justification.
+- **Drop `_remove_close_peaks_chunked` + `_nms_halo` (chosen).** The
+  chunked variant existed solely because the full-volume `score_img`
+  was the dominant memory cost. Sparse memory is `O(P)`, so chunking
+  is moot. `low_memory=True` becomes a no-op for NMS specifically;
+  the LoG chunked variant (`_local_max_peak_chunked` +
+  `_log_halo`) still gates on `low_memory` and is untouched by this
+  PRD.
+- **Reverse the "GPU-friendliness" intent (chosen).** The wiki article
+  at `wiki/segmentation/mocap-marking.md` line 23 documented the
+  morphological choice as "Chosen for GPU-friendliness, not
+  theoretical purity." This rationale is theoretical: Markers is not
+  MPS-onboarded; the CUDA path exists but is not perf-validated; the
+  99% case is CPU. cKDTree is scipy/CPU-only — for backend coords we
+  transfer to CPU once (size = peak count, not volume — negligible),
+  run, transfer back. If/when Markers is MPS-onboarded later, the
+  sparse approach still wins because the transfer is `O(P)` while
+  the morphological cost is `O(N × size^d)` regardless of platform.
+- **Always thread `query_pairs` (rejected).** `cKDTree.query_pairs` is
+  a single C call that releases the GIL internally and is already
+  fast on typical peak counts (microseconds for `P ≈ 10⁴`). Threading
+  the post-pair `keep[i]` / `keep[j]` updates would race on shared
+  state and is unwarranted given the negligible serial cost.
+
+## Consequences
+
+- The Slice 1 synthetic-test suite (#180) covers all morphological-NMS
+  edge cases: empty input, single peak, two-peaks-far-apart,
+  two-peaks-close-different-scores, two-peaks-close-equal-scores,
+  Chebyshev-corner-peak (offset `(peak_min_distance,
+  peak_min_distance)`), Chebyshev-just-outside (offset
+  `(peak_min_distance + 1, 0)`), three-peak chain. All hand-derived
+  from morphological semantics, platform-stable, parametrized 2D/3D.
+  Slice 2's sparse rewrite must pass them byte-identical (modulo
+  coord ordering).
+- **No cross-platform snapshot test.** `_remove_close_peaks`'s input
+  `coords` come from `_local_max_peak`'s `gaussian_laplace`, which is
+  SIMD-sensitive across platforms (same root cause that forced PRD
+  #168 to cache both input and output `.npy` files for
+  `_remove_connected_label_pixels`). The synthetic suite is
+  sufficient; a yeast-3D snapshot would either require
+  input-caching infrastructure (not worth it for this scope) or
+  drift cross-platform in a way that masks real regressions.
+- Future maintainers should not re-introduce the chunked path. If a
+  real workload demands memory-bounded NMS, that's a separate PRD
+  that must address why sparse-O(P) is insufficient (and update or
+  remove this ADR).
+- Future maintainers should not re-introduce the "GPU-friendliness"
+  framing without a real perf measurement on a backend-aware
+  morphological path. The current expectation is that sparse cKDTree
+  on CPU is faster than morphological max-filter on any backend for
+  any realistic peak count.
+- Future maintainers tempted to switch to Euclidean metric should
+  read this ADR first — the morphological semantics are the contract,
+  and Chebyshev is the only metric that preserves them.
+
+## References
+
+- PRD #179 — replace morphological NMS in `Markers._remove_close_peaks`
+  with sparse `cKDTree`
+- Slice 1 #180 — pin current behavior with synthetic-test suite + this
+  ADR (no production code changes)
+- Slice 2 #181 — sparse rewrite that preserves the synthetic suite
+  byte-identical
+- ADR 0005 — `Network._relabel_objects` writeback serialization
+  (similar precedent: synthetic suite + intra-platform equivalence,
+  no cross-platform snapshot, low_memory gating decisions)
+- PRD #168 — `Network._remove_connected_label_pixels` sparse rewrite
+  (precedent for sparse coordinate scan in this repo, including the
+  input-caching infrastructure for snapshot tests)

--- a/wiki/decisions/index.md
+++ b/wiki/decisions/index.md
@@ -3,6 +3,7 @@ created: 2026-05-09
 modified: 2026-05-11
 ---
 
+
 # Architecture Decision Records
 
 Decisions worth recording per [[CLAUDE|wiki conventions]] — hard to reverse, surprising without context, the result of a real trade-off. See `repo-wiki/DECISIONS_FORMAT.md` for the format.
@@ -14,3 +15,4 @@ Decisions worth recording per [[CLAUDE|wiki conventions]] — hard to reverse, s
 - [[decisions/0003-device-gpu-platform-aware]] — `device="gpu"` becomes platform-aware (MPS on Darwin, CUDA elsewhere)
 - [[decisions/0004-skel-boundary-preservation]] — boundary voxels in `Network._remove_connected_label_pixels` are exempt from ambiguity cleanup (root cause unknown; pinned by test)
 - [[decisions/0005-relabel-objects-serialized-writeback]] — `Network._relabel_objects` writeback is intentionally serialized; threading is gated on `low_memory` (preventive, ahead of PRD #173 Slice 2 threading rewrite)
+- [[decisions/0006-mocap-marking-sparse-nms]] — `Markers._remove_close_peaks` switches from morphological max-filter to sparse `cKDTree` with Chebyshev metric; chunked variant + `_nms_halo` are dropped (preventive, ahead of PRD #179 Slice 2 rewrite)


### PR DESCRIPTION
## Summary

Slice 1 of #179 — pin `Markers._remove_close_peaks` behavior with synthetic edge-case tests + ADR 0006. **No production code changes.** Closes #180.

- 16 parametrized (2D + 3D) synthetic tests covering the morphological-NMS contract: empty, single peak, far-apart, close-different-intensity, close-equal-intensity, Chebyshev-corner, Chebyshev-just-outside, three-peak-chain
- All inputs constructed directly (no fixture, no upstream pipeline) — platform-stable, isolates the NMS contract from `_local_max_peak`'s SIMD-sensitive `gaussian_laplace`
- ADR 0006 documents: KDTree-with-Chebyshev preserves morphological semantics; chunked variant + `_nms_halo` are dropped because sparse memory is O(P) not O(N); `low_memory` becomes a no-op for NMS; wiki "GPU-friendliness" framing is reversed (theoretical — Markers is not MPS-onboarded, CUDA is unvalidated); no cross-platform snapshot for the same reason ADR 0005 declined one

Slice 2 (#181) will rewrite the body using `scipy.spatial.cKDTree` and must pass these tests byte-identical.

## Test plan

- [x] All 16 new tests pass against the current morphological code on darwin (16 passed in 0.07s)
- [x] Full `tests/test_mocap_marking.py` suite passes (45 passed in 6.59s)
- [ ] CI matrix (Linux + Windows + Python 3.11/3.12) passes the new tests
- [ ] No mocap_marking.py production code touched (verify diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)