### PR TITLE
perf(hu_tracking): matmul rewrite of _calculate_normalized_moments (Slice 2 of #191)

### DIFF
--- a/nellie/tracking/hu_tracking.py
+++ b/nellie/tracking/hu_tracking.py
@@ -215,38 +215,51 @@ class HuMomentTracking:
         xp.ndarray
             Normalized moments eta for each image, shape (N, 4, 4).
         """
+        # Two-step batched matmul (per ADR 0008): the broadcast formulation
+        # ``(N, H, W, 4, 4)`` materializes ~28 MB intermediates at typical
+        # N=1000 / H=W=21 and runs 3× per 3D frame via the orthogonal-
+        # projection path. matmul contracts the spatial axes via BLAS and
+        # caps the peak intermediate at ~336 KB.
         xp = self.xp
-        # Broadcasting-heavy implementation for speed.
-        num_images, height, width = images.shape
-        extended_images = images[:, :, :, None, None]  # (N, H, W, 1, 1)
-
-        # pre-compute meshgrid
-        x, y = xp.meshgrid(xp.arange(width), xp.arange(height))
-        x = x[None, :, :, None, None]
-        y = y[None, :, :, None, None]
-
+        _, height, width = images.shape
+        dtype = images.dtype
         powers = xp.arange(4)
-        powers_x = powers[None, None, None, :, None]
-        powers_y = powers[None, None, None, None, :]
 
-        # raw moments M_{pq}
-        M = xp.sum(extended_images * (x ** powers_x) * (y ** powers_y), axis=(1, 2))  # (N, 4, 4)
+        # Raw-moment power tables: x_powers[w, p] = w^p, y_powers[h, q] = h^q.
+        # Cast the coordinate grids to the image dtype so the matmul stays in
+        # the input's precision (float32 → float32; matches the broadcast
+        # formulation's effective output precision modulo BLAS reduction
+        # ordering, which is the source of the rtol=1e-5 drift documented in
+        # ADR 0008).
+        x_arr = xp.arange(width, dtype=dtype)
+        y_arr = xp.arange(height, dtype=dtype)
+        x_powers = x_arr[:, None] ** powers[None, :]   # (W, 4)
+        y_powers = y_arr[:, None] ** powers[None, :]   # (H, 4)
 
-        # centroids
-        x_bar = M[:, 1, 0] / (M[:, 0, 0] + 1e-12)
-        y_bar = M[:, 0, 1] / (M[:, 0, 0] + 1e-12)
-        x_bar = x_bar[:, None, None, None, None]
-        y_bar = y_bar[:, None, None, None, None]
+        # Raw moments M[n, p, q] = sum_{h, w} I[n, h, w] * w^p * h^q via
+        # 2-step BLAS contraction. Broadcasting matmul handles the leading
+        # batch dim uniformly across numpy / cupy / torch.
+        M_inter = images @ x_powers                    # (N, H, 4)
+        M = M_inter.transpose(0, 2, 1) @ y_powers      # (N, 4, 4)
 
-        # central moments mu_{pq}
-        mu = xp.sum(
-            extended_images *
-            (x - x_bar) ** powers_x *
-            (y - y_bar) ** powers_y,
-            axis=(1, 2)
-        )  # (N, 4, 4)
+        # Centroids
+        x_bar = M[:, 1, 0] / (M[:, 0, 0] + 1e-12)      # (N,)
+        y_bar = M[:, 0, 1] / (M[:, 0, 0] + 1e-12)      # (N,)
 
-        # normalized moments eta_{pq}
+        # Centered coordinate power tables: per-N, since x_bar/y_bar vary.
+        # x_centered[n, w] = w - x_bar[n]; raised to integer powers ∈ {0..3}.
+        x_centered = x_arr[None, :] - x_bar[:, None]   # (N, W)
+        y_centered = y_arr[None, :] - y_bar[:, None]   # (N, H)
+        x_centered_powers = x_centered[..., None] ** powers   # (N, W, 4)
+        y_centered_powers = y_centered[..., None] ** powers   # (N, H, 4)
+
+        # Central moments mu[n, p, q] via batched matmul along the n axis.
+        # `(N, H, W) @ (N, W, 4) → (N, H, 4)` and so on — the broadcasting
+        # rule for matmul treats the leading dims as batch.
+        mu_inter = images @ x_centered_powers                    # (N, H, 4)
+        mu = mu_inter.transpose(0, 2, 1) @ y_centered_powers     # (N, 4, 4)
+
+        # Normalized moments eta_{pq} = mu_{pq} / M_{0,0}^((p+q+2)/2)
         i_plus_j = xp.arange(4)[:, None] + xp.arange(4)[None, :]
         denom = (M[:, 0, 0][:, None, None] ** ((i_plus_j[None, :, :] + 2) / 2.0)) + 1e-12
         eta = mu / denom

--- a/tests/test_hu_tracking.py
+++ b/tests/test_hu_tracking.py
@@ -821,6 +821,101 @@ def test_calculate_normalized_moments_single_pixel_analytical() -> None:
     np.testing.assert_allclose(out, expected, rtol=1e-5, atol=1e-7)
 
 
+def _broadcast_normalized_moments_reference(images: np.ndarray) -> np.ndarray:
+    """Reference broadcast implementation of `_calculate_normalized_moments`.
+
+    Verbatim copy of the pre-PRD #191 body (the (N, H, W, 4, 4) broadcast
+    formulation). Lives inline in the test file so the equivalence pin in
+    :func:`test_calculate_normalized_moments_matmul_matches_broadcast_3d`
+    survives even after the production code drops the broadcast version.
+    Pure numpy — independent of HuMomentTracking instance state.
+    """
+    extended_images = images[:, :, :, None, None]
+    height, width = images.shape[1], images.shape[2]
+    x, y = np.meshgrid(np.arange(width), np.arange(height))
+    x = x[None, :, :, None, None]
+    y = y[None, :, :, None, None]
+    powers = np.arange(4)
+    powers_x = powers[None, None, None, :, None]
+    powers_y = powers[None, None, None, None, :]
+    M = np.sum(extended_images * (x ** powers_x) * (y ** powers_y), axis=(1, 2))
+    x_bar = (M[:, 1, 0] / (M[:, 0, 0] + 1e-12))[:, None, None, None, None]
+    y_bar = (M[:, 0, 1] / (M[:, 0, 0] + 1e-12))[:, None, None, None, None]
+    mu = np.sum(
+        extended_images
+        * (x - x_bar) ** powers_x
+        * (y - y_bar) ** powers_y,
+        axis=(1, 2),
+    )
+    i_plus_j = np.arange(4)[:, None] + np.arange(4)[None, :]
+    denom = (M[:, 0, 0][:, None, None] ** ((i_plus_j[None, :, :] + 2) / 2.0)) + 1e-12
+    return mu / denom
+
+
+def test_calculate_normalized_moments_matmul_matches_broadcast_3d(make_hu_imageinfo_3d) -> None:
+    """Matmul output ≈ broadcast reference on realistic 3D orthogonal projections.
+
+    Drives the **realistic** input the production code sees: build a
+    HuMomentTracking against the yeast 3D fixture, capture
+    ``intensity_sub_volumes`` for ``t=0`` post-``_get_sub_volumes``, run
+    ``_get_orthogonal_projections`` to get the three (N, H, W) projections,
+    then assert the matmul implementation matches the inline broadcast
+    reference at ``rtol=1e-5, atol=1e-7`` for each projection.
+
+    Per ADR 0008, BLAS reorders the spatial-axis reduction so the matmul
+    output is not bit-equal to the broadcast version. ``rtol=1e-5`` is the
+    bound on the relative drift at float32 precision on realistic Hu
+    moment magnitudes — same intra-platform precedent as the equivalence
+    tests in PRDs #173 / #184. Both paths run in the same process so the
+    BLAS implementation is constant (no cross-platform variance to
+    confound the assertion).
+    """
+    info = make_hu_imageinfo_3d()
+    h = HuMomentTracking(info, HuMomentTrackingConfig(device="cpu"), num_t=2)
+    h._allocate_memory()
+
+    # Drive the per-frame ROI extraction to obtain realistic sub-volumes.
+    # `_get_frame_features` does the dense ROI extraction internally; we
+    # peek at the same intermediates by replaying the relevant fragment
+    # of `_get_frame_features` for t=0.
+    t = 0
+    intensity_frame = np.asarray(h.im_memmap[t]).astype(np.float32, copy=False)
+    distance_frame = np.asarray(h.im_distance_memmap[t])
+    distance_max_frame = distance_frame.copy()
+    h.ndi.maximum_filter(distance_max_frame, size=3, output=distance_max_frame)
+    distance_max_frame *= 2
+
+    marker_frame = np.asarray(h.im_marker_memmap[t]) > 0
+    marker_indices = np.argwhere(marker_frame)
+
+    # Skip the test gracefully if the fixture happens to have no markers
+    # in the first frame. (The synthetic suite already pins the
+    # zero-marker behavior; this test depends on having realistic data.)
+    if marker_indices.shape[0] == 0:
+        _release_hu(h)
+        pytest.skip("3D fixture frame 0 has no markers; equivalence test needs realistic input.")
+
+    region_bounds = h._get_im_bounds(marker_indices, distance_max_frame)
+    marker_mask = marker_frame
+    max_radius = int(np.ceil(np.max(distance_max_frame[marker_mask])).item()) * 2 + 1
+    intensity_sub_volumes = h._get_sub_volumes(intensity_frame, region_bounds, max_radius)
+
+    z_proj, y_proj, x_proj = h._get_orthogonal_projections(intensity_sub_volumes)
+
+    for label, projection in (("z", z_proj), ("y", y_proj), ("x", x_proj)):
+        out_matmul = h._calculate_normalized_moments(projection)
+        out_ref = _broadcast_normalized_moments_reference(projection)
+        np.testing.assert_allclose(
+            out_matmul,
+            out_ref,
+            rtol=1e-5,
+            atol=1e-7,
+            err_msg=f"matmul/broadcast disagreement on {label}-projection (rtol=1e-5)",
+        )
+
+    _release_hu(h)
+
+
 def test_calculate_normalized_moments_translation_invariance() -> None:
     """eta is translation-invariant: shifting a blob preserves eta.
 


