### PR TITLE
perf(flow_interpolation): vectorize interpolate_all_forward / _backward per-coord loops (Slice 2 of #205)

### DIFF
--- a/nellie/tracking/flow_interpolation.py
+++ b/nellie/tracking/flow_interpolation.py
@@ -338,6 +338,97 @@ class FlowInterpolator:
         self._allocate_memory()
 
 
+def _interpolate_all_directional(
+    coords, start_t, end_t, im_info, min_track_num, max_distance_um, *, forward
+):
+    """Shared driver for ``interpolate_all_forward`` / ``_backward``.
+
+    Parameters mirror the public functions; ``forward`` controls the
+    direction of traversal and the sign of the per-frame coord update.
+
+    Per-frame work:
+      1. ``flow_interpx.interpolate_coord(coords, t)`` returns per-coord
+         flow vectors (NaN row when no neighbor was found).
+      2. NaN-mask: ``valid_mask = ~np.isnan(final_vector).any(axis=1)``.
+      3. Pre-update coords for valid rows are captured (used only for the
+         init row at ``t_idx == 0``).
+      4. In-place update for valid rows (``+=`` for forward, ``-=`` for
+         backward); invalid rows clobbered with NaN (terminal NaN
+         propagation per the wiki contract).
+      5. Per-frame block built as one ndarray; at ``t_idx == 0`` the
+         block has shape ``(2 * n_valid, n_dim + 2)`` with init/post
+         rows interleaved per valid coord (``block[0::2] = init_rows``,
+         ``block[1::2] = post_rows``) — preserves the bit-identical
+         per-coord row ordering of the pre-vectorize implementation.
+    """
+    flow_interpx = FlowInterpolator(im_info, forward=forward, max_distance_um=max_distance_um)
+    n_coords = len(coords)
+    base_ids = np.arange(n_coords, dtype=np.float64) + min_track_num
+    track_blocks: list[np.ndarray] = []
+    frame_num_blocks: list[np.ndarray] = []
+    if forward:
+        frame_range = np.arange(start_t, end_t)
+    else:
+        frame_range = np.array(list(np.arange(end_t, start_t + 1))[::-1])
+    if len(frame_range) == 0:
+        return [], {'frame_num': []}
+    initial_frame = float(frame_range[0])
+    for t_idx, t in enumerate(frame_range):
+        final_vector = flow_interpx.interpolate_coord(coords, t)
+        if final_vector is None or len(final_vector) == 0:
+            continue
+        valid_mask = ~np.isnan(final_vector).any(axis=1)
+        n_valid = int(valid_mask.sum())
+        if n_valid == 0:
+            # Even with no valid coords, the original loop walks every
+            # coord and marks invalids as NaN — preserve that here.
+            coords[~valid_mask] = np.nan
+            continue
+        # `coords[valid_mask]` is advanced indexing → returns a copy that
+        # is unaffected by the in-place update below.
+        valid_coords_pre = coords[valid_mask]
+        valid_ids = base_ids[valid_mask]
+        if forward:
+            coords[valid_mask] += final_vector[valid_mask]
+        else:
+            coords[valid_mask] -= final_vector[valid_mask]
+        coords[~valid_mask] = np.nan
+        valid_coords_post = coords[valid_mask]
+        post_frame = float(t + 1) if forward else float(t - 1)
+        n_dim = valid_coords_pre.shape[1]
+        if t_idx == 0:
+            # Interleave init + post rows per valid coord:
+            # [init_0, post_0, init_1, post_1, ...].
+            block = np.empty((2 * n_valid, n_dim + 2))
+            block[0::2, 0] = valid_ids
+            block[0::2, 1] = initial_frame
+            block[0::2, 2:] = valid_coords_pre
+            block[1::2, 0] = valid_ids
+            block[1::2, 1] = post_frame
+            block[1::2, 2:] = valid_coords_post
+            frames_for_block = np.empty(2 * n_valid)
+            frames_for_block[0::2] = initial_frame
+            frames_for_block[1::2] = post_frame
+        else:
+            block = np.empty((n_valid, n_dim + 2))
+            block[:, 0] = valid_ids
+            block[:, 1] = post_frame
+            block[:, 2:] = valid_coords_post
+            frames_for_block = np.full(n_valid, post_frame)
+        track_blocks.append(block)
+        frame_num_blocks.append(frames_for_block)
+
+    if track_blocks:
+        tracks = np.concatenate(track_blocks, axis=0).tolist()
+    else:
+        tracks = []
+    if frame_num_blocks:
+        frame_num_list = np.concatenate(frame_num_blocks).tolist()
+    else:
+        frame_num_list = []
+    return tracks, {'frame_num': frame_num_list}
+
+
 def interpolate_all_forward(coords, start_t, end_t, im_info, min_track_num=0, max_distance_um=0.5):
     """
     Interpolates coordinates forward in time across multiple timepoints using flow vectors.
@@ -362,36 +453,9 @@ def interpolate_all_forward(coords, start_t, end_t, im_info, min_track_num=0, ma
     tuple
         List of tracks and associated track properties.
     """
-    flow_interpx = FlowInterpolator(im_info, forward=True, max_distance_um=max_distance_um)
-    tracks = []
-    track_properties = {'frame_num': []}
-    frame_range = np.arange(start_t, end_t)
-    for t in frame_range:
-        final_vector = flow_interpx.interpolate_coord(coords, t)
-        if final_vector is None or len(final_vector) == 0:
-            continue
-        for coord_num, coord in enumerate(coords):
-            if np.all(np.isnan(final_vector[coord_num])):
-                coords[coord_num] = np.nan
-                continue
-            if t == frame_range[0]:
-                if im_info.no_z:
-                    tracks.append([coord_num + min_track_num, frame_range[0], coord[0], coord[1]])
-                else:
-                    tracks.append([coord_num + min_track_num, frame_range[0], coord[0], coord[1], coord[2]])
-                track_properties['frame_num'].append(frame_range[0])
-
-            track_properties['frame_num'].append(t + 1)
-            if im_info.no_z:
-                coords[coord_num] = np.array([coord[0] + final_vector[coord_num][0],
-                                              coord[1] + final_vector[coord_num][1]])
-                tracks.append([coord_num + min_track_num, t + 1, coord[0], coord[1]])
-            else:
-                coords[coord_num] = np.array([coord[0] + final_vector[coord_num][0],
-                                              coord[1] + final_vector[coord_num][1],
-                                              coord[2] + final_vector[coord_num][2]])
-                tracks.append([coord_num + min_track_num, t + 1, coord[0], coord[1], coord[2]])
-    return tracks, track_properties
+    return _interpolate_all_directional(
+        coords, start_t, end_t, im_info, min_track_num, max_distance_um, forward=True,
+    )
 
 
 def interpolate_all_backward(coords, start_t, end_t, im_info, min_track_num=0, max_distance_um=0.5):
@@ -418,36 +482,9 @@ def interpolate_all_backward(coords, start_t, end_t, im_info, min_track_num=0, m
     tuple
         List of tracks and associated track properties.
     """
-    flow_interpx = FlowInterpolator(im_info, forward=False, max_distance_um=max_distance_um)
-    tracks = []
-    track_properties = {'frame_num': []}
-    frame_range = list(np.arange(end_t, start_t + 1))[::-1]
-    for t in frame_range:
-        final_vector = flow_interpx.interpolate_coord(coords, t)
-        if final_vector is None or len(final_vector) == 0:
-            continue
-        for coord_num, coord in enumerate(coords):
-            # if final_vector[coord_num] is all nan, skip
-            if np.all(np.isnan(final_vector[coord_num])):
-                coords[coord_num] = np.nan
-                continue
-            if t == frame_range[0]:
-                if im_info.no_z:
-                    tracks.append([coord_num + min_track_num, frame_range[0], coord[0], coord[1]])
-                else:
-                    tracks.append([coord_num + min_track_num, frame_range[0], coord[0], coord[1], coord[2]])
-                track_properties['frame_num'].append(frame_range[0])
-            if im_info.no_z:
-                coords[coord_num] = np.array([coord[0] - final_vector[coord_num][0],
-                                              coord[1] - final_vector[coord_num][1]])
-                tracks.append([coord_num + min_track_num, t - 1, coord[0], coord[1]])
-            else:
-                coords[coord_num] = np.array([coord[0] - final_vector[coord_num][0],
-                                              coord[1] - final_vector[coord_num][1],
-                                              coord[2] - final_vector[coord_num][2]])
-                tracks.append([coord_num + min_track_num, t - 1, coord[0], coord[1], coord[2]])
-            track_properties['frame_num'].append(t - 1)
-    return tracks, track_properties
+    return _interpolate_all_directional(
+        coords, start_t, end_t, im_info, min_track_num, max_distance_um, forward=False,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_flow_interpolation.py
+++ b/tests/test_flow_interpolation.py
@@ -758,6 +758,125 @@ def test_interpolate_all_forward_id_uses_min_track_num_offset(tmp_path) -> None:
     assert track_ids == [1000, 1001], f"Expected ids [1000, 1001], got {track_ids}"
 
 
+# -------------------------------------------------------------------------
+# Slice 2 (#211) post-vectorize equivalence test
+# -------------------------------------------------------------------------
+
+
+def _interpolate_all_forward_reference(
+    coords, start_t, end_t, im_info, min_track_num=0, max_distance_um=0.5
+):
+    """Inline reference implementation of pre-Slice-2 ``interpolate_all_forward``.
+
+    Verbatim copy of the per-coord Python loop from before PRD #205 /
+    Slice 2 (#211). Used only to pin the bit-identical equivalence
+    claim — the production code is the vectorized version. If a future
+    maintainer changes the production behavior, both this reference
+    AND the equivalence test below need to update consciously.
+    """
+    from nellie.tracking.flow_interpolation import FlowInterpolator
+
+    flow_interpx = FlowInterpolator(im_info, forward=True, max_distance_um=max_distance_um)
+    tracks: list = []
+    track_properties: dict = {'frame_num': []}
+    frame_range = np.arange(start_t, end_t)
+    for t in frame_range:
+        final_vector = flow_interpx.interpolate_coord(coords, t)
+        if final_vector is None or len(final_vector) == 0:
+            continue
+        for coord_num, coord in enumerate(coords):
+            if np.all(np.isnan(final_vector[coord_num])):
+                coords[coord_num] = np.nan
+                continue
+            if t == frame_range[0]:
+                if im_info.no_z:
+                    tracks.append([coord_num + min_track_num, frame_range[0], coord[0], coord[1]])
+                else:
+                    tracks.append(
+                        [coord_num + min_track_num, frame_range[0], coord[0], coord[1], coord[2]]
+                    )
+                track_properties['frame_num'].append(frame_range[0])
+            track_properties['frame_num'].append(t + 1)
+            if im_info.no_z:
+                coords[coord_num] = np.array(
+                    [coord[0] + final_vector[coord_num][0], coord[1] + final_vector[coord_num][1]]
+                )
+                tracks.append([coord_num + min_track_num, t + 1, coord[0], coord[1]])
+            else:
+                coords[coord_num] = np.array([
+                    coord[0] + final_vector[coord_num][0],
+                    coord[1] + final_vector[coord_num][1],
+                    coord[2] + final_vector[coord_num][2],
+                ])
+                tracks.append(
+                    [coord_num + min_track_num, t + 1, coord[0], coord[1], coord[2]]
+                )
+    return tracks, track_properties
+
+
+def test_interpolate_all_forward_post_rewrite_equivalence_to_reference(tmp_path) -> None:
+    """Post-rewrite output value-equivalent to the inline reference impl.
+
+    Bit-identical at the float-value level: vectorized vector-add and
+    column_stack do the exact same elementwise float arithmetic as
+    the per-coord scalar add. The TYPE of the id/frame columns
+    changes (pre-rewrite: int/np.int64 mixed with float coords;
+    post-rewrite: all float64 from `np.column_stack` promotion +
+    `.tolist()`) — value comparison via cast-to-float is the
+    appropriate equivalence bar (consumers only rely on numerical
+    values, not exact types — see e.g. ``LabelTracks`` consumer at
+    ``all_tracks_for_label.py:125`` which calls
+    ``np.argsort([track[0] for track in tracks_bw])``).
+    """
+    from nellie.tracking.flow_interpolation import interpolate_all_forward
+
+    rng = np.random.default_rng(2026)
+    flow_array = _make_synthetic_flow_3d(rng, n_markers=300, frames=4)
+    info = _make_stub_iminfo(tmp_path, flow_array, no_z=False)
+
+    coords_for_ref = rng.uniform(0.0, 100.0, size=(15, 3))
+    coords_for_new = coords_for_ref.copy()
+
+    tracks_ref, props_ref = _interpolate_all_forward_reference(
+        coords_for_ref, 0, 4, info, max_distance_um=5.0,
+    )
+    tracks_new, props_new = interpolate_all_forward(
+        coords_for_new, 0, 4, info, max_distance_um=5.0,
+    )
+
+    # Same row count.
+    assert len(tracks_new) == len(tracks_ref), (
+        f"Row count diverges: new={len(tracks_new)}, ref={len(tracks_ref)}"
+    )
+    # Same frame_num count.
+    assert len(props_new["frame_num"]) == len(props_ref["frame_num"])
+
+    # Value-equivalence on the row contents (cast to float64 ndarray;
+    # the row arrangement should match per the bit-identical interleave
+    # invariant per Slice 2's interleave block).
+    np.testing.assert_allclose(
+        np.asarray(tracks_new, dtype=np.float64),
+        np.asarray(tracks_ref, dtype=np.float64),
+        rtol=0.0,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        np.asarray(props_new["frame_num"], dtype=np.float64),
+        np.asarray(props_ref["frame_num"], dtype=np.float64),
+        rtol=0.0,
+        atol=0.0,
+    )
+    # Coords driver-state equivalence: after the run, both `coords`
+    # arrays should match (same in-place updates, same NaN propagation).
+    np.testing.assert_allclose(
+        coords_for_new,
+        coords_for_ref,
+        rtol=0.0,
+        atol=0.0,
+        equal_nan=True,
+    )
+
+
 def test_interpolate_all_forward_2d_emits_4_column_rows(tmp_path) -> None:
     """2D path emits ``[id, frame, y, x]`` rows (no z column).
 


### PR DESCRIPTION
Slice 2 of PRD #205. Closes #211.

## Summary

- Replace per-coord Python loop in `interpolate_all_forward` / `_backward` with vectorized blocks: NaN-mask, in-place vector-add (forward) / vector-subtract (backward), batched per-frame row block construction, terminal NaN propagation.
- Preserve the bit-identical per-coord interleaved init/post row arrangement at `t == frame_range[0]` via `block[0::2] = init; block[1::2] = post` stride assignment.
- Both forward/backward delegate to a shared `_interpolate_all_directional` helper — collapses the two near-identical 70-line loops into one body parameterized by direction.

## Wall-clock wins (M2 Pro CPU, 3 frames synthetic, median over 3)

|                                  | Pre   | Post  | Speedup |
|----------------------------------|-------|-------|---------|
| `interpolate_all_forward` N=100  | 1.39 ms | 1.28 ms | -8% |
| `interpolate_all_forward` N=500  | 3.70 ms | 2.75 ms | -26% |

Driver-loop savings scale with N — N=100 is dominated by the FlowInterpolator constructor + tree build (independent of N). PR B's target was the N-dependent per-coord work; that cost is what shrinks at scale.

## Type-side note

Pre-rewrite `tracks` were `[int(id), int(frame), float(z), ...]` per row (Python list with mixed types from `tracks.append([coord_num + min_track_num, t + 1, ...])`). Post-rewrite they are `[float(id), float(frame), float(z), ...]` from `np.column_stack(...).tolist()` promoting all to float64. All known consumers (`LabelTracks`, `nellie/tracking/all_tracks_for_label.py:125`) treat the id/frame columns numerically (`int(track[0])` / `np.argsort([track[0] ...])`), so the type change is non-breaking.

## Tests

- New `test_interpolate_all_forward_post_rewrite_equivalence_to_reference` — bit-identical at the value level (cast to float64 ndarray; `rtol=0.0, atol=0.0`) against an inline copy of the pre-vectorize reference impl. Both `tracks` and `track_properties['frame_num']` values match; the post-run `coords` state matches.
- 7 Slice 1 (#210 / #212) characterization tests — all pass.
- 33 `test_voxel_reassignment.py` consumer tests pass.
- 40 `test_hierarchical.py` consumer tests pass.
- 6 `test_flow_interpolation_perf.py` benchmarks pass with the wall-clock wins above.

## Test plan

- [x] `pytest tests/test_flow_interpolation.py -q` → 24 passed
- [x] `pytest tests/test_flow_interpolation_perf.py -m benchmark -q` → 6 passed
- [x] `pytest tests/test_voxel_reassignment.py tests/test_hierarchical.py -q` → 73 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)