### PR TITLE
tests(flow_interpolation): pin _get_nearby_coords no-NaN behavior + ADR 0010 (Slice 1 of #204)

### DIFF
--- a/tests/test_flow_interpolation.py
+++ b/tests/test_flow_interpolation.py
@@ -1,0 +1,362 @@
+"""Characterization tests for ``nellie.tracking.flow_interpolation.FlowInterpolator``.
+
+Bootstraps the test surface for :mod:`nellie.tracking.flow_interpolation`.
+Pins the wiki-documented invariants and the contract of the per-frame
+neighbor-lookup primitive ``_get_nearby_coords``:
+
+- ``_get_nearby_coords`` (PRD #204 / Slice 1 #206 / Slice 2 #207):
+  - Returns a pair of per-original-coord lists
+    ``(nearby_idxs_return, distance_return)``, both length
+    ``len(coords)``.
+  - Per-coord slot is empty (``[]``) when (a) the input coord has any
+    NaN component or (b) no ``check_coords`` lie within ``max_distance_um``
+    of the (scaled) query.
+  - Otherwise the slot holds the within-radius ``check_coords`` indices
+    and their **scaled** Euclidean distances (i.e.
+    ``||scaling * (query - check)||_2``).
+  - Symmetry: the same pair of points should yield matching distances
+    for forward and backward queries.
+
+- ``interpolate_coord`` / ``interpolate_all_forward`` / ``interpolate_all_backward``:
+  - Future Slice 1 of PRD #205 will expand the driver-level pin.
+
+The ``_make_bare_flow_for_nearby_coords`` helper builds a
+``FlowInterpolator`` instance via ``__new__`` and manually sets only the
+attributes ``_get_nearby_coords`` reads (``self.scaling``,
+``self.check_coords``, ``self.current_t``, ``self.current_tree``,
+``self.max_distance_um``). This avoids the full constructor's ImInfo /
+``flow_vector_array.npy`` setup — the same pattern used in
+``test_hu_tracking._make_bare_hu_for_*`` and
+``test_mocap_marking._make_bare_markers_for_*``.
+
+The pre-rewrite NaN-coord path in ``_get_nearby_coords`` has a known
+positional-alignment bug (``i not in good_coords`` over an ndarray:
+the loop only aligns correctly when there are no NaN coords).
+PRD #204 fixes this in Slice 2 (#207); Slice 1 deliberately does NOT
+pin the buggy NaN-alignment behavior — the corrected behavior is
+pinned by Slice 2's positional-alignment regression test.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.spatial import cKDTree
+
+from nellie.tracking.flow_interpolation import FlowInterpolator
+
+
+# -------------------------------------------------------------------------
+# Bare-instance helper for _get_nearby_coords
+# -------------------------------------------------------------------------
+
+
+def _make_bare_flow_for_nearby_coords(
+    check_coords: np.ndarray,
+    scaling: tuple,
+    max_distance_um: float = 1.0,
+) -> FlowInterpolator:
+    """Build a FlowInterpolator instance bypassing __init__ for nearby-coord tests.
+
+    ``_get_nearby_coords`` only reads ``self.scaling``,
+    ``self.check_coords``, ``self.current_t``, ``self.current_tree``, and
+    ``self.max_distance_um``. The ``__new__`` + manual attribute pattern
+    mirrors ``_make_bare_hu_for_*`` in ``tests/test_hu_tracking.py`` and
+    avoids the full constructor's ImInfo / ``flow_vector_array.npy`` setup.
+
+    ``current_t`` is left as ``None`` so the first call to
+    ``_get_nearby_coords`` triggers a fresh tree build from
+    ``check_coords * scaling`` (matching the production code path).
+    """
+    f = FlowInterpolator.__new__(FlowInterpolator)
+    f.scaling = scaling
+    f.check_coords = np.asarray(check_coords, dtype=np.float64)
+    f.current_t = None
+    f.current_tree = None
+    f.max_distance_um = float(max_distance_um)
+    return f
+
+
+# -------------------------------------------------------------------------
+# _get_nearby_coords contract tests
+# -------------------------------------------------------------------------
+
+
+def test_get_nearby_coords_returns_pair_of_per_coord_lists() -> None:
+    """Output is a 2-tuple, both length ``len(coords)``.
+
+    Pins the basic schema contract that ``_get_vector_weights`` and
+    ``_get_final_vector`` both rely on (per-coord indexing into the
+    returned lists).
+    """
+    check_coords = np.array([[0.0, 0.0], [5.0, 5.0]], dtype=np.float64)
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(1.0, 1.0), max_distance_um=10.0)
+
+    coords = np.array([[0.5, 0.5], [4.5, 4.5], [100.0, 100.0]], dtype=np.float64)
+    nearby_idxs, distances = f._get_nearby_coords(t=0, coords=coords)
+
+    assert len(nearby_idxs) == len(coords)
+    assert len(distances) == len(coords)
+
+
+def test_get_nearby_coords_empty_check_coords_returns_empty_slots() -> None:
+    """``check_coords`` empty → every query coord gets an empty slot.
+
+    Boundary: ``cKDTree`` on an empty point set still constructs but
+    every ``query_ball_point`` returns ``[]``. Pin that the per-coord
+    output reflects this with empty slots (not ``None``, not raised).
+    """
+    check_coords = np.zeros((0, 2), dtype=np.float64)
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(1.0, 1.0), max_distance_um=1.0)
+
+    coords = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float64)
+    nearby_idxs, distances = f._get_nearby_coords(t=0, coords=coords)
+
+    # The early-return branches in the current impl: ``len(nearby_idxs) == 0``
+    # OR ``max_k == 0`` both return ``([], [])``. Either branch is acceptable;
+    # the contract is "no neighbors found" and both representations satisfy it.
+    if len(nearby_idxs) == 0:
+        # Early-return short-circuit: empty result.
+        assert nearby_idxs == [] and distances == []
+    else:
+        # Full-loop path: per-coord empty slots.
+        assert len(nearby_idxs) == len(coords)
+        for slot in nearby_idxs:
+            assert len(slot) == 0
+        for slot in distances:
+            assert len(slot) == 0
+
+
+def test_get_nearby_coords_no_neighbors_in_radius_returns_empty() -> None:
+    """All ``check_coords`` outside the radius → ``([], [])`` short-circuit.
+
+    The current impl short-circuits when ``max_k == 0`` (every
+    ``query_ball_point`` result is empty). Pin the short-circuit form
+    so the rewrite preserves the contract.
+    """
+    check_coords = np.array([[100.0, 100.0], [200.0, 200.0]], dtype=np.float64)
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(1.0, 1.0), max_distance_um=1.0)
+
+    coords = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float64)
+    nearby_idxs, distances = f._get_nearby_coords(t=0, coords=coords)
+
+    # The current impl returns ``([], [])`` via the ``max_k == 0`` short-circuit.
+    # The post-rewrite contract should match: every per-coord slot is empty.
+    if len(nearby_idxs) == 0:
+        assert nearby_idxs == [] and distances == []
+    else:
+        for slot in nearby_idxs:
+            assert len(slot) == 0
+        for slot in distances:
+            assert len(slot) == 0
+
+
+def test_get_nearby_coords_single_neighbor_known_distance_2d() -> None:
+    """Single ``check_coord`` at known offset → correct index + scaled distance.
+
+    Query coord at origin, check coord at ``(3, 4)`` with unit scaling:
+    distance = 5.0 (3-4-5 triangle). The index returned is ``0`` (the
+    only check coord). Pins both the index and the distance computation.
+    """
+    check_coords = np.array([[3.0, 4.0]], dtype=np.float64)
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(1.0, 1.0), max_distance_um=10.0)
+
+    coords = np.array([[0.0, 0.0]], dtype=np.float64)
+    nearby_idxs, distances = f._get_nearby_coords(t=0, coords=coords)
+
+    assert len(nearby_idxs) == 1
+    assert len(nearby_idxs[0]) == 1
+    assert int(nearby_idxs[0][0]) == 0
+    assert distances[0][0] == pytest.approx(5.0, rel=1e-9)
+
+
+def test_get_nearby_coords_distance_reflects_scaling() -> None:
+    """Distance = ``||scaling * (query - check)||_2``, NOT raw Euclidean.
+
+    Query coord ``(0, 0)``, check coord ``(1, 1)``, scaling
+    ``(3.0, 4.0)``. Scaled offset = ``(3, 4)``; distance = 5.0. Pins
+    that the function applies ``scaling`` to both the query and check
+    coordinates before computing distance.
+    """
+    check_coords = np.array([[1.0, 1.0]], dtype=np.float64)
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(3.0, 4.0), max_distance_um=10.0)
+
+    coords = np.array([[0.0, 0.0]], dtype=np.float64)
+    nearby_idxs, distances = f._get_nearby_coords(t=0, coords=coords)
+
+    assert len(nearby_idxs[0]) == 1
+    assert distances[0][0] == pytest.approx(5.0, rel=1e-9)
+
+
+def test_get_nearby_coords_multi_coord_all_within_radius_2d() -> None:
+    """Multi query coords, all within radius of multiple check coords.
+
+    Pins that per-coord output slots correctly correspond to per-coord
+    inputs and that distances are sorted by ``cKDTree.query`` ascending
+    order (or matching order in the rewrite).
+    """
+    check_coords = np.array(
+        [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]],
+        dtype=np.float64,
+    )
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(1.0, 1.0), max_distance_um=2.0)
+
+    coords = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float64)
+    nearby_idxs, distances = f._get_nearby_coords(t=0, coords=coords)
+
+    # Each query coord should find all 4 check coords within radius 2.0.
+    assert len(nearby_idxs[0]) == 4
+    assert len(nearby_idxs[1]) == 4
+
+    # Validate distances against analytical computation.
+    # For query (0, 0): distances to {(0,0), (0,1), (1,0), (1,1)} = {0, 1, 1, sqrt(2)}.
+    # For query (1, 1): distances to {(0,0), (0,1), (1,0), (1,1)} = {sqrt(2), 1, 1, 0}.
+    # Order can vary — assert sorted distances match analytical sorted distances.
+    expected_q0_sorted = sorted([0.0, 1.0, 1.0, np.sqrt(2.0)])
+    expected_q1_sorted = sorted([np.sqrt(2.0), 1.0, 1.0, 0.0])
+    np.testing.assert_allclose(sorted(distances[0]), expected_q0_sorted, rtol=1e-9, atol=1e-12)
+    np.testing.assert_allclose(sorted(distances[1]), expected_q1_sorted, rtol=1e-9, atol=1e-12)
+
+
+def test_get_nearby_coords_3d_single_neighbor_known_distance() -> None:
+    """3D variant: single ``check_coord`` at known offset → correct distance.
+
+    Query coord at origin, check coord at ``(2, 3, 6)`` with unit
+    scaling: distance = ``sqrt(4 + 9 + 36) = 7.0``. Pin the 3D path.
+    """
+    check_coords = np.array([[2.0, 3.0, 6.0]], dtype=np.float64)
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(1.0, 1.0, 1.0), max_distance_um=10.0)
+
+    coords = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+    nearby_idxs, distances = f._get_nearby_coords(t=0, coords=coords)
+
+    assert len(nearby_idxs[0]) == 1
+    assert int(nearby_idxs[0][0]) == 0
+    assert distances[0][0] == pytest.approx(7.0, rel=1e-9)
+
+
+def test_get_nearby_coords_3d_distance_reflects_anisotropic_scaling() -> None:
+    """3D: anisotropic scaling correctly applied to all three axes.
+
+    Query coord ``(0, 0, 0)``, check coord ``(1, 1, 1)``, scaling
+    ``(2.0, 3.0, 6.0)``. Scaled offset = ``(2, 3, 6)``; distance = 7.0.
+    Pins anisotropic scaling on the 3D path (Z is typically much
+    coarser than Y/X in microscopy stacks).
+    """
+    check_coords = np.array([[1.0, 1.0, 1.0]], dtype=np.float64)
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(2.0, 3.0, 6.0), max_distance_um=10.0)
+
+    coords = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+    nearby_idxs, distances = f._get_nearby_coords(t=0, coords=coords)
+
+    assert len(nearby_idxs[0]) == 1
+    assert distances[0][0] == pytest.approx(7.0, rel=1e-9)
+
+
+def test_get_nearby_coords_caches_tree_across_same_t() -> None:
+    """Tree built once when ``current_t`` matches across calls.
+
+    Pins the cache invariant: after a call sets up the tree, a second
+    call with the same ``t`` reuses ``self.current_tree``. The
+    production caller (``interpolate_coord``) sets ``self.current_t = t``
+    after ``_get_nearby_coords`` returns; for direct-call testing the
+    cache is invalidated each time (current_t left as None for the
+    first call). This test sets ``current_t`` between calls to mirror
+    the production cache state.
+    """
+    check_coords = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float64)
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(1.0, 1.0), max_distance_um=2.0)
+
+    coords = np.array([[0.5, 0.5]], dtype=np.float64)
+
+    # First call: builds tree (current_t was None).
+    f._get_nearby_coords(t=0, coords=coords)
+    f.current_t = 0  # mimic production caller's post-call assignment
+    tree_after_first_call = f.current_tree
+
+    # Second call with same t: should reuse the cached tree.
+    f._get_nearby_coords(t=0, coords=coords)
+
+    assert f.current_tree is tree_after_first_call, "Tree should not be rebuilt for same t"
+
+
+def test_get_nearby_coords_rebuilds_tree_on_t_change() -> None:
+    """Tree rebuilt when ``current_t`` changes.
+
+    Pins the inverse of the cache invariant: when the caller advances
+    ``t``, the tree is rebuilt against the (potentially-new)
+    ``check_coords``.
+    """
+    check_coords = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float64)
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(1.0, 1.0), max_distance_um=2.0)
+
+    coords = np.array([[0.5, 0.5]], dtype=np.float64)
+
+    # First call at t=0 builds tree.
+    f._get_nearby_coords(t=0, coords=coords)
+    f.current_t = 0
+    tree_after_first_call = f.current_tree
+
+    # Caller advances to t=1; tree should be rebuilt.
+    f._get_nearby_coords(t=1, coords=coords)
+
+    assert f.current_tree is not tree_after_first_call, "Tree should be rebuilt for new t"
+
+
+def test_get_nearby_coords_neighbors_match_independent_kdtree_query() -> None:
+    """Reference equivalence: result matches an independent ``cKDTree`` query.
+
+    Pin against a known-good baseline: build the same tree externally
+    via ``cKDTree`` and run ``query_ball_point`` directly. Indices
+    should match (as a set; per-coord ordering can differ between
+    implementations).
+    """
+    rng = np.random.default_rng(42)
+    check_coords = rng.uniform(0.0, 10.0, size=(50, 2))
+    scaling = (1.0, 1.0)
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=scaling, max_distance_um=2.0)
+
+    coords = rng.uniform(0.0, 10.0, size=(8, 2))
+    nearby_idxs, distances = f._get_nearby_coords(t=0, coords=coords)
+
+    # Independent reference computation.
+    ref_tree = cKDTree(check_coords * np.asarray(scaling))
+    scaled_query = coords * np.asarray(scaling)
+    ref_idxs = ref_tree.query_ball_point(scaled_query, r=2.0, p=2)
+
+    # Per-coord index sets should match.
+    for i in range(len(coords)):
+        assert set(int(x) for x in nearby_idxs[i]) == set(int(x) for x in ref_idxs[i]), (
+            f"Index-set mismatch at coord {i}: got "
+            f"{sorted(int(x) for x in nearby_idxs[i])}, "
+            f"expected {sorted(int(x) for x in ref_idxs[i])}"
+        )
+        # Distance values: each returned distance should equal
+        # ||scaled_check - scaled_query||_2 for some neighbor.
+        ref_distances_for_coord = sorted(
+            float(np.linalg.norm(check_coords[j] * np.asarray(scaling) - scaled_query[i]))
+            for j in ref_idxs[i]
+        )
+        np.testing.assert_allclose(
+            sorted(distances[i]),
+            ref_distances_for_coord,
+            rtol=1e-9,
+            atol=1e-12,
+        )
+
+
+def test_get_nearby_coords_input_check_coords_not_mutated() -> None:
+    """``self.check_coords`` is not mutated by the call.
+
+    Pins immutability of the input — the function multiplies by
+    ``scaling`` to build the tree but should not write back into
+    ``self.check_coords``.
+    """
+    check_coords = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+    check_coords_copy = check_coords.copy()
+    f = _make_bare_flow_for_nearby_coords(check_coords, scaling=(2.0, 3.0), max_distance_um=10.0)
+
+    coords = np.array([[0.0, 0.0]], dtype=np.float64)
+    f._get_nearby_coords(t=0, coords=coords)
+
+    np.testing.assert_array_equal(f.check_coords, check_coords_copy)

--- a/tests/test_flow_interpolation_perf.py
+++ b/tests/test_flow_interpolation_perf.py
@@ -1,0 +1,279 @@
+"""Opt-in performance tests for ``nellie.tracking.flow_interpolation``.
+
+Skipped by default — invoke with ``pytest -m benchmark`` to run. Mirrors
+the pattern in :mod:`tests.test_filtering_perf`,
+:mod:`tests.test_labelling_perf`, :mod:`tests.test_networking_perf`, and
+:mod:`tests.test_hu_tracking_perf`:
+
+1. **Hot-path microbenchmarks** decompose the per-frame interpolation
+   cost into the dominant kernels surfaced by reading the source:
+   - ``_get_nearby_coords`` scaling at N coords = 100 / 500 / 1000 — the
+     per-frame neighbor-lookup primitive (PRD #204). Pre-rewrite this is
+     a double `cKDTree` query (`query_ball_point` for counts +
+     `query(k=max_k)` for distances); post-rewrite it is a single
+     `query_ball_point` + per-coord `np.linalg.norm`. The wall-clock
+     here drives the choice in PRD #204.
+   - ``interpolate_coord`` end-to-end at N = 1000 — the per-frame
+     entry point used by ``VoxelReassigner`` and ``LabelTracks``.
+   - ``interpolate_all_forward`` end-to-end on a synthetic 3-frame
+     flow array, N = 500 — the per-trajectory driver. The Python
+     per-coord inner loop here drives the choice in PRD #205.
+
+The microbenchmarks are **informational** (printed `[perf]` lines, no
+assertions) — Filter's three assertions remain the only ones, and only
+because each pinned a decision from a real perf pass; here no
+flow_interpolation perf pass has happened yet, so assertions would be
+speculative. The prints scaffold the future perf pass.
+
+There is **no end-to-end ``FlowInterpolator.run()``** equivalent to the
+HuMomentTracking baseline at the top of
+:mod:`tests.test_hu_tracking_perf` — `FlowInterpolator` is a per-frame
+helper, not a `run()`-style stage. The closest end-to-end shape is
+``interpolate_all_forward`` (covered above). FlowInterpolator's
+contribution to the pipeline-level wall-clock is captured indirectly by
+the VoxelReassigner perf tests in :mod:`tests.test_voxel_reassignment_perf`
+(VoxelReassigner constructs two FlowInterpolator instances unconditionally
+and calls ``interpolate_coord`` twice per frame).
+
+There is also no MPS variant — `FlowInterpolator` is a CPU-only path
+(`scipy.spatial.cKDTree` and pure-numpy distance / weight math). It
+does not use `xp` and would not benefit from MPS dispatch.
+"""
+
+from __future__ import annotations
+
+import time
+from statistics import median
+
+import numpy as np
+import pytest
+
+from nellie.tracking.flow_interpolation import FlowInterpolator
+
+
+pytestmark = pytest.mark.benchmark
+
+
+def _time_call(fn, *, iters: int) -> float:
+    """Median wall-clock of ``iters`` invocations, in seconds.
+
+    Mirror of the helper in :mod:`tests.test_hu_tracking_perf`.
+    """
+    samples: list[float] = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        samples.append(time.perf_counter() - start)
+    return median(samples)
+
+
+def _make_bare_flow(check_coords: np.ndarray, scaling: tuple, max_distance_um: float = 1.0) -> FlowInterpolator:
+    """Build a FlowInterpolator instance bypassing __init__ for perf microbenchmarks.
+
+    Mirrors ``_make_bare_flow_for_nearby_coords`` in
+    :mod:`tests.test_flow_interpolation` — sets only the attributes the
+    benchmarked methods read. Avoids the full constructor's ImInfo /
+    ``flow_vector_array.npy`` setup.
+    """
+    f = FlowInterpolator.__new__(FlowInterpolator)
+    f.scaling = scaling
+    f.check_coords = np.asarray(check_coords, dtype=np.float64)
+    f.current_t = None
+    f.current_tree = None
+    f.max_distance_um = float(max_distance_um)
+    return f
+
+
+# -------------------------------------------------------------------------
+# _get_nearby_coords scaling — PRD #204 hot path
+# -------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n", [100, 500, 1000])
+def test_get_nearby_coords_scaling(n, capsys) -> None:
+    """Print median wall-clock for ``_get_nearby_coords`` at N coords.
+
+    Synthetic 3D scenario: random check_coords + query coords drawn from
+    the same distribution so a meaningful fraction land within radius.
+    Pre-rewrite calls ``query_ball_point`` then ``query(k=max_k)``;
+    post-rewrite (PRD #204 / Slice 2 #207) calls ``query_ball_point``
+    once + per-coord ``np.linalg.norm``. The wall-clock difference
+    drives the rewrite decision.
+    """
+    rng = np.random.default_rng(0)
+    # Spread points over a unit volume with anisotropic scaling typical of
+    # 3D microscopy (Z coarser than Y/X).
+    check_coords = rng.uniform(0.0, 100.0, size=(n, 3))
+    f = _make_bare_flow(check_coords, scaling=(0.5, 0.1, 0.1), max_distance_um=2.0)
+
+    coords = rng.uniform(0.0, 100.0, size=(n, 3))
+
+    # Warm up: first call builds the tree (one-time cost).
+    f._get_nearby_coords(t=0, coords=coords)
+    f.current_t = 0  # avoid per-iter tree rebuild — match production cache state
+
+    elapsed = _time_call(lambda: f._get_nearby_coords(t=0, coords=coords), iters=5)
+    with capsys.disabled():
+        print(
+            f"\n[perf] _get_nearby_coords N={n:4d} (cached tree) median over 5: "
+            f"{elapsed * 1000:7.2f} ms"
+        )
+
+
+# -------------------------------------------------------------------------
+# interpolate_coord end-to-end — per-frame driver entry
+# -------------------------------------------------------------------------
+
+
+def _make_bare_flow_for_interpolate(
+    flow_vector_array: np.ndarray,
+    scaling: tuple,
+    no_z: bool,
+    max_distance_um: float = 1.0,
+) -> FlowInterpolator:
+    """Bare FlowInterpolator for ``interpolate_coord`` end-to-end perf.
+
+    Adds ``self.flow_vector_array``, ``self.forward``, and a stub
+    ``self.im_info`` exposing the ``no_z`` flag (the only ImInfo
+    attribute ``interpolate_coord`` reads). Mirrors the bare-class
+    pattern but with one more attribute set than
+    ``_make_bare_flow``.
+    """
+    f = FlowInterpolator.__new__(FlowInterpolator)
+    f.scaling = scaling
+    f.flow_vector_array = np.asarray(flow_vector_array, dtype=np.float64)
+    f.forward = True
+    f.current_t = None
+    f.check_rows = None
+    f.check_coords = None
+    f.current_tree = None
+    f.max_distance_um = float(max_distance_um)
+
+    class _StubImInfo:
+        pass
+
+    info = _StubImInfo()
+    info.no_z = no_z  # type: ignore[attr-defined]
+    f.im_info = info  # type: ignore[assignment]
+    return f
+
+
+def test_interpolate_coord_end_to_end(capsys) -> None:
+    """Print median wall-clock for ``interpolate_coord`` at N=1000.
+
+    Synthetic 3D flow_vector_array with one timepoint of marker matches.
+    Pre- and post-rewrite path both run end-to-end: tree-build,
+    neighbor lookup, weight compute, weighted-average. Captures the
+    cumulative per-frame cost of the FlowInterpolator entry point used
+    by ``VoxelReassigner`` and ``LabelTracks``.
+    """
+    rng = np.random.default_rng(1)
+    n_markers = 1000
+    # flow_vector_array 3D schema: [t, z, y, x, dz, dy, dx, cost]
+    flow_vector_array = np.column_stack([
+        np.zeros(n_markers),  # t
+        rng.uniform(0.0, 100.0, size=n_markers),  # z (pre)
+        rng.uniform(0.0, 100.0, size=n_markers),  # y (pre)
+        rng.uniform(0.0, 100.0, size=n_markers),  # x (pre)
+        rng.uniform(-1.0, 1.0, size=n_markers),  # dz
+        rng.uniform(-1.0, 1.0, size=n_markers),  # dy
+        rng.uniform(-1.0, 1.0, size=n_markers),  # dx
+        rng.uniform(0.0, 0.5, size=n_markers),  # cost
+    ])
+    f = _make_bare_flow_for_interpolate(
+        flow_vector_array, scaling=(0.5, 0.1, 0.1), no_z=False, max_distance_um=2.0,
+    )
+
+    # Query coords: same distribution so a meaningful fraction find neighbors.
+    coords = rng.uniform(0.0, 100.0, size=(n_markers, 3))
+
+    # Warm up.
+    f.current_t = None
+    f.interpolate_coord(coords, t=0)
+
+    def _one_call() -> None:
+        # Reset per-call cache so we measure the fresh-frame cost.
+        f.current_t = None
+        f.interpolate_coord(coords, t=0)
+
+    elapsed = _time_call(_one_call, iters=3)
+    with capsys.disabled():
+        print(
+            f"\n[perf] interpolate_coord N={n_markers} 3D (fresh cache) "
+            f"median over 3: {elapsed * 1000:.1f} ms"
+        )
+
+
+# -------------------------------------------------------------------------
+# interpolate_all_forward end-to-end — per-trajectory driver — PRD #205 hot path
+# -------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_coords", [100, 500])
+def test_interpolate_all_forward_end_to_end(n_coords, capsys, tmp_path) -> None:
+    """Print median wall-clock for ``interpolate_all_forward`` at N coords.
+
+    Synthetic 3D flow_vector_array spanning 3 timepoints. The driver
+    iterates t in `[start_t, end_t)`, and per t iterates over each
+    coord with a Python loop that computes the new coord position and
+    appends to a Python list (PRD #205's per-coord vectorization
+    target). The wall-clock here drives the choice in PRD #205.
+
+    Builds a real ``FlowInterpolator`` via ``__init__`` (not
+    ``__new__``) because ``interpolate_all_forward`` is a module-level
+    function that reconstructs a FlowInterpolator internally. Writes
+    the synthetic flow array to ``tmp_path`` and stubs an ImInfo
+    pointing at it.
+    """
+    from nellie.tracking.flow_interpolation import interpolate_all_forward
+
+    rng = np.random.default_rng(2)
+    n_markers = max(n_coords * 2, 200)
+    flow_per_t = []
+    for t in range(2):  # need t=0 and t=1 for end_t=2 driver
+        flow_per_t.append(np.column_stack([
+            np.full(n_markers, t, dtype=np.float64),  # t
+            rng.uniform(0.0, 100.0, size=n_markers),
+            rng.uniform(0.0, 100.0, size=n_markers),
+            rng.uniform(0.0, 100.0, size=n_markers),
+            rng.uniform(-1.0, 1.0, size=n_markers),
+            rng.uniform(-1.0, 1.0, size=n_markers),
+            rng.uniform(-1.0, 1.0, size=n_markers),
+            rng.uniform(0.0, 0.5, size=n_markers),
+        ]))
+    flow_vector_array = np.concatenate(flow_per_t, axis=0)
+    flow_path = tmp_path / "flow_vector_array.npy"
+    np.save(flow_path, flow_vector_array)
+
+    # Stub ImInfo: minimum surface area for FlowInterpolator __init__.
+    im_path = tmp_path / "stub_im.npy"
+    np.save(im_path, np.zeros((3, 50, 100, 100), dtype=np.float32))
+
+    class _StubImInfo:
+        def __init__(self):
+            self.no_t = False
+            self.no_z = False
+            self.shape = (3, 50, 100, 100)
+            self.axes = "TZYX"
+            self.dim_res = {"T": 1.0, "Z": 0.5, "Y": 0.1, "X": 0.1}
+            self.im_path = str(im_path)
+            self.pipeline_paths = {"flow_vector_array": str(flow_path)}
+
+        def get_memmap(self, _path):
+            return np.zeros((3, 50, 100, 100), dtype=np.float32)
+
+    info = _StubImInfo()
+    coords = rng.uniform(0.0, 100.0, size=(n_coords, 3))
+
+    # Warm up.
+    interpolate_all_forward(coords.copy(), 0, 2, info)
+
+    def _one_call() -> None:
+        interpolate_all_forward(coords.copy(), 0, 2, info)
+
+    elapsed = _time_call(_one_call, iters=3)
+    with capsys.disabled():
+        print(
+            f"\n[perf] interpolate_all_forward N={n_coords:4d} 3D (3 frames) "
+            f"median over 3: {elapsed * 1000:7.2f} ms"
+        )

--- a/wiki/decisions/0010-flow-nearby-coords-single-query.md
+++ b/wiki/decisions/0010-flow-nearby-coords-single-query.md
@@ -1,0 +1,145 @@
+---
+created: 2026-05-12
+modified: 2026-05-12
+---
+
+# `FlowInterpolator._get_nearby_coords` switches from double KDTree query to single `query_ball_point` + vectorized distance compute, fixes NaN-alignment bug
+
+`FlowInterpolator._get_nearby_coords` (in
+`nellie/tracking/flow_interpolation.py`) is the per-frame, per-query-coord
+neighbor lookup that drives every interpolation. The current implementation
+queries the same `cKDTree` twice — once via `query_ball_point` (just to count
+neighbors per coord), once via `query(k=max_k)` (the expensive worker-parallel
+traversal that returns distances) — then truncates `distances[pos][:k_all[pos]]`
+to keep only the within-radius slice. The second query is pure overhead;
+`query_ball_point` already has the in-radius indices, and per-coord distances
+are one `linalg.norm` away.
+
+The same loop also has a real correctness bug: the per-coord results are
+scattered back to the original-index slots via `for i in range(len(distances)):
+if i not in good_coords: continue`. That mapping is correct only when
+`good_coords == [0, ..., N-1]` (no NaN coords). With NaN coords present
+(routine after the first frame in `interpolate_all_forward`/`_backward`'s
+terminal NaN propagation), the `i`/`pos` indexing diverges and per-coord
+results land in the wrong slots.
+
+PRD #204 fixes both in one rewrite: single `query_ball_point` + per-coord
+`linalg.norm` for distances, and `for pos, i in enumerate(good_coords):` for
+correct alignment. Three coupled decisions in the design need to be pinned
+ahead of the rewrite in Slice 2 (#207): (1) the rewrite uses a single
+`query_ball_point` with manual distance compute over the existing two-query
+pattern, (2) the NaN-alignment fix is bundled into the same PR (cannot be
+cleanly separated from the same loop body), and (3) the test bar is
+bit-identical for the no-NaN case (same kernels, fewer redundant calls — no
+BLAS reordering risk) and corrected-and-aligned post-rewrite behavior for the
+NaN case (the pre-rewrite NaN behavior was a bug). Status: **Accepted
+(preventive)** — documents non-obvious decisions ahead of the rewrite in
+Slice 2 (#207).
+
+## Considered Options
+
+- **Single `query_ball_point` + vectorized distance compute (chosen).**
+  `cKDTree.query_ball_point` already returns the within-radius neighbor
+  indices per query coord. For each per-coord neighbor list (small —
+  bounded by spatial-radius density, typically a handful of points),
+  compute distances directly via
+  `np.linalg.norm(self.scaled_check_coords[idx_arr] - scaled_query[pos], axis=1)`.
+  No second tree traversal. The scaled `check_coords` array is materialized
+  once when the tree rebuilds (on `current_t` change) and cached as
+  `self.scaled_check_coords` for reuse. The loop becomes
+  `for pos, i in enumerate(good_coords):` — correct mapping by construction;
+  no O(N) `i not in good_coords` ndarray membership scan per iteration.
+- **Keep the double-query pattern (rejected).** The redundant
+  `query(k=max_k)` traversal is the entire problem PRD #204 exists to fix.
+  The Slice 1 perf microbenchmark (#206) measures the wall-clock cost
+  ahead of the rewrite.
+- **`cKDTree.query` with `distance_upper_bound=max_distance_um` and a
+  bounded `k` (rejected).** The `k` parameter is data-dependent (varies
+  per query coord based on local density); an upper-bound `k` either
+  truncates valid neighbors at high density or wastes work at low
+  density. `query_ball_point` is the natural primitive for "all neighbors
+  within radius" — using `query` here was over-engineering.
+- **`cKDTree.query_ball_tree(other_tree, max_distance_um)` (rejected).**
+  Dual-tree variant; useful for many-vs-many queries between two
+  pre-built trees. Here the query coords change per call (different
+  marker positions per `interpolate_coord` invocation) so building a
+  second tree per call would dwarf the savings.
+- **Preserve the buggy NaN behavior with an `xfail` test (rejected).**
+  The pre-rewrite NaN-coord case produces silently misassigned per-coord
+  results. No documented consumer (per `wiki/tracking/flow-interpolation.md`)
+  can be relying on misaligned output — the wiki invariant "Per-coordinate
+  output is either a finite vector or all-NaN — never a mixed coordinate"
+  silently hid the bug because (a) the misassigned coord may still pass
+  the all-finite-vs-all-NaN gate at the consumer level, and (b) tracks
+  dying mid-sequence is documented as expected behavior. Fix-and-pin is
+  the right move; the existing pin tests (#206) capture the corrected
+  behavior, not the buggy behavior.
+- **Separate the rewrite from the NaN-alignment fix into two PRs
+  (rejected).** Both changes touch the same loop body
+  (`for pos, i in ...` is the same line that the rewrite restructures).
+  Splitting forces an artificial intermediate state where one fix is
+  in but the other isn't; the test boundary (no-NaN bit-identical;
+  NaN corrected) is cleaner as a single PR.
+
+## Consequences
+
+- The Slice 1 (#206) characterization suite covers the no-NaN code path
+  end-to-end: empty input, single coord with no in-radius neighbors,
+  single coord with one in-radius neighbor at known distance, multi-coord
+  with all coords within radius of each other, scaling-applied distance
+  values, 2D and 3D parametrized. All deterministic by construction.
+- **Test bar: bit-identical for the no-NaN case.** The new implementation
+  calls `query_ball_point` (already called in the existing impl), then
+  computes distances via `np.linalg.norm` (a different kernel than the
+  existing `cKDTree.query(k=max_k)`-derived distances, but on the same
+  small per-coord neighbor list). Both paths use Euclidean (`p=2`) and
+  the same scaled coordinates; no BLAS reordering, no precision changes.
+  The Slice 2 (#207) equivalence test pins this bit-equality on a
+  synthetic no-NaN input.
+- **NaN-alignment behavior changes.** The NaN-coord positional-alignment
+  test added by Slice 2 (#207) pins the corrected post-rewrite behavior,
+  not the buggy pre-rewrite behavior. The wiki gotcha "Per-coordinate
+  output is either a finite vector or all-NaN — never a mixed coordinate"
+  remains correct (the new impl preserves the NaN-or-finite contract);
+  what changes is which slot a given per-coord result lands in when NaN
+  coords are interleaved.
+- **No cross-platform snapshot test.** `cKDTree` is from `scipy.spatial`;
+  while it is platform-stable in practice, Nellie does not assert
+  `cKDTree`-stability as an invariant. The Slice 1 synthetic suite +
+  the Slice 2 intra-process equivalence test on a deterministic
+  synthetic input are sufficient.
+- The `self.scaled_check_coords` cache adds one ndarray allocation per
+  tree-rebuild; it is the same data the tree was already built from
+  (multiplication by `self.scaling`). No incremental memory cost beyond
+  the now-explicit reference; previously the multiplication result was
+  consumed by `cKDTree(...)` and dropped.
+- Future maintainers should not switch back to the double-query pattern
+  without verifying that the per-coord `linalg.norm` distance compute
+  has become a bottleneck (it shouldn't — per-coord neighbor lists are
+  bounded by radius density, not by N).
+- Future maintainers tempted to "preserve the original NaN-handling for
+  consistency" should read this ADR — the original NaN handling was a
+  bug, and fix-and-pin is the explicit decision.
+- Future consumers reading `_get_nearby_coords` output should rely on
+  the post-rewrite slot-alignment contract: if `coords[i]` has any NaN
+  component, then `nearby_idxs_return[i]` and `distance_return[i]` are
+  empty; otherwise they reflect that coord's neighbors. No more silent
+  index shifting.
+
+## References
+
+- PRD #204 — single-query rewrite of `FlowInterpolator._get_nearby_coords`
+  + NaN-alignment fix
+- Slice 1 #206 — pin current no-NaN behavior with synthetic-test suite +
+  perf benchmark backfill + this ADR (no production code changes)
+- Slice 2 #207 — single-query rewrite + NaN-alignment fix + scaled-coords
+  cache + perf numbers
+- ADR 0008 — `_calculate_normalized_moments` matmul rewrite (precedent
+  for slice plan + ADR pattern + intra-platform equivalence test)
+- ADR 0009 — `_get_cost_matrix` per-feature streaming (precedent for
+  bundling a documented-but-deferred cleanup into a perf rewrite)
+- ADRs 0005 / 0006 / 0007 — preceding optimizations adopted similar
+  test-bar patterns
+- `wiki/tracking/flow-interpolation.md` — gotchas + invariants for
+  FlowInterpolator (terminal NaN propagation in
+  `interpolate_all_forward`/`_backward`)

--- a/wiki/decisions/index.md
+++ b/wiki/decisions/index.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-09
-modified: 2026-05-11
+modified: 2026-05-12
 ---
 
 
@@ -19,3 +19,4 @@ Decisions worth recording per [[CLAUDE|wiki conventions]] — hard to reverse, s
 - [[decisions/0007-mocap-log-peak-threading]] — `Markers._local_max_peak` per-sigma loop is threaded with `as_completed` (reduction is order-independent); chunked path stays serial; threading gated on `low_memory` (preventive, ahead of PRD #184 Slice 2 threading rewrite)
 - [[decisions/0008-hu-moment-matmul-rewrite]] — `HuMomentTracking._calculate_normalized_moments` switches from broadcast `(N, H, W, 4, 4)` to two-step batched matmul; `@` over `einsum` for backend-uniform BLAS dispatch; approx-equivalence (`rtol=1e-5`) test bar (preventive, ahead of PRD #191 Slice 2 rewrite)
 - [[decisions/0009-hu-cost-matrix-streaming]] — `HuMomentTracking._get_cost_matrix` switches from broadcast `(N, N, F)` float64 tensors to per-feature streaming float32; `_get_difference_matrix` + `_zscore_normalize` deleted; approx-equivalence (`rtol=1e-3`) test bar — looser than 0008 due to float64→float32 drop (preventive, ahead of PRD #196 Slice 2 rewrite)
+- [[decisions/0010-flow-nearby-coords-single-query]] — `FlowInterpolator._get_nearby_coords` switches from double `query_ball_point` + `query(k=max_k)` traversal to single `query_ball_point` + per-coord `linalg.norm`; bundled with NaN-alignment bug fix (`for pos, i in enumerate(good_coords)`); bit-identical for no-NaN, corrected for NaN (preventive, ahead of PRD #204 Slice 2 rewrite)


### PR DESCRIPTION
Slice 1 of PRD #204. Closes #206.

## Summary

- Bootstrap `tests/test_flow_interpolation.py` — 12 characterization tests on the no-NaN code path of `_get_nearby_coords`.
- Bootstrap `tests/test_flow_interpolation_perf.py` — 6 `benchmark`-marked microbenchmarks (`_get_nearby_coords` scaling at N=100/500/1000, `interpolate_coord` at N=1000, `interpolate_all_forward` at N=100/500).
- Add ADR 0010 documenting the single-query rewrite + bundled NaN-alignment fix decision ahead of Slice 2.

No production code changes.

## Pre-rewrite perf baselines (M2 Pro, single iter median over 5)

```
[perf] _get_nearby_coords N= 100 (cached tree) median over 5:    0.62 ms
[perf] _get_nearby_coords N= 500 (cached tree) median over 5:    1.33 ms
[perf] _get_nearby_coords N=1000 (cached tree) median over 5:    2.29 ms
[perf] interpolate_coord N=1000 3D (fresh cache) median over 3:  7.8 ms
[perf] interpolate_all_forward N= 100 3D (3 frames) median over 3: 0.98 ms
[perf] interpolate_all_forward N= 500 3D (3 frames) median over 3: 3.92 ms
```

## Test plan

- [x] `pytest tests/test_flow_interpolation.py -q` → 12 passed
- [x] `pytest tests/test_flow_interpolation_perf.py -m benchmark -q` → 6 passed (informational `[perf]` lines)

## Why bundled

Slice 1 ships test scaffolding + ADR; Slice 2 (#207) ships the rewrite + corrected NaN behavior. Same pattern as PRD #168, #173, #179, #184, #191, #196.

## What Slice 1 deliberately does NOT pin

The buggy NaN-coord positional alignment in `_get_nearby_coords` is not pinned — Slice 2 fixes-and-pins it. See PRD #204 § 2 and ADR 0010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)