### PR DESCRIPTION
## Summary

Slice 2 of #191. Replaces the `(N, H, W, 4, 4)` broadcast formulation in `HuMomentTracking._calculate_normalized_moments` with a two-step batched matmul per ADR 0008. Memory drops ~80×; matmul dispatches to BLAS via `@`, backend-uniform across numpy / cupy / torch.

## Perf (M2 Pro CPU, yeast 3D fixture sizing)

| Benchmark | Before (broadcast) | After (matmul) | Speedup |
|-----------|-------------------|----------------|---------|
| `_calculate_normalized_moments` N=100 | 3.7 ms | 0.1 ms | **37×** |
| `_calculate_normalized_moments` N=500 | 18.5 ms | 0.7 ms | **26×** |
| `_calculate_normalized_moments` N=1000 | 36.5 ms | 1.3 ms | **28×** |
| `_get_hu_moments` 3D N=100 | 12.0 ms | 1.3 ms | 9.2× |
| `_get_hu_moments` 3D N=500 | 59.6 ms | 6.1 ms | 9.8× |
| `_get_hu_moments` 3D N=1000 | 118.5 ms | 12.5 ms | **9.5×** |

The 3D `_get_hu_moments` win is "only" 9.5× because `_get_orthogonal_projections` (3× `xp.max` over the volume) is now the dominant cost — separate concern, not a limitation of this rewrite.

