### PR TITLE
tests(voxel_reassignment): pin _assign_unique_matches greedy semantics + ADR 0011 (Slice 1 of #222)

### DIFF
--- a/tests/test_voxel_reassignment.py
+++ b/tests/test_voxel_reassignment.py
@@ -1262,6 +1262,248 @@ def test_select_best_pairs_empty_input_returns_2tuple_post_fix(
     _release_voxel_reassigner(v)
 
 
+# -------------------------------------------------------------------------
+# PRD #222 Slice 1 — characterize current `_assign_unique_matches` Python
+# greedy semantics so Slice 2's round-based vectorized rewrite can be
+# verified for set-equivalence on a known suite of corner cases.
+#
+# These tests pin BEHAVIOR (which kept-row SET emerges from each
+# input), not IMPLEMENTATION ordering — the round-based rewrite returns
+# kept indices in input-row order while the pre-rewrite returns them in
+# distance-ascending order. Both are deterministic but distinct
+# orderings; the function's contract is set-of-pairs, not a sequence.
+# See ADR 0011.
+# -------------------------------------------------------------------------
+
+
+def _make_voxel_reassigner_for_assign_unique(
+    info_factory, spatial_shape: tuple[int, ...] = (32, 32, 32)
+) -> VoxelReassigner:
+    """Bare VoxelReassigner with `spatial_shape` set, suitable for direct
+    `_assign_unique_matches` calls without the full memmap allocation.
+    """
+    info = info_factory()
+    v = VoxelReassigner(info, VoxelReassignerConfig(device="cpu"), num_t=2)
+    v.spatial_shape = spatial_shape
+    return v
+
+
+def _kept_pair_set(prev_arr: np.ndarray, next_arr: np.ndarray) -> set:
+    """(prev, next) pair set for set-equality comparison."""
+    return {
+        (tuple(int(x) for x in p), tuple(int(x) for x in n))
+        for p, n in zip(prev_arr, next_arr)
+    }
+
+
+def test_assign_unique_matches_empty_input_returns_2tuple(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Empty input → 2-tuple of `(0, D)` int64 arrays.
+
+    The function's empty-input contract is documented in the wiki
+    gotcha (`_allocate_memory()` must run first or this raises). With
+    `spatial_shape` set but distances empty, we expect the early-return
+    path at lines 666-669: 2-tuple of `(0, D)` int64 arrays.
+    """
+    v = _make_voxel_reassigner_for_assign_unique(
+        make_voxel_reassign_imageinfo_3d
+    )
+
+    empty_prev = np.empty((0, 3), dtype=np.int64)
+    empty_next = np.empty((0, 3), dtype=np.int64)
+    empty_dist = np.empty((0,), dtype=np.float64)
+
+    result = v._assign_unique_matches(empty_prev, empty_next, empty_dist)
+    assert len(result) == 2
+    out_prev, out_next = result
+    assert out_prev.shape == (0, 3)
+    assert out_next.shape == (0, 3)
+    assert out_prev.dtype == np.int64
+    assert out_next.dtype == np.int64
+    _release_voxel_reassigner(v)
+
+
+def test_assign_unique_matches_single_match_kept_verbatim(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Single (prev, next) pair → kept verbatim."""
+    v = _make_voxel_reassigner_for_assign_unique(
+        make_voxel_reassign_imageinfo_3d
+    )
+
+    vox_prev = np.array([[1, 2, 3]], dtype=np.int64)
+    vox_next = np.array([[4, 5, 6]], dtype=np.int64)
+    distances = np.array([1.5], dtype=np.float64)
+
+    out_prev, out_next = v._assign_unique_matches(vox_prev, vox_next, distances)
+    np.testing.assert_array_equal(out_prev, vox_prev)
+    np.testing.assert_array_equal(out_next, vox_next)
+    _release_voxel_reassigner(v)
+
+
+def test_assign_unique_matches_no_contention_keeps_all(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Three pairs with disjoint prev_ids and disjoint next_ids → all kept."""
+    v = _make_voxel_reassigner_for_assign_unique(
+        make_voxel_reassign_imageinfo_3d
+    )
+
+    vox_prev = np.array(
+        [[1, 1, 1], [2, 2, 2], [3, 3, 3]], dtype=np.int64
+    )
+    vox_next = np.array(
+        [[10, 10, 10], [20, 20, 20], [30, 30, 30]], dtype=np.int64
+    )
+    distances = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+
+    out_prev, out_next = v._assign_unique_matches(vox_prev, vox_next, distances)
+    expected = _kept_pair_set(vox_prev, vox_next)
+    actual = _kept_pair_set(out_prev, out_next)
+    assert actual == expected, (
+        f"All 3 disjoint pairs should be kept; got {actual} (expected "
+        f"{expected})"
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_assign_unique_matches_prev_contention_keeps_lowest_distance(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Two pairs share prev_id; only the lowest-distance row is kept.
+
+    Pair A (prev P, next N1, d=1.0) competes with pair B (prev P,
+    next N2, d=2.0). Greedy keeps pair A (lower distance) and drops
+    pair B (P is used).
+    """
+    v = _make_voxel_reassigner_for_assign_unique(
+        make_voxel_reassign_imageinfo_3d
+    )
+
+    p = [5, 5, 5]
+    vox_prev = np.array([p, p], dtype=np.int64)
+    vox_next = np.array([[10, 10, 10], [20, 20, 20]], dtype=np.int64)
+    distances = np.array([1.0, 2.0], dtype=np.float64)
+
+    out_prev, out_next = v._assign_unique_matches(vox_prev, vox_next, distances)
+    expected = {(tuple(p), (10, 10, 10))}
+    actual = _kept_pair_set(out_prev, out_next)
+    assert actual == expected, (
+        f"Lower-distance pair (d=1.0) should be kept; got {actual}"
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_assign_unique_matches_next_contention_keeps_lowest_distance(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Two pairs share next_id; only the lowest-distance row is kept.
+
+    Pair A (prev P1, next N, d=1.0) competes with pair B (prev P2,
+    next N, d=2.0). Greedy keeps pair A and drops pair B (N is used).
+    """
+    v = _make_voxel_reassigner_for_assign_unique(
+        make_voxel_reassign_imageinfo_3d
+    )
+
+    n = [10, 10, 10]
+    vox_prev = np.array([[1, 1, 1], [2, 2, 2]], dtype=np.int64)
+    vox_next = np.array([n, n], dtype=np.int64)
+    distances = np.array([1.0, 2.0], dtype=np.float64)
+
+    out_prev, out_next = v._assign_unique_matches(vox_prev, vox_next, distances)
+    expected = {((1, 1, 1), tuple(n))}
+    actual = _kept_pair_set(out_prev, out_next)
+    assert actual == expected, (
+        f"Lower-distance pair (d=1.0) should be kept; got {actual}"
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_assign_unique_matches_chain_contention_multi_round(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Chain contention exercises multi-round convergence.
+
+    Rows: (P1,N1,d=1), (P1,N2,d=2), (P2,N2,d=3), (P2,N3,d=4),
+    (P3,N3,d=5). Greedy:
+      - Take (P1,N1): keep, used={P1, N1}
+      - (P1,N2): P1 used, skip
+      - (P2,N2): keep, used={P1, P2, N1, N2}
+      - (P2,N3): P2 used, skip
+      - (P3,N3): N3 NOT used → keep, used={P1, P2, P3, N1, N2, N3}
+    Expected kept set: {(P1,N1), (P2,N2), (P3,N3)}.
+
+    Round-based version would converge in 3 rounds:
+      - R1: keep (P1,N1) only — only row that's argmin for both prev
+        and next.
+      - R2: active = {(P2,N2), (P2,N3), (P3,N3)}; keep (P2,N2).
+      - R3: active = {(P3,N3)}; keep.
+    Same kept set.
+    """
+    v = _make_voxel_reassigner_for_assign_unique(
+        make_voxel_reassign_imageinfo_3d
+    )
+
+    P1, P2, P3 = (1, 1, 1), (2, 2, 2), (3, 3, 3)
+    N1, N2, N3 = (10, 10, 10), (20, 20, 20), (30, 30, 30)
+
+    vox_prev = np.array([P1, P1, P2, P2, P3], dtype=np.int64)
+    vox_next = np.array([N1, N2, N2, N3, N3], dtype=np.int64)
+    distances = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float64)
+
+    out_prev, out_next = v._assign_unique_matches(vox_prev, vox_next, distances)
+    expected = {(P1, N1), (P2, N2), (P3, N3)}
+    actual = _kept_pair_set(out_prev, out_next)
+    assert actual == expected, (
+        f"Chain contention should keep {expected}; got {actual}"
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_assign_unique_matches_tied_distances_pick_one(
+    make_voxel_reassign_imageinfo_3d,
+) -> None:
+    """Tied distances on contention: exactly one of the tied rows is kept.
+
+    Two rows share prev_id with identical distance. The greedy loop
+    iterates in `np.argsort(distances)` order (default 'quicksort',
+    stable enough on tied keys for argsort to fall back to insertion
+    sort behavior at small N). Both rows can't be kept (prev_id
+    conflict); exactly one survives. The choice between the two ties
+    is implementation-defined; both pre-rewrite (greedy by argsort
+    order) and post-rewrite (round-based by lexsort tie-break) would
+    pick deterministically but possibly differently.
+
+    The TEST asserts only the cardinality + uniqueness invariants:
+      - Exactly 1 pair kept.
+      - Kept pair is one of the two input pairs.
+      - prev_id of the kept pair is the shared prev_id.
+    """
+    v = _make_voxel_reassigner_for_assign_unique(
+        make_voxel_reassign_imageinfo_3d
+    )
+
+    p = [7, 7, 7]
+    vox_prev = np.array([p, p], dtype=np.int64)
+    vox_next = np.array([[15, 15, 15], [25, 25, 25]], dtype=np.int64)
+    distances = np.array([1.0, 1.0], dtype=np.float64)
+
+    out_prev, out_next = v._assign_unique_matches(vox_prev, vox_next, distances)
+    assert len(out_prev) == 1
+    actual = _kept_pair_set(out_prev, out_next)
+    expected_options = {
+        (tuple(p), (15, 15, 15)),
+        (tuple(p), (25, 25, 25)),
+    }
+    assert actual.issubset(expected_options) and len(actual) == 1, (
+        f"Tied-distance contention should keep exactly 1 of the two "
+        f"input pairs; got {actual} (options: {expected_options})"
+    )
+    _release_voxel_reassigner(v)
+
+
 def test_run_reassignment_3d_snapshot_post_rewrite_matches_pre_rewrite_reference(
     make_voxel_reassign_imageinfo_3d,
 ) -> None:

--- a/wiki/decisions/0011-voxel-assign-unique-matches-round-based.md
+++ b/wiki/decisions/0011-voxel-assign-unique-matches-round-based.md
@@ -1,0 +1,154 @@
+---
+created: 2026-05-11
+modified: 2026-05-11
+---
+
+# `VoxelReassigner._assign_unique_matches` switches from Python greedy loop to round-based vectorized intersection
+
+`VoxelReassigner._assign_unique_matches` (in
+`nellie/tracking/voxel_reassignment.py`) implements 1-to-1 voxel-pair
+selection by greedy descent on distance. The pre-rewrite implementation
+sorts matches by ascending distance, then iterates `range(len(order))`
+in Python, marking `used_prev[p_idx]` / `used_next[n_idx]` and skipping
+rows whose prev_id or next_id has already been claimed. PRD #153's perf
+test (`tests/test_voxel_reassignment_perf.py:159`) explicitly flags the
+Python loop as the strongest vectorization suspect in the entire
+VoxelReassigner stage.
+
+PRD #222 replaces the loop with a **round-based per-prev/per-next argmin
+intersection**. Per round: find the per-prev-id argmin-distance row and
+the per-next-id argmin-distance row (over still-active rows); a row is
+kept iff it is the argmin for BOTH its prev_id AND its next_id;
+deactivate kept rows + all rows whose prev or next id was claimed;
+repeat until no rows are kept. Two coupled decisions need to be pinned
+ahead of the rewrite in Slice 2 (#224): (1) the round-based intersection
+is the chosen vectorization (rather than a single first-occurrence-of-both
+heuristic, which is faster but **not** equivalent to sequential greedy),
+and (2) the test bar is **set-equality** on kept rows (rather than
+ordered-equality), because the round-based version returns kept indices
+in input-row order while the greedy returns them in distance-ascending
+order — both deterministic, both correct, but distinct orderings.
+
+A third decision worth pinning ahead of merge: this PR ships even though
+`_assign_unique_matches` is **not called by `_run_reassignment`** — the
+production driver uses `_select_best_pairs` (1-best per target via a
+single lexsort, no 1-to-1 uniqueness). The function is exposed for
+external callers and tests; PRD #153 pre-instrumented it as a hot-path
+suspect, so the rewrite pins the perf-test target and is correctness-
+preserving for any future caller that wants 1-to-1 unique matches with
+global greedy semantics. Status: **Accepted (preventive)** — documents
+non-obvious decisions ahead of the rewrite in Slice 2 (#224).
+
+## Equivalence sketch
+
+Sequential greedy (current): process rows in distance-ascending order,
+keep iff neither prev_id nor next_id has been claimed by an earlier row.
+
+Round-based (new): per round, keep all rows that are simultaneously the
+per-prev argmin and the per-next argmin over the active set; remove
+kept rows + rows touching their ids; repeat.
+
+Both produce the same kept SET because:
+
+- A row that is the smallest-distance row for both its prev_id and its
+  next_id (over all rows) is kept first by sequential greedy (no earlier
+  row touches either id) → kept in round 1 of round-based.
+- A row that has contention on either side waits in greedy until the
+  contender is resolved (kept or evicted) → kept in a later round of
+  round-based, after the contender has been processed.
+- Walked example: P1→N1 (d=1), P1→N2 (d=2), P2→N2 (d=3), P2→N3 (d=4),
+  P3→N3 (d=5).
+  - Greedy: keeps row 0 (P1,N1), skips row 1 (P1 used), keeps row 2
+    (P2,N2), skips row 3 (P2 used), keeps row 4 (P3,N3). Result:
+    {row 0, row 2, row 4}.
+  - Round-based:
+    - Round 1: per-prev argmin = {0, 2, 4}; per-next argmin = {0, 1, 3}.
+      Intersection = {0}. Kept = {row 0}; deactivate rows touching P1
+      or N1 → rows 0, 1.
+    - Round 2: active = {2, 3, 4}. Per-prev argmin (over active) =
+      {2, 4}; per-next argmin = {2, 3}. Intersection = {2}. Kept =
+      {row 2}; deactivate rows touching P2 or N2 → rows 2, 3.
+    - Round 3: active = {4}. Per-prev argmin = {4}; per-next argmin =
+      {4}. Intersection = {4}. Kept = {row 4}.
+  - Result: {row 0, row 2, row 4}. ✓ Matches greedy.
+
+## Considered Options
+
+- **Round-based per-prev/per-next argmin intersection (chosen).** Per
+  round, find the per-id argmin via lexsort + first-of-group on `(id,
+  distance)`; a row is kept iff it is the argmin for both its prev_id
+  and its next_id. Deactivate kept rows + all rows whose prev_id or
+  next_id was claimed. Repeat. Provably equivalent to sequential greedy
+  (sketch above). Pure NumPy; no new dependencies.
+- **First-occurrence-of-both heuristic (rejected).** Sort by distance
+  ascending; precompute `prev_first_idx[p]` = index of first occurrence
+  of prev_id `p`, same for next; keep row `i` iff `i ==
+  prev_first_idx[prev[i]] and i == next_first_idx[next[i]]`. **Not
+  equivalent to sequential greedy.** Counter-example: rows
+  (P1,N1,d=1), (P1,N2,d=2), (P2,N1,d=3), (P2,N2,d=4). Greedy keeps
+  (P1,N1) and (P2,N2). First-of-both keeps only (P1,N1) — for (P2,N2)
+  the prev-first-idx for P2 is 2 (row P2,N1), but row 2 was rejected
+  (N1 used), and the heuristic doesn't track rejections. Cannot be
+  used; ruled out by walked counter-example.
+- **Cython / C extension (rejected).** Adds build-time complexity for
+  a non-production hot path. The Python loop today takes ~3 ms at
+  N=10k per the perf test — fast enough that the round-based vectorized
+  version (also a few ms with `lexsort` overhead) is the appropriate
+  scope. Not worth a build-system dependency.
+- **`numba.njit` JIT compile of the loop (rejected).** Same scope
+  argument: heavy dependency for a non-production code path. Numba
+  isn't a current Nellie dependency and adding it for one function
+  is over-engineering.
+- **Defer entirely (rejected).** PRD #153's perf test pre-instruments
+  this function as the lead suspect. The rewrite is small (~30 lines
+  net) and well-defined (round-based intersection is a textbook trick
+  for parallelizing greedy bipartite matching). The cost of doing it
+  now is small and the benefit is real — pins the perf-test target so
+  future profile-driven work doesn't trip over a well-known suspect.
+
+## Consequences
+
+- **Test bar: set-equality on kept rows, not ordered-equality.** The
+  round-based version returns `keep_indices = np.flatnonzero(keep)`
+  (input-row order); the pre-rewrite returns indices in
+  `keep_indices.append` order (= ascending-distance order over the
+  kept subset). Both are deterministic. The Slice 2 (#224) equivalence
+  test compares as sets via `set(map(tuple, vox))`. If a future caller
+  needs ordered output, sort the result by distance externally — not a
+  contract this function has provided.
+- **Empty-input contract preserved.** The pre-rewrite returns a 2-tuple
+  of `(0, D)` int64 arrays for empty input; the post-rewrite preserves
+  this. The `_select_best_pairs` empty-return arity bug fixed in PRD
+  #217 was a separate latent issue and does not apply here.
+- **`spatial_shape is None` precondition preserved.** The function
+  raises `RuntimeError("spatial_shape is not set; ...")` before the
+  ravel calls — same behavior pre and post.
+- **`_assign_unique_matches` remains not-called by `_run_reassignment`.**
+  The PR does not change which callers exist; it only optimizes the
+  function for the test/external caller path. The
+  `wiki/tracking/voxel-reassignment.md` gotcha at line 46
+  (`_allocate_memory()` must run first or these helpers raise) remains
+  applicable.
+- Future maintainers should not switch to the first-occurrence-of-both
+  heuristic without re-verifying equivalence — see the rejection
+  rationale and walked counter-example above.
+- Future maintainers should not unwind the round-based vectorization
+  to "simplify" without measuring the perf test — the pre-rewrite
+  Python loop was the lead VoxelReassigner suspect for a reason.
+
+## References
+
+- PRD #222 — vectorize `_assign_unique_matches` Python greedy loop
+- Slice 1 #223 — synthetic test suite + this ADR (no production code
+  changes)
+- Slice 2 #224 — round-based vectorized rewrite + equivalence test +
+  perf comparison
+- PRD #153 — opt-in perf coverage rollout that pre-instrumented this
+  hot spot
+- ADR 0010 — preceding tracking-stage rewrite (precedent for
+  test-bar pattern + ADR format)
+- ADRs 0005 / 0006 / 0007 / 0008 / 0009 — preceding optimization
+  ADRs adopted similar slice-plan + considered-options + consequences
+  patterns
+- `wiki/tracking/voxel-reassignment.md` — documents
+  `_assign_unique_matches` as a kept API alongside `_select_best_pairs`

--- a/wiki/decisions/index.md
+++ b/wiki/decisions/index.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-09
-modified: 2026-05-12
+modified: 2026-05-11
 ---
 
 
@@ -20,3 +20,4 @@ Decisions worth recording per [[CLAUDE|wiki conventions]] — hard to reverse, s
 - [[decisions/0008-hu-moment-matmul-rewrite]] — `HuMomentTracking._calculate_normalized_moments` switches from broadcast `(N, H, W, 4, 4)` to two-step batched matmul; `@` over `einsum` for backend-uniform BLAS dispatch; approx-equivalence (`rtol=1e-5`) test bar (preventive, ahead of PRD #191 Slice 2 rewrite)
 - [[decisions/0009-hu-cost-matrix-streaming]] — `HuMomentTracking._get_cost_matrix` switches from broadcast `(N, N, F)` float64 tensors to per-feature streaming float32; `_get_difference_matrix` + `_zscore_normalize` deleted; approx-equivalence (`rtol=1e-3`) test bar — looser than 0008 due to float64→float32 drop (preventive, ahead of PRD #196 Slice 2 rewrite)
 - [[decisions/0010-flow-nearby-coords-single-query]] — `FlowInterpolator._get_nearby_coords` switches from double `query_ball_point` + `query(k=max_k)` traversal to single `query_ball_point` + per-coord `linalg.norm`; bundled with NaN-alignment bug fix (`for pos, i in enumerate(good_coords)`); bit-identical for no-NaN, corrected for NaN (preventive, ahead of PRD #204 Slice 2 rewrite)
+- [[decisions/0011-voxel-assign-unique-matches-round-based]] — `VoxelReassigner._assign_unique_matches` switches from Python greedy loop to round-based per-prev/per-next argmin intersection; rejected first-occurrence-of-both heuristic as not equivalent to greedy; set-equality (not ordered-equality) test bar (preventive, ahead of PRD #222 Slice 2 rewrite)


### PR DESCRIPTION
Slice 1 of #222 — synthetic tests + ADR; no production changes.

## Tests added (7)
1. `_assign_unique_matches_empty_input_returns_2tuple` — empty input → 2-tuple of `(0, D)` int64 arrays
2. `_single_match_kept_verbatim` — single (prev, next) → kept verbatim
3. `_no_contention_keeps_all` — 3 disjoint pairs → all kept
4. `_prev_contention_keeps_lowest_distance` — shared prev_id → only lower-distance row kept
5. `_next_contention_keeps_lowest_distance` — shared next_id → only lower-distance row kept
6. `_chain_contention_multi_round` — exercises multi-round convergence (P1→N1, P1→N2, P2→N2, P2→N3, P3→N3 → keeps {P1→N1, P2→N2, P3→N3})
7. `_tied_distances_pick_one` — exactly 1 of 2 tied rows kept (cardinality + uniqueness only)

Tests assert SET-equality on kept `(prev, next)` pairs (not ordered-equality), because the round-based rewrite returns kept indices in input-row order while the pre-rewrite returns them in distance-ascending order — both deterministic but distinct orderings. ADR 0011 documents the rationale.

## ADR added
`wiki/decisions/0011-voxel-assign-unique-matches-round-based.md` — round-based per-prev/per-next argmin intersection as the chosen vectorization; walked equivalence proof on the chain-contention example; rejected first-occurrence-of-both heuristic with walked counter-example; rejected Cython/numba as over-engineering; set-equality test bar; caveat that `_assign_unique_matches` is NOT called by `_run_reassignment` (perf-test pinning target only). `wiki/decisions/index.md` updated.

## Test plan
- [x] All 43 `tests/test_voxel_reassignment.py` tests pass locally on `.venv/bin/python`
- [x] No production changes — characterization-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)