### PR TITLE
perf(mocap_marking): thread per-sigma LoG loop in _local_max_peak (Slice 2 of #184)

### DIFF
--- a/nellie/segmentation/mocap_marking.py
+++ b/nellie/segmentation/mocap_marking.py
@@ -10,6 +10,8 @@ Notes
 - The border mask is the outside shell, computed as dilation(mask) XOR mask.
 """
 import itertools
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 
 import numpy as np
@@ -382,6 +384,10 @@ class Markers:
         - Streams over scales (sigmas), no 4D (scale, z, y, x) arrays.
         - For each scale, computes LoG response, local maxima, and updates a global peak mask
           where the current scale response is better than previous scales.
+        - Threads the per-sigma loop with ``ThreadPoolExecutor`` when
+          ``low_memory`` is False and ``len(self.sigmas) > 1``;
+          combination uses ``as_completed`` because the per-sigma
+          reduction is order-independent (see ADR 0007).
 
         Parameters
         ----------
@@ -401,39 +407,71 @@ class Markers:
             return self._local_max_peak_chunked(use_im, mask, distance_im, chunk_voxels)
 
         xp_mod = self.xp
-        ndi_mod = self.ndi
-
-        # Valid pixels: inside the object mask and with positive distance
         valid_mask = mask & (distance_im > 0)
-
-        # Initialize best response and a peak mask
         best_resp = xp_mod.zeros_like(use_im, dtype=xp_mod.float32)
         peak_mask = xp_mod.zeros_like(use_im, dtype=bool)
 
+        sigmas = list(self.sigmas)
+        if len(sigmas) < 2:
+            for s in sigmas:
+                local_max, log_resp = self._compute_per_sigma(use_im, valid_mask, s)
+                self._reduce_per_sigma(peak_mask, best_resp, local_max, log_resp)
+        else:
+            max_workers = min(os.cpu_count() or 1, len(sigmas), 8)
+            with ThreadPoolExecutor(max_workers=max_workers) as ex:
+                futures = [
+                    ex.submit(self._compute_per_sigma, use_im, valid_mask, s)
+                    for s in sigmas
+                ]
+                # Reduction is order-independent — see ADR 0007.
+                for fut in as_completed(futures):
+                    local_max, log_resp = fut.result()
+                    self._reduce_per_sigma(peak_mask, best_resp, local_max, log_resp)
+
+        return xp_mod.argwhere(peak_mask)
+
+    def _local_max_peak_serial(self, use_im, mask, distance_im):
+        """Serial per-sigma loop (no threading), exposed for the
+        serial-vs-threaded equivalence test. Production callers should
+        use ``_local_max_peak`` which auto-dispatches.
+        """
+        xp_mod = self.xp
+        valid_mask = mask & (distance_im > 0)
+        best_resp = xp_mod.zeros_like(use_im, dtype=xp_mod.float32)
+        peak_mask = xp_mod.zeros_like(use_im, dtype=bool)
         for s in self.sigmas:
-            sigma_val = float(s)
-            sigma_vec = self._get_sigma_vec(sigma_val)
+            local_max, log_resp = self._compute_per_sigma(use_im, valid_mask, s)
+            self._reduce_per_sigma(peak_mask, best_resp, local_max, log_resp)
+        return xp_mod.argwhere(peak_mask)
 
-            # LoG response with scale normalization (s^2)
-            log_resp = -ndi_mod.gaussian_laplace(use_im, sigma_vec)
-            log_resp = (log_resp * (sigma_val ** 2)).astype(xp_mod.float32, copy=False)
+    def _compute_per_sigma(self, use_im, valid_mask, sigma):
+        """Per-sigma worker: compute ``(local_max, log_resp)`` for one scale.
 
-            # Clamp negative values
-            log_resp[log_resp < 0] = 0
+        Pure: returns no shared state. Safe to call from a
+        ``ThreadPoolExecutor`` worker — scipy ndimage releases the GIL
+        on ``gaussian_laplace`` and ``maximum_filter``.
+        """
+        xp_mod = self.xp
+        ndi_mod = self.ndi
+        sigma_val = float(sigma)
+        sigma_vec = self._get_sigma_vec(sigma_val)
+        log_resp = -ndi_mod.gaussian_laplace(use_im, sigma_vec)
+        log_resp = (log_resp * (sigma_val ** 2)).astype(xp_mod.float32, copy=False)
+        log_resp[log_resp < 0] = 0
+        local_max = log_resp == ndi_mod.maximum_filter(log_resp, size=3, mode='nearest')
+        local_max &= valid_mask
+        return local_max, log_resp
 
-            # Local maxima in image space (no scale dimension)
-            local_max = log_resp == ndi_mod.maximum_filter(log_resp, size=3, mode='nearest')
+    def _reduce_per_sigma(self, peak_mask, best_resp, local_max, log_resp):
+        """Combine one sigma's result into the running peak_mask + best_resp.
 
-            # Restrict to valid pixels (inside objects and away from border)
-            local_max &= valid_mask
-
-            # Non-max suppression across scales (keep best response)
-            better = local_max & (log_resp > best_resp)
-            peak_mask[better] = True
-            best_resp[better] = log_resp[better]
-
-        coords_idx = xp_mod.argwhere(peak_mask)
-        return coords_idx
+        Called from the main thread after each future completes. The
+        strict ``>`` comparison makes the reduction order-independent
+        (see ADR 0007 for the proof).
+        """
+        better = local_max & (log_resp > best_resp)
+        peak_mask[better] = True
+        best_resp[better] = log_resp[better]
 
     def _local_max_peak_chunked(self, use_im, mask, distance_im, chunk_voxels):
         xp_mod = self.xp

--- a/tests/test_mocap_marking.py
+++ b/tests/test_mocap_marking.py
@@ -984,3 +984,36 @@ def test_local_max_peak_detects_isolated_blob(ndim: int) -> None:
     assert result.shape[0] >= 1, (
         "Expected at least one peak for a clean Gaussian blob; got none"
     )
+
+
+def test_local_max_peak_serial_vs_threaded_3d(make_markers_imageinfo_3d) -> None:
+    """Serial and threaded `_local_max_peak` produce byte-identical output.
+
+    Intra-platform deterministic by construction — runs both paths on
+    the same machine; no cross-platform Frangi/labeling drift concerns.
+    The threaded version's combination via ``as_completed`` is provably
+    order-independent (ADR 0007); this test pins that property
+    end-to-end on the yeast 3D fixture.
+    """
+    info = make_markers_imageinfo_3d()
+    m = Markers(info, MarkersConfig(device="cpu"), num_t=1)
+    m._allocate_memory()
+    m._set_default_sigmas()
+
+    assert m.im_memmap is not None and m.label_memmap is not None
+    intensity = np.asarray(m.im_memmap[0])
+    mask = np.asarray(m.label_memmap[0] > 0)
+    distance, _ = m._distance_im(mask)
+
+    # `_local_max_peak` thread-dispatches when `len(sigmas) >= 2`; the
+    # default fixture has 5 sigmas, so this exercises the threaded path.
+    threaded = m._local_max_peak(distance, mask, distance, low_memory=False)
+    serial = m._local_max_peak_serial(distance, mask, distance)
+
+    assert np.array_equal(threaded, serial), (
+        "Threaded and serial `_local_max_peak` produced different "
+        f"outputs ({threaded.shape[0]} vs {serial.shape[0]} peaks). "
+        "ADR 0007's order-independence proof may be violated."
+    )
+
+    _release_markers(m)


### PR DESCRIPTION
## Summary

Slice 2 of #184 — thread the per-sigma loop in `Markers._local_max_peak` with `concurrent.futures.ThreadPoolExecutor` + `as_completed`. Closes #186.

- Workers compute `(local_max, log_resp)` for each sigma; main thread combines via `as_completed` because the per-sigma reduction is provably **order-independent** (see [[decisions/0007-mocap-log-peak-threading|ADR 0007]] for proof)
- Worker count `min(cpu_count, len(sigmas), 8)` per ADR 0005; skip threading when `len(sigmas) < 2`
- Chunked path (`_local_max_peak_chunked`) **untouched** — threading per-sigma inside a chunk re-introduces the memory pressure chunking is supposed to bound (rationale in ADR 0007). `low_memory=True` continues to use the unchanged chunked variant.
- Refactored serial per-sigma work into `_compute_per_sigma` (pure worker) + `_reduce_per_sigma` (main-thread combiner). `_local_max_peak_serial` exposes the serial path for the equivalence test only.
- Added `test_local_max_peak_serial_vs_threaded_3d` — runs both paths on the yeast 3D fixture and asserts `np.array_equal`. Intra-platform deterministic by construction.

## Perf numbers (yeast fixtures, 5 sigmas)

| Path | Before (serial) | After (threaded) | Speedup |
|------|----------------:|-----------------:|--------:|
| 2D `_local_max_peak` total | 5.8 ms | 2.9 ms | 2.0× |
| 3D `_local_max_peak` total | 161.0 ms | 41.6 ms | **3.9×** |
| 2D `Markers.run()` | 86.4 ms | 78.5 ms | -9% |
| 3D `Markers.run()` | 494.8 ms | 264.6 ms | **-46%** |

The 3D win is asymptotically larger because the per-sigma LoG was the dominant cost in the post-PRD-#179 pipeline (NMS now sub-ms, distance_im 36 ms, LoG was 161 ms → now 41 ms).

## Test plan

- [x] All 10 Slice 1 synthetic tests from #187 pass byte-identical against the threaded impl
- [x] New `test_local_max_peak_serial_vs_threaded_3d` passes (intra-platform `np.array_equal`)
- [x] Full `tests/test_mocap_marking.py` (56 tests) passes — including `test_low_memory_matches_full_*` (chunked path untouched)
- [x] `tests/test_mocap_marking_perf.py -m benchmark` shows the wall-clock wins above
- [ ] CI matrix (Linux + Windows + macOS, Python 3.10/3.11/3.12/3.13) all green

## What's next (out of scope here)

- PR C: bundled micro-cleanups in `_distance_im`, `_local_max_peak` (items 3-8 of audit) — pre-allocate `maximum_filter` output buffer, `gaussian_laplace` `output=`, in-place clamp, in-place XOR, drop redundant astype, cache `tuple(coords.T)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)