Numbers captured via the perf microbenchmarks added in Slice 1 (#194):
```
pytest -m benchmark tests/test_hu_tracking_perf.py -k 'calculate_normalized_moments or get_hu_moments_3d_scaling' -s
```

## Equivalence test

`test_calculate_normalized_moments_matmul_matches_broadcast_3d` drives realistic 3D-fixture `intensity_sub_volumes` through:
1. The matmul implementation (production code)
2. An inline broadcast-reference reimplementation (`_broadcast_normalized_moments_reference`)

…and asserts `np.allclose(rtol=1e-5, atol=1e-7)` on each of the 3 orthogonal projections (`z`, `y`, `x`). Both paths run in the same process so BLAS is constant — intra-platform deterministic by construction per ADR 0008.

## Test plan

- [x] `pytest tests/test_hu_tracking.py` — 42/42 pass (was 41 + 1 new equivalence test)
- [x] All 5 Slice 1 synthetic tests still pass against the matmul implementation (analytical / translation-invariance assertions hold within tolerance)
- [x] `pytest tests/ --ignore=tests/test_*_perf.py` — 609/609 pass (no regressions across the broader suite)
- [x] `pytest -m benchmark tests/test_hu_tracking_perf.py -s` — perf benchmarks run cleanly, numbers above

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)