### PR TITLE
perf(flow_interpolation): bundled cleanups — pre-index by t + dead code + docstring + __main__ (#214)

### DIFF
--- a/nellie/tracking/flow_interpolation.py
+++ b/nellie/tracking/flow_interpolation.py
@@ -1,8 +1,8 @@
 """
 Flow vector interpolation for temporal tracking in microscopy images.
 
-This module provides interpolation of optical flow vectors between timepoints with
-optimizations for large datasets and optional GPU acceleration.
+This module provides interpolation of optical flow vectors between timepoints
+via distance-weighted KDTree lookup over a precomputed `flow_vector_array`.
 """
 import numpy as np
 from scipy.spatial import cKDTree
@@ -91,8 +91,7 @@ class FlowInterpolator:
         else:
             self.scaling = (im_info.dim_res['Z'], im_info.dim_res['Y'], im_info.dim_res['X'])
 
-        self.max_distance_um = max_distance_um * im_info.dim_res['T']
-        self.max_distance_um = np.max(np.array([self.max_distance_um, 0.5]))
+        self.max_distance_um = max(max_distance_um * im_info.dim_res['T'], 0.5)
 
         self.forward = forward
 
@@ -123,6 +122,22 @@ class FlowInterpolator:
 
         flow_vector_array_path = self.im_info.pipeline_paths['flow_vector_array']
         self.flow_vector_array = np.load(flow_vector_array_path)
+        # Pre-bucket the flow_vector_array by t so per-frame `interpolate_coord`
+        # lookups are O(1) dict reads instead of O(total_markers) `np.where`
+        # scans. The forward path indexes by t directly; the backward path
+        # indexes by t-1 (looks up markers from the previous frame). Storing
+        # the index arrays (not the row slices) keeps memory minimal — the
+        # full `flow_vector_array` is the source of truth.
+        if self.flow_vector_array.size:
+            t_col = self.flow_vector_array[:, 0]
+            unique_t, inverse = np.unique(t_col, return_inverse=True)
+            order = np.argsort(inverse, kind='stable')
+            sorted_inverse = inverse[order]
+            split_at = np.searchsorted(sorted_inverse, np.arange(1, len(unique_t)))
+            grouped = np.split(order, split_at)
+            self._t_to_rows = {int(t_val): rows for t_val, rows in zip(unique_t, grouped)}
+        else:
+            self._t_to_rows = {}
 
     def _get_t(self):
         """
@@ -299,17 +314,23 @@ class FlowInterpolator:
         # For forward, simply find nearby LMPs, interpolate based on distance-weighted vectors
         # For backward, get coords from t-1 + vector, then find nearby coords from that, and interpolate based on distance-weighted vectors
         if self.current_t != t:
+            # O(1) dict lookup over the pre-bucketed `_t_to_rows` index built
+            # in `_allocate_memory` — replaces the per-frame
+            # `np.where(self.flow_vector_array[:, 0] == t)` scan.
+            lookup_t = t if self.forward else t - 1
+            row_indices = self._t_to_rows.get(int(lookup_t))
+            if row_indices is None or len(row_indices) == 0:
+                self.check_rows = self.flow_vector_array[:0]
+            else:
+                self.check_rows = self.flow_vector_array[row_indices, :]
             if self.forward:
-                # check_rows will be all rows where the self.flow_vector_array's 0th column is equal to t
-                self.check_rows = self.flow_vector_array[np.where(self.flow_vector_array[:, 0] == t)[0], :]
                 if self.im_info.no_z:
                     self.check_coords = self.check_rows[:, 1:3]
                 else:
                     self.check_coords = self.check_rows[:, 1:4]
             else:
-                # check_rows will be all rows where the self.flow_vector_array's 0th columns is equal to t-1
-                self.check_rows = self.flow_vector_array[np.where(self.flow_vector_array[:, 0] == t - 1)[0], :]
-                # check coords will be the coords + vector
+                # Backward: check coords are pre-coord + forward vector
+                # (the marker's destination at t).
                 if self.im_info.no_z:
                     self.check_coords = self.check_rows[:, 1:3] + self.check_rows[:, 3:5]
                 else:
@@ -317,9 +338,6 @@ class FlowInterpolator:
 
         nearby_idxs, distances_all = self._get_nearby_coords(t, coords)
         self.current_t = t
-
-        if nearby_idxs is None:
-            return None
 
         weights_all = self._get_vector_weights(nearby_idxs, distances_all)
         final_vectors = self._get_final_vector(nearby_idxs, weights_all)
@@ -486,29 +504,3 @@ def interpolate_all_backward(coords, start_t, end_t, im_info, min_track_num=0, m
         coords, start_t, end_t, im_info, min_track_num, max_distance_um, forward=False,
     )
 
-
-if __name__ == "__main__":
-    im_path = r"D:\test_files\nelly_smorgasbord\deskewed-iono_pre.ome.tif"
-    im_info = ImInfo(im_path)
-    label_memmap = self.im_info.get_memmap(im_info.pipeline_paths['im_instance_label'])
-    im_memmap = self.im_info.get_memmap(im_info.im_path)
-
-    import napari
-    viewer = napari.Viewer()
-    start_frame = 0
-    # going backwards
-    coords = np.argwhere(label_memmap[0] > 0).astype(float)
-    # get 100 random coords
-    # np.random.seed(0)
-    # coords = coords[np.random.choice(coords.shape[0], 10000, replace=False), :].astype(float)
-    # x in range 450-650
-    # y in range 600-750
-    new_coords = []
-    for coord in coords:
-        if 450 < coord[-1] < 650 and 600 < coord[-2] < 750:
-            new_coords.append(coord)
-    coords = np.array(new_coords[::1])
-    tracks, track_properties = interpolate_all_forward(coords, start_frame, 3, im_info)
-
-    viewer.add_image(im_memmap)
-    viewer.add_tracks(tracks, properties=track_properties, name='tracks')

--- a/tests/test_flow_interpolation.py
+++ b/tests/test_flow_interpolation.py
@@ -898,6 +898,124 @@ def test_interpolate_all_forward_2d_emits_4_column_rows(tmp_path) -> None:
         assert len(row) == 4, f"Expected (id, frame, y, x) row in 2D, got {row}"
 
 
+# -------------------------------------------------------------------------
+# PR C cleanups (#214) regression tests
+# -------------------------------------------------------------------------
+
+
+def test_allocate_memory_pre_buckets_flow_array_by_t(tmp_path) -> None:
+    """`_allocate_memory` builds `_t_to_rows` index over the flow_vector_array.
+
+    Pin the pre-bucketing contract introduced by issue #214: per-frame
+    `interpolate_coord` lookups should be O(1) dict reads instead of
+    O(total_markers) `np.where` scans. The dict must contain one entry
+    per unique `t` value; each entry's row indices must select the
+    same rows as the equivalent `np.where(flow[:, 0] == t)` scan.
+    """
+    from nellie.tracking.flow_interpolation import FlowInterpolator
+
+    rng = np.random.default_rng(214)
+    n_per_t = 100
+    blocks = []
+    for t in range(5):
+        blocks.append(np.column_stack([
+            np.full(n_per_t, t, dtype=np.float64),
+            rng.uniform(0.0, 100.0, size=n_per_t),
+            rng.uniform(0.0, 100.0, size=n_per_t),
+            rng.uniform(0.0, 100.0, size=n_per_t),
+            rng.uniform(-1.0, 1.0, size=n_per_t),
+            rng.uniform(-1.0, 1.0, size=n_per_t),
+            rng.uniform(-1.0, 1.0, size=n_per_t),
+            rng.uniform(0.0, 0.5, size=n_per_t),
+        ]))
+    flow_array = np.concatenate(blocks, axis=0)
+    info = _make_stub_iminfo(tmp_path, flow_array, no_z=False)
+
+    f = FlowInterpolator(info, forward=True, max_distance_um=1.0)
+
+    # Each unique t in [0, 4] should map to a distinct row-index array.
+    assert hasattr(f, "_t_to_rows"), "Cleanup must add _t_to_rows index"
+    assert set(f._t_to_rows.keys()) == set(range(5))
+
+    # Per-t row indices select the same rows as np.where would.
+    for t in range(5):
+        expected = np.where(flow_array[:, 0] == t)[0]
+        actual = f._t_to_rows[t]
+        np.testing.assert_array_equal(np.sort(actual), np.sort(expected))
+
+
+def test_interpolate_coord_uses_t_bucketed_lookup_post_cleanup(tmp_path) -> None:
+    """`interpolate_coord` for forward and backward returns the same `check_rows` as the pre-cleanup scan.
+
+    Pin behavior-preservation of the t-bucketing change: the rows
+    selected per frame should be identical to what the pre-cleanup
+    `np.where(flow_vector_array[:, 0] == t)` scan returned.
+    """
+    from nellie.tracking.flow_interpolation import FlowInterpolator
+
+    rng = np.random.default_rng(2140)
+    n_per_t = 50
+    blocks = []
+    for t in range(3):
+        blocks.append(np.column_stack([
+            np.full(n_per_t, t, dtype=np.float64),
+            rng.uniform(0.0, 100.0, size=n_per_t),
+            rng.uniform(0.0, 100.0, size=n_per_t),
+            rng.uniform(0.0, 100.0, size=n_per_t),
+            rng.uniform(-1.0, 1.0, size=n_per_t),
+            rng.uniform(-1.0, 1.0, size=n_per_t),
+            rng.uniform(-1.0, 1.0, size=n_per_t),
+            rng.uniform(0.0, 0.5, size=n_per_t),
+        ]))
+    flow_array = np.concatenate(blocks, axis=0)
+    info = _make_stub_iminfo(tmp_path, flow_array, no_z=False)
+
+    coords = rng.uniform(0.0, 100.0, size=(10, 3))
+
+    # Forward at t=2.
+    f_fw = FlowInterpolator(info, forward=True, max_distance_um=2.0)
+    f_fw.interpolate_coord(coords, t=2)
+    expected_fw_rows = flow_array[np.where(flow_array[:, 0] == 2)[0], :]
+    np.testing.assert_array_equal(f_fw.check_rows, expected_fw_rows)
+
+    # Backward at t=2 (looks up markers from t=1).
+    f_bw = FlowInterpolator(info, forward=False, max_distance_um=2.0)
+    f_bw.interpolate_coord(coords, t=2)
+    expected_bw_rows = flow_array[np.where(flow_array[:, 0] == 1)[0], :]
+    np.testing.assert_array_equal(f_bw.check_rows, expected_bw_rows)
+
+
+def test_max_distance_um_floor_unchanged_post_cleanup(tmp_path) -> None:
+    """`max_distance_um` floor at 0.5 preserved when caller passes < 0.5 / dt.
+
+    Pin the wiki-documented floor invariant: per
+    `wiki/tracking/flow-interpolation.md`, the constructor scales
+    `max_distance_um` by `dim_res['T']` and floors at 0.5. Pre-cleanup:
+    `np.max(np.array([um*dt, 0.5]))`. Post-cleanup: `max(um*dt, 0.5)`.
+    Equivalent for any reasonable input.
+    """
+    from nellie.tracking.flow_interpolation import FlowInterpolator
+
+    flow_array = np.array(
+        [[0.0, 50.0, 50.0, 50.0, 0.5, 0.5, 0.5, 0.0]], dtype=np.float64
+    )
+    # dim_res T=1.0, caller passes 0.1 → 0.1 * 1.0 = 0.1, below the 0.5 floor.
+    info = _make_stub_iminfo(
+        tmp_path, flow_array, no_z=False,
+        dim_res={"T": 1.0, "Z": 0.5, "Y": 0.1, "X": 0.1},
+    )
+    f = FlowInterpolator(info, max_distance_um=0.1)
+    assert f.max_distance_um == 0.5
+
+    # dim_res T=2.0, caller passes 0.4 → 0.4 * 2.0 = 0.8, above the 0.5 floor.
+    info2 = _make_stub_iminfo(
+        tmp_path, flow_array, no_z=False,
+        dim_res={"T": 2.0, "Z": 0.5, "Y": 0.1, "X": 0.1},
+    )
+    f2 = FlowInterpolator(info2, max_distance_um=0.4)
+    assert f2.max_distance_um == 0.8
+
+
 def test_get_nearby_coords_post_rewrite_distances_sorted_ascending() -> None:
     """Post-rewrite distances need not be sorted (pre-rewrite was via cKDTree.query).
 

--- a/tests/test_flow_interpolation_perf.py
+++ b/tests/test_flow_interpolation_perf.py
@@ -148,6 +148,18 @@ def _make_bare_flow_for_interpolate(
     f.check_coords = None
     f.current_tree = None
     f.max_distance_um = float(max_distance_um)
+    # Mirror `_allocate_memory`'s pre-bucketing — required by the
+    # post-cleanup `interpolate_coord` lookup (#214).
+    if f.flow_vector_array.size:
+        t_col = f.flow_vector_array[:, 0]
+        unique_t, inverse = np.unique(t_col, return_inverse=True)
+        order = np.argsort(inverse, kind='stable')
+        sorted_inverse = inverse[order]
+        split_at = np.searchsorted(sorted_inverse, np.arange(1, len(unique_t)))
+        grouped = np.split(order, split_at)
+        f._t_to_rows = {int(t_val): rows for t_val, rows in zip(unique_t, grouped)}
+    else:
+        f._t_to_rows = {}
 
     class _StubImInfo:
         pass

--- a/wiki/tracking/flow-interpolation.md
+++ b/wiki/tracking/flow-interpolation.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-06
-modified: 2026-05-07
+modified: 2026-05-12
 ---
 
 # Flow interpolation
@@ -23,7 +23,7 @@ Hu tracking only matches markers; voxel reassignment and label trajectories need
 - **Returns NaN rows for queries with no neighbors within `max_distance_um`.** Callers must handle NaN explicitly.
 - **NaN is terminal in `interpolate_all_forward/backward`.** Once a coord's interpolated vector is all-NaN, the driver overwrites the coord with NaN and never revives it on later frames — tracks die silently mid-sequence rather than skipping a gap.
 - **`max_distance_um` is scaled by `dim_res['T']` at construction**, with a 0.5 μm floor. The constructor argument is effectively μm-per-frame, so the search radius grows with frame interval. Passing `0.5` does not give a 0.5 μm radius unless `dt == 1`.
-- **The `__main__` block has a `self.im_info` typo bug** (uses `self` outside a class). Don't run the script standalone.
+- **`flow_vector_array` is pre-bucketed by `t` at `_allocate_memory`**: `self._t_to_rows = {t: row_indices}` is built once. Per-frame `interpolate_coord` lookups are O(1) dict reads; the pre-cleanup O(total_markers) `np.where(flow_vector_array[:, 0] == t)` scan is gone (PR #214).
 
 ## Invariants
 


### PR DESCRIPTION
Closes #214.

## Summary

5 tactical cleanups in `nellie/tracking/flow_interpolation.py`:

1. **Pre-index `flow_vector_array` by t at `_allocate_memory`** — `self._t_to_rows = {int(t): row_indices}` built once via a `np.unique` + `np.argsort` + `np.split` pass. Per-frame `interpolate_coord` lookups become O(1) dict reads instead of O(total_markers) `np.where` scans.
2. **Drop dead `if nearby_idxs is None: return None`** in `interpolate_coord` — `_get_nearby_coords` returns `([], [])` (or per-coord empty slots), never `None`.
3. **Replace `np.max(np.array([self.max_distance_um, 0.5]))` → `max(self.max_distance_um, 0.5)`** — simpler, no allocation; `cKDTree.query_ball_point(r=...)` accepts both numpy scalars and Python floats. 0.5 μm floor invariant preserved.
4. **Remove stale "optional GPU acceleration" claim** from module docstring — there's no GPU code here.
5. **Delete broken `__main__` block** that used `self.im_info` outside a class. Wiki gotcha at `wiki/tracking/flow-interpolation.md:26` previously said "don't run standalone"; now removed since the broken block is gone.

## Tests

3 new regression tests:
- `test_allocate_memory_pre_buckets_flow_array_by_t` — pins the new `_t_to_rows` index.
- `test_interpolate_coord_uses_t_bucketed_lookup_post_cleanup` — pins forward+backward `check_rows` equivalence.
- `test_max_distance_um_floor_unchanged_post_cleanup` — pins the 0.5 μm floor for both above- and below-floor inputs.

24 → 27 `test_flow_interpolation.py` tests pass; 33 `test_voxel_reassignment.py` + 40 `test_hierarchical.py` consumer tests pass; 6 perf benchmarks pass.

## Wiki

`wiki/tracking/flow-interpolation.md`:
- Removed `__main__` typo gotcha.
- Added t-bucketing gotcha (per-frame lookup is O(1) dict read).

## Test plan

- [x] `pytest tests/test_flow_interpolation.py -q` → 27 passed
- [x] `pytest tests/test_flow_interpolation_perf.py -m benchmark -q` → 6 passed
- [x] `pytest tests/test_voxel_reassignment.py tests/test_hierarchical.py -q` → 73 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)