### PR TITLE
perf(mocap_marking): sparse cKDTree rewrite of _remove_close_peaks (Slice 2 of #179)

### DIFF
--- a/nellie/segmentation/mocap_marking.py
+++ b/nellie/segmentation/mocap_marking.py
@@ -13,6 +13,7 @@ import itertools
 from dataclasses import dataclass
 
 import numpy as np
+from scipy.spatial import cKDTree
 
 from nellie.utils import adaptive_run
 from nellie.utils.base_logger import logger
@@ -238,10 +239,6 @@ class Markers:
         hz = int(np.ceil(self.truncate * z_sigma))
         hxy = int(np.ceil(self.truncate * sigma_max))
         return (max(hz, 1), max(hxy, 1), max(hxy, 1))
-
-    def _nms_halo(self):
-        halo = max(int(self.peak_min_distance), 0)
-        return (halo,) * (2 if self.im_info.no_z else 3)
 
     # -------------------------------------------------------------------------
     # Core logic
@@ -496,7 +493,15 @@ class Markers:
 
     def _remove_close_peaks(self, coords, intensity_im, low_memory=False, chunk_voxels=None):
         """
-        Removes peaks that are too close together using morphological non-max suppression.
+        Removes peaks that are too close together using sparse coordinate-based NMS.
+
+        Uses ``scipy.spatial.cKDTree`` with Chebyshev metric (Minkowski
+        ``p=∞``) to find peak pairs within ``peak_min_distance``; the
+        lower-intensity peak in each pair is suppressed. Ties are
+        preserved (both kept), matching the original morphological
+        max-filter semantics. See ADR 0006 for the design rationale and
+        why ``low_memory`` / ``chunk_voxels`` are accepted but ignored
+        (sparse memory is O(peak_count), not O(volume)).
 
         Parameters
         ----------
@@ -508,70 +513,48 @@ class Markers:
         Returns
         -------
         array-like
-            Coordinates of the remaining peaks after filtering.
+            Coordinates of the remaining peaks after filtering, sorted
+            in row-major order to match the legacy
+            ``xp.argwhere(keep_mask)`` ordering.
         """
-        if low_memory:
-            return self._remove_close_peaks_chunked(coords, intensity_im, chunk_voxels)
-
-        xp_mod = self.xp
-        ndi_mod = self.ndi
-
-        if coords.size == 0:
+        if coords.shape[0] == 0:
             return coords
 
-        # Build a score image with intensities only at peak coordinates
-        score_img = xp_mod.zeros_like(intensity_im, dtype=xp_mod.float32)
-        score_img[tuple(coords.T)] = intensity_im[tuple(coords.T)]
+        # cKDTree is scipy/CPU; bring coords + per-peak intensities to CPU once.
+        is_numpy_in = isinstance(coords, np.ndarray)
+        coords_np = coords if is_numpy_in else self._to_cpu(coords)
+        intensities_at_peaks = intensity_im[tuple(coords.T)]
+        intensities_np = (
+            intensities_at_peaks
+            if isinstance(intensities_at_peaks, np.ndarray)
+            else self._to_cpu(intensities_at_peaks)
+        )
+        intensities_np = np.asarray(intensities_np, dtype=np.float32)
 
-        # Apply maximum filter with a window corresponding to peak_min_distance
-        size = 2 * int(self.peak_min_distance) + 1
-        max_filtered = ndi_mod.maximum_filter(score_img, size=size, mode='nearest')
+        # Mirrors the `score_img > 0` gate from the morphological version.
+        keep = intensities_np > 0
 
-        # Keep peaks that are equal to the local max and have positive score
-        keep_mask = (score_img == max_filtered) & (score_img > 0)
+        if int(keep.sum()) > 1:
+            active_indices = np.flatnonzero(keep)
+            tree = cKDTree(coords_np[active_indices])
+            pairs = tree.query_pairs(
+                r=int(self.peak_min_distance), p=np.inf, output_type='ndarray',
+            )
+            if pairs.size > 0:
+                i_orig = active_indices[pairs[:, 0]]
+                j_orig = active_indices[pairs[:, 1]]
+                i_score = intensities_np[i_orig]
+                j_score = intensities_np[j_orig]
+                keep[i_orig[i_score < j_score]] = False
+                keep[j_orig[j_score < i_score]] = False
 
-        kept_coords = xp_mod.argwhere(keep_mask)
-        return kept_coords
+        survivors = coords_np[keep]
 
-    def _remove_close_peaks_chunked(self, coords, intensity_im, chunk_voxels):
-        xp_mod = self.xp
-        ndi_mod = self.ndi
+        if survivors.shape[0] > 1:
+            order = np.lexsort(survivors.T[::-1])
+            survivors = survivors[order]
 
-        if coords.size == 0:
-            return coords
-
-        shape = intensity_im.shape
-        chunk_shape = self._compute_chunk_shape(shape, chunk_voxels or self.max_chunk_voxels)
-        halo = self._nms_halo()
-        size = 2 * int(self.peak_min_distance) + 1
-
-        coords_list = []
-        for core, ext, core_in_ext, core_start, ext_start in self._iter_chunks(
-            shape, chunk_shape, halo
-        ):
-            ext_end = [s.stop for s in ext]
-            coords_ext = self._coords_in_bounds(coords, ext_start, ext_end)
-            if coords_ext.size == 0:
-                continue
-
-            ext_shape = tuple(s.stop - s.start for s in ext)
-            score_chunk = xp_mod.zeros(ext_shape, dtype=xp_mod.float32)
-            local_coords = coords_ext - xp_mod.asarray(ext_start, dtype=coords_ext.dtype)
-            score_chunk[tuple(local_coords.T)] = intensity_im[tuple(coords_ext.T)]
-
-            max_filtered = ndi_mod.maximum_filter(score_chunk, size=size, mode='nearest')
-            keep_mask = (score_chunk == max_filtered) & (score_chunk > 0)
-            keep_core = keep_mask[core_in_ext]
-            if xp_mod.any(keep_core):
-                core_coords = xp_mod.argwhere(keep_core)
-                offset = xp_mod.asarray(core_start, dtype=core_coords.dtype)
-                coords_list.append(core_coords + offset)
-
-        if not coords_list:
-            ndim = intensity_im.ndim
-            return xp_mod.zeros((0, ndim), dtype=int)
-
-        return xp_mod.concatenate(coords_list, axis=0)
+        return survivors if is_numpy_in else self.xp.asarray(survivors)
 
     def _run_frame(self, t):
         """

--- a/tests/test_mocap_marking.py
+++ b/tests/test_mocap_marking.py
@@ -20,8 +20,9 @@ Pins the wiki-documented invariants on both the 3D and 2D paths:
   - ``'frangi'`` raises with a clear error when ``im_preprocessed`` is
     absent on disk (Markers should not silently no-op)
 - ``low_memory`` chunked vs unchunked equivalence on BOTH 2D and 3D:
-  ``_log_halo`` and ``_nms_halo`` keep chunked output byte-identical to
-  the full-volume path
+  ``_log_halo`` keeps the chunked LoG output byte-identical to the
+  full-volume path. (NMS chunking + ``_nms_halo`` were retired in #181;
+  sparse cKDTree NMS has O(peak_count) memory — no chunking needed.)
 - Input memmaps (raw + Frangi + Label) are not mutated by ``Markers.run()``
 - ``viewer.status`` is left untouched when ``viewer=None`` and is set
   exactly once per frame when ``viewer`` is a stub
@@ -344,13 +345,13 @@ def test_use_im_frangi_raises_when_frangi_absent(make_imageinfo_3d, label_3d_pat
 def test_low_memory_matches_full_2d(make_markers_imageinfo_2d) -> None:
     """Full-volume and chunked-low-memory runs produce identical outputs (2D).
 
-    Pins the wiki-documented ``_log_halo`` + ``_nms_halo`` correctness:
-    the chunked LoG and chunked NMS paths use just enough halo voxels
-    to keep results byte-identical to the unchunked path. Pinning all
-    three outputs (``marker``, ``distance``, ``border``) ensures both
-    the LoG and NMS halos are exercised — distance is unchanged by
-    chunking (it's a global EDT) but marker positions and border
-    voxels depend on the per-chunk halo math.
+    Pins the wiki-documented ``_log_halo`` correctness: the chunked
+    LoG path uses just enough halo voxels to keep results byte-identical
+    to the unchunked path. Pinning all three outputs (``marker``,
+    ``distance``, ``border``) keeps the LoG halo exercised — distance is
+    unchanged by chunking (it's a global EDT) and marker positions
+    depend on the per-chunk LoG halo math. (NMS no longer chunks after
+    #181 — sparse cKDTree handles arbitrary peak counts in O(P) memory.)
     """
     full = _run_markers(make_markers_imageinfo_2d(), low_memory=False)
     # Force multi-chunk processing on the small yeast-2d fixture.
@@ -372,8 +373,8 @@ def test_low_memory_matches_full_3d(make_markers_imageinfo_3d) -> None:
     """Full-volume and chunked-low-memory runs produce identical outputs (3D).
 
     Same contract as :func:`test_low_memory_matches_full_2d`, but on
-    the 3D fixture so ``_log_halo`` and ``_nms_halo`` are exercised
-    along all three spatial axes.
+    the 3D fixture so ``_log_halo`` is exercised along all three spatial
+    axes.
     """
     full = _run_markers(make_markers_imageinfo_3d(), low_memory=False)
     chunked = _run_markers(

--- a/tests/test_mocap_marking_perf.py
+++ b/tests/test_mocap_marking_perf.py
@@ -10,8 +10,9 @@ and :mod:`tests.test_hu_tracking_perf`:
    prior commit.
 2. **Hot-path microbenchmarks** decompose the per-frame cost into the
    three dominant ops surfaced by reading the code: the multi-scale
-   LoG loop in ``_local_max_peak``, the morphological NMS in
-   ``_remove_close_peaks``, and the dilation+EDT in ``_distance_im``.
+   LoG loop in ``_local_max_peak``, the sparse cKDTree NMS in
+   ``_remove_close_peaks`` (was morphological max-filter pre-#181), and
+   the dilation+EDT in ``_distance_im``.
 
 The microbenchmarks are **informational** (printed `[perf]` lines, no
 assertions). Filter's three assertions exist because each pinned a
@@ -194,11 +195,12 @@ def test_local_max_peak_per_sigma_breakdown(markers_setup, capsys) -> None:
 
 
 def test_remove_close_peaks_wall_clock(markers_setup, capsys) -> None:
-    """`_remove_close_peaks` morphological NMS — single hot op, baseline.
+    """`_remove_close_peaks` sparse cKDTree NMS — single hot op, baseline.
 
-    The maximum_filter window is ``2 * peak_min_distance + 1`` (default
-    5), applied to a sparse score image of intensities at peak
-    coordinates only.
+    Sparse coordinate-based NMS (cKDTree with Chebyshev metric, `p=∞`,
+    `r=peak_min_distance`); replaced the morphological max-filter in
+    #181 (PRD #179) — see ADR 0006. Cost is `O(P log P + |pairs|)`,
+    not `O(volume × size^d)` like the old morphological path.
     """
     m, mask, intensity, dim = markers_setup
     distance_im, _ = m._distance_im(mask)

--- a/wiki/segmentation/mocap-marking.md
+++ b/wiki/segmentation/mocap-marking.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-06
-modified: 2026-05-08
+modified: 2026-05-11
 ---
 
 # Mocap marking
@@ -20,10 +20,10 @@ Detect motion-tracking anchor points (multi-scale LoG peaks) inside each label, 
 ## Gotchas
 
 - **`use_im` switches between LoG-of-distance (default) and LoG-of-Frangi.** Different rationales — distance is shape-agnostic; Frangi is structure-aware. Default works for the paper's data.
-- **NMS is morphological max-filter** (window `2 * peak_min_distance + 1`), not KD-tree. Chosen for GPU-friendliness, not theoretical purity.
+- **NMS is sparse `scipy.spatial.cKDTree` with Chebyshev metric** (`p=∞`, `r=peak_min_distance`); semantically equivalent to a window of width `2*peak_min_distance + 1` (same neighborhood as the original morphological max-filter). Switched in #181 because morphological's `O(volume × size^d)` cost was wasted by ~1000× on typical sparse-peak frames. Ties preserve both peaks, matching morphological "both equal the local max". See [[decisions/0006-mocap-marking-sparse-nms|ADR 0006]].
 - **Distance is clamped to `2 * max_radius_px`.** Mimics the legacy KD-tree's behavior for infinities; if you remove the clamp, downstream LoG can pick up runaway peaks.
 - **Empty mask short-circuits to all-zero outputs.** No error.
-- **Low-memory chunked LoG/NMS uses `_log_halo` (= `truncate * sigma_max`) and `_nms_halo`** to keep results identical to the unchunked path. `test_low_memory_matches_full_2d` / `_3d` pin this equivalence.
+- **Low-memory chunked LoG uses `_log_halo` (= `truncate * sigma_max`)** to keep results identical to the unchunked path. `test_low_memory_matches_full_2d` / `_3d` pin this equivalence. NMS no longer chunks after #181 — sparse cKDTree's memory is O(peak_count), and `low_memory` is a no-op for `_remove_close_peaks`.
 - **Multi-scale reduction is per-pixel "best response wins", with scales streamed.** No 4D `(scale, z, y, x)` array; per sigma the scale-normalized `-LoG · σ²` is computed and a running best-response mask is updated in place. Dropping the `σ²` factor breaks cross-scale comparison (small scales dominate); stacking instead of streaming will OOM on real volumes.
 - **OOM handling is the outer [[gpu-runtime|`adaptive_run.mode_candidates`]] cascade only.** Slice 3 of #84 deleted the per-frame inner cascade and the cross-frame state-mutation it caused. On OOM the whole stage now restarts from frame 0 with the next `(device, low_memory)` candidate — partial progress on long time series is lost in exchange for predictable per-call state.
 - **`prefer_gpu` was dropped in Slice 2 of #84** (matching Network/Label/Filter); pass `device="cpu"` instead. The constructor now normalizes `device` through `adaptive_run.normalize_device` so `"cuda"` is accepted as a synonym for `"gpu"`. The constructor also indexes `dim_res['X']` / `dim_res['Z']` directly — a missing X (or Z, when the image has Z) now raises `KeyError` instead of silently falling back to a 1.0 µm scale.


### PR DESCRIPTION
## Summary

Slice 2 of #179 — replace the morphological max-filter NMS in `Markers._remove_close_peaks` with sparse `scipy.spatial.cKDTree` (Chebyshev metric, `p=∞`). Closes #181.

- Cost drops from `O(volume × size^d)` to `O(P log P + |pairs|)` — algorithmic, not just constant-factor
- Drops `_remove_close_peaks_chunked` and `_nms_halo` (sparse memory is O(peak_count); chunking is moot)
- Reverses the wiki article's "GPU-friendliness" framing; see [[decisions/0006-mocap-marking-sparse-nms|ADR 0006]] for the rationale and rejected alternatives
- Semantics preserved byte-equivalent to the morphological path: Chebyshev neighborhood = morphological window of width `2*peak_min_distance + 1`; ties preserve both peaks (matches morphological "both equal the local max"); coord ordering sorted row-major to match `xp.argwhere`
- All 45 existing characterization tests + all 16 synthetic NMS edge-case tests from #182 pass byte-identical

## Perf numbers

On the small yeast fixtures (49 / 57 peaks):

| Path | Before (morphological) | After (sparse cKDTree) |
|------|-----------------------:|-----------------------:|
| 2D `_remove_close_peaks` | 0.4 ms | 0.0 ms (sub-ms) |
| 3D `_remove_close_peaks` | 9.3 ms | 0.0 ms (sub-ms) |

At realistic scale (5000 peaks in `(200,200,200)`, synthetic input):
- Sparse cKDTree: median **1.91 ms** (n=20)
- Morphological estimate: `200³ × 5³ ≈ 1B ops` → hundreds of ms to ~1s on CPU

The fixture-scale win is small because the fixture is small. The asymptotic win on real frames is ~1000×.

## Test plan

- [x] All 16 synthetic NMS edge-case tests from #182 pass byte-identical against the new sparse impl
- [x] Full `tests/test_mocap_marking.py` (45 tests) passes — including `test_low_memory_matches_full_*` (LoG chunking still gates on low_memory; NMS path is the same regardless)
- [x] `tests/test_mocap_marking_perf.py -m benchmark` shows expected wall-clock improvement
- [ ] CI matrix (Linux + Windows + macOS, Python 3.10/3.11/3.12/3.13) all green
- [x] Wiki article (`wiki/segmentation/mocap-marking.md`) line 23 + line 26 updated to reflect sparse cKDTree + dropped `_nms_halo`
- [x] Test docstring references to `_nms_halo` updated (lines 22-24, 347, 375)
- [x] Perf test docstrings updated to reflect new sparse path

## What's next (out of scope here)

- PR B: thread the per-sigma LoG loop in `_local_max_peak` (item 2 of audit; LoG is the new dominant cost — 161 ms on 3D fixture vs 0 ms NMS now)
- PR C: bundled micro-cleanups in `_distance_im`, `_local_max_peak` (items 3-8 of audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)