### PR TITLE
perf(hu_tracking): bundled cleanups — GPU distance trick + vectorize _find_best_matches (#201)

### DIFF
--- a/nellie/tracking/hu_tracking.py
+++ b/nellie/tracking/hu_tracking.py
@@ -783,16 +783,22 @@ class HuMomentTracking:
         if coords_post_phys.size == 0 or coords_pre_phys.size == 0:
             return xp.zeros((0, 0), dtype=xp.float32), xp.zeros((0, 0), dtype=bool)
 
-        # Both GPU backends compute the pairwise distance matrix on-device
-        # via broadcasting; CPU defers to scipy's ``cdist`` and lifts the
-        # result into the active xp namespace. Slice 5 widens this branch
-        # to MPS so the matrix math stays on-GPU rather than round-tripping
-        # to numpy when ``device="mps"`` is in effect.
+        # Both GPU backends compute the pairwise distance matrix on-device;
+        # CPU defers to scipy's ``cdist`` (which already uses the BLAS
+        # ``||A||² + ||B||² − 2 A·B`` trick under the hood). The GPU branch
+        # uses the same trick directly to avoid the ``(N_post, N_pre, dim)``
+        # broadcast-subtract intermediate (~12 MB transient at typical
+        # N=1000, dim=3, float32) — issue #201 cleanup.
         if self.device_type in ("cuda", "mps"):
             A = xp.asarray(coords_post_phys)
             B = xp.asarray(coords_pre_phys)
-            diff = A[:, None, :] - B[None, :, :]
-            distance_matrix = xp.sqrt(xp.sum(diff ** 2, axis=2))
+            A_sq = xp.sum(A * A, axis=1)         # (N_post,)
+            B_sq = xp.sum(B * B, axis=1)         # (N_pre,)
+            AB = A @ B.T                          # (N_post, N_pre) via BLAS
+            dist_sq = A_sq[:, None] + B_sq[None, :] - 2 * AB
+            # Clamp tiny negative values from float subtraction error
+            # before sqrt — same pattern as scipy.spatial.distance.cdist.
+            distance_matrix = xp.sqrt(xp.maximum(dist_sq, 0))
         else:
             distance_matrix_np = cdist(coords_post_phys, coords_pre_phys)
             distance_matrix = xp.asarray(distance_matrix_np)
@@ -922,36 +928,43 @@ class HuMomentTracking:
         if int(np.prod(cost_matrix.shape)) == 0:
             return [], [], []
 
-        # Row-wise minima
+        # Row- and column-wise minima.
         row_min_idx = xp.argmin(cost_matrix, axis=1)
         row_min_val = xp.min(cost_matrix, axis=1)
-
-        # Column-wise minima
         col_min_idx = xp.argmin(cost_matrix, axis=0)
         col_min_val = xp.min(cost_matrix, axis=0)
 
-        row_matches = []
-        col_matches = []
-        costs = []
+        # Lift to numpy for vectorized boolean-mask filtering. The Python
+        # loop the previous version ran (one float() / int() / append per
+        # row + col) is moved into numpy's masked-index path below; for
+        # N=1000, this drops ~0.24 ms of per-frame Python overhead per
+        # the existing perf microbenchmark.
+        row_min_idx_np = self._to_cpu(row_min_idx)
+        row_min_val_np = self._to_cpu(row_min_val)
+        col_min_idx_np = self._to_cpu(col_min_idx)
+        col_min_val_np = self._to_cpu(col_min_val)
 
-        # Row candidates
-        for i, (r_idx, r_val) in enumerate(zip(row_min_idx, row_min_val)):
-            val = float(r_val)
-            if val > self.cost_cutoff:
-                continue
-            row_matches.append(int(i))
-            col_matches.append(int(r_idx))
-            costs.append(val)
+        # Row candidates: keep rows where min cost <= cost_cutoff (strict
+        # `>` skip in the original loop → inclusive `<=` keep here; pinned
+        # by `test_find_best_matches_cutoff_boundary_inclusive`).
+        row_keep = row_min_val_np <= self.cost_cutoff
+        row_i = np.flatnonzero(row_keep).astype(np.int64)
+        row_j = np.asarray(row_min_idx_np)[row_keep].astype(np.int64)
+        row_c = np.asarray(row_min_val_np, dtype=np.float64)[row_keep]
 
-        # Column candidates
-        for j, (c_idx, c_val) in enumerate(zip(col_min_idx, col_min_val)):
-            val = float(c_val)
-            if val > self.cost_cutoff:
-                continue
-            row_matches.append(int(c_idx))
-            col_matches.append(int(j))
-            costs.append(val)
+        # Column candidates: same shape but i is the argmin and j is the
+        # column index.
+        col_keep = col_min_val_np <= self.cost_cutoff
+        col_i = np.asarray(col_min_idx_np)[col_keep].astype(np.int64)
+        col_j = np.flatnonzero(col_keep).astype(np.int64)
+        col_c = np.asarray(col_min_val_np, dtype=np.float64)[col_keep]
 
+        # Concatenate row-then-column candidates — matches the original
+        # Python-loop append order (row block first, then column block);
+        # pinned by `test_find_best_matches_basic_concatenated_row_col`.
+        row_matches = np.concatenate((row_i, col_i)).tolist()
+        col_matches = np.concatenate((row_j, col_j)).tolist()
+        costs = np.concatenate((row_c, col_c)).tolist()
         return row_matches, col_matches, costs
 
     # -------------------------------------------------------------------------

--- a/tests/test_hu_tracking.py
+++ b/tests/test_hu_tracking.py
@@ -1205,6 +1205,91 @@ def test_get_cost_matrix_single_matchable_pair_finite_elsewhere_inf() -> None:
 
 
 # -------------------------------------------------------------------------
+# Direct synthetic tests for `_find_best_matches`
+#
+# Issue #201 (bundled cleanups) vectorizes the Python row/col loop with
+# `np.flatnonzero` + boolean mask + `.tolist()`. These tests pin the
+# observable contract: row+col concatenation order, the `<= cost_cutoff`
+# inclusive boundary, and the empty-matrix short-circuit. No fixture —
+# bare `HuMomentTracking` with `xp` and `cost_cutoff` only.
+# -------------------------------------------------------------------------
+
+
+def _make_bare_hu_for_find_best_matches(cost_cutoff: float = 1.0) -> HuMomentTracking:
+    h = HuMomentTracking.__new__(HuMomentTracking)
+    h.xp = np
+    h.cost_cutoff = cost_cutoff
+    return h
+
+
+def test_find_best_matches_empty_cost_matrix() -> None:
+    """`(0, 0)` cost matrix returns `([], [], [])` short-circuit."""
+    h = _make_bare_hu_for_find_best_matches()
+    cost = np.zeros((0, 0), dtype=np.float32)
+    row_matches, col_matches, costs = h._find_best_matches(cost)
+    assert row_matches == []
+    assert col_matches == []
+    assert costs == []
+
+
+def test_find_best_matches_all_above_cutoff_skipped() -> None:
+    """Every row/col min above `cost_cutoff` → no matches returned.
+
+    Pins the strict `>` skip semantics: values strictly above
+    cost_cutoff are skipped; values equal to cost_cutoff are kept
+    (covered separately by
+    :func:`test_find_best_matches_cutoff_boundary_inclusive`).
+    """
+    h = _make_bare_hu_for_find_best_matches(cost_cutoff=1.0)
+    cost = np.array([[2.0, 3.0], [4.0, 5.0]], dtype=np.float32)
+    row_matches, col_matches, costs = h._find_best_matches(cost)
+    assert row_matches == []
+    assert col_matches == []
+    assert costs == []
+
+
+def test_find_best_matches_basic_concatenated_row_col() -> None:
+    """Row candidates come first, then column candidates — concatenation order pinned.
+
+    On a small (2, 2) cost matrix where all entries pass the cutoff,
+    the function returns four candidate triples: two row-based plus
+    two column-based. The pre-vectorization Python loop appends row
+    candidates first (in row-index order), then column candidates
+    (in col-index order); the vectorized refactor must preserve this
+    exact ordering or downstream `_run_hu_tracking`'s
+    `frame_vector_array` row order changes silently.
+    """
+    h = _make_bare_hu_for_find_best_matches(cost_cutoff=1.0)
+    cost = np.array([[0.5, 0.9], [0.8, 0.3]], dtype=np.float32)
+    row_matches, col_matches, costs = h._find_best_matches(cost)
+    # Row candidates: row 0 best is j=0 (val 0.5); row 1 best is j=1 (val 0.3)
+    # Col candidates: col 0 best is i=0 (val 0.5); col 1 best is i=1 (val 0.3)
+    assert row_matches == [0, 1, 0, 1]
+    assert col_matches == [0, 1, 0, 1]
+    np.testing.assert_allclose(costs, [0.5, 0.3, 0.5, 0.3], rtol=1e-6)
+
+
+def test_find_best_matches_cutoff_boundary_inclusive() -> None:
+    """Value exactly equal to `cost_cutoff` is kept (`>` skip, not `>=`).
+
+    The check at the original :func:`_find_best_matches` is
+    ``if val > self.cost_cutoff: continue`` — strict `>`. Pinning
+    the inclusive boundary so the vectorized refactor doesn't
+    silently flip to `>=` (which would drop matches at the cutoff
+    edge — a real-world regression class).
+    """
+    h = _make_bare_hu_for_find_best_matches(cost_cutoff=1.0)
+    # Row 0 min is 0.5 (j=0); row 1 min is 1.0 (j=1, exactly at cutoff)
+    # Col 0 min is 0.5 (i=0); col 1 min is 1.0 (i=1, exactly at cutoff)
+    cost = np.array([[0.5, 1.5], [2.0, 1.0]], dtype=np.float32)
+    row_matches, col_matches, costs = h._find_best_matches(cost)
+    # All four candidates pass the inclusive cutoff
+    assert row_matches == [0, 1, 0, 1]
+    assert col_matches == [0, 1, 0, 1]
+    np.testing.assert_allclose(costs, [0.5, 1.0, 0.5, 1.0], rtol=1e-6)
+
+
+# -------------------------------------------------------------------------
 # Input mutation: hash-before / hash-after
 # -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two unrelated cleanups from the 2026-05-11 audit, items 3 + 6 of 7. Both preserve output semantics exactly. **Single PR**, no slice plan (mocap_marking PR C precedent — bundled micro-cleanups don't need the 2-slice ceremony).

## Item 3: `_get_distance_mask` GPU path — BLAS distance trick

GPU branch (CUDA / MPS) replaces the broadcast-subtract pattern with the BLAS `||A||² + ||B||² − 2 A·B` trick:

```python
A_sq = sum(A * A, axis=1)
B_sq = sum(B * B, axis=1)
AB = A @ B.T                                         # BLAS dispatch
dist = sqrt(maximum(A_sq[:, None] + B_sq[None, :] - 2 * AB, 0))
```

Avoids the `(N_post, N_pre, dim)` intermediate (~12 MB transient at typical N=1000, dim=3, float32). CPU branch unchanged — `scipy.spatial.distance.cdist` already uses the same trick.

Output equivalence verified by `tests/test_mps_smoke.py` + `tests/test_mps_equivalence.py` hu_tracking suites — **Jaccard = 1.0000 on both 2D and 3D** against the CPU baseline; cost_mean identical to 4 decimals.

## Item 6: `_find_best_matches` — vectorize the Python loops

Replace the per-element Python `for i, (r_idx, r_val) in enumerate(zip(...)):` with `np.flatnonzero` + boolean-mask + `.tolist()`. Concatenation order + inclusive `<=` cutoff boundary preserved (both pinned by new synthetic tests).

### Perf (M2 Pro CPU)

| | Total | argmin/min | Loop overhead |
|---|---|---|---|
| Before | 1.15 ms | 0.91 ms | **0.24 ms** |
| After | 0.99 ms | 0.93 ms | **0.06 ms** |

Loop overhead drops **4×** (0.24 → 0.06 ms). Total saving is modest in absolute terms because `argmin`/`min` itself is the dominant cost.

## New tests

4 synthetic tests for `_find_best_matches`:
- `test_find_best_matches_empty_cost_matrix` — `(0, 0)` → `([], [], [])` short-circuit
- `test_find_best_matches_all_above_cutoff_skipped` — every min above cutoff → no matches
- `test_find_best_matches_basic_concatenated_row_col` — pins row+col concatenation order
- `test_find_best_matches_cutoff_boundary_inclusive` — pins `<= cost_cutoff` (NOT `<`) inclusive boundary

## Item 5 (sparse two-pass cache) — deferred

Caching per-row arrays in `_match_frames_sparse` would add 25 MB at typical sparse-mode N (~10000) and up to 500 MB at the pathological end. Not worth the memory cost without profiler data showing the second-pass recomputation is actually a hot loop.

## Test plan

- [x] `pytest tests/test_hu_tracking.py` — 51/51 pass (was 47 + 4 new synthetic tests)
- [x] `pytest tests/ --ignore=tests/test_*_perf.py` — 618/618 pass
- [x] `pytest -m mps tests/test_mps_smoke.py tests/test_mps_equivalence.py -k hu` — 4/4 pass with Jaccard = 1.0000 on both 2D and 3D
- [x] `pytest -m benchmark tests/test_hu_tracking_perf.py::test_find_best_matches_loop_overhead -s` — perf benchmark runs cleanly with the new numbers

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)