### PR TITLE
perf(voxel_reassignment): cache tree_next across frames in match_voxels (high-mem only) (Slice 2 of #227)

### DIFF
--- a/nellie/tracking/voxel_reassignment.py
+++ b/nellie/tracking/voxel_reassignment.py
@@ -147,6 +147,13 @@ class VoxelReassigner:
         self.reassigned_branch_memmap = None
         self.reassigned_obj_memmap = None
 
+        # cKDTree from previous iteration's vox_next, reused as next
+        # iteration's tree_prev when in high-memory mode (see PRD #227).
+        # Identity-checked against vox_prev in match_voxels; safe-by-default
+        # for direct match_voxels callers (their vox_prev is a fresh array).
+        self._cached_tree_for_next_frame = None
+        self._cached_vox_for_next_frame = None
+
         self.viewer = viewer
 
     # -------------------------------------------------------------------------
@@ -816,7 +823,18 @@ class VoxelReassigner:
             if self.device_type == "cuda":
                 adaptive_run.free_gpu_memory(self.xp)
         else:
-            tree_prev = self._build_tree(self._scale_coords(vox_prev))
+            # tree_next of frame t-1 was built from coords byte-identical to
+            # vox_prev of frame t (PRD #217 caches and rotates vox_next →
+            # vox_prev). If we're called from `_run_reassignment`, that
+            # cached tree is already on the instance via the identity check
+            # below — reuse it instead of rebuilding. Direct callers of
+            # match_voxels won't hit the identity check (their vox_prev is a
+            # fresh array), so the cache is safe-by-default.
+            if (self._cached_tree_for_next_frame is not None
+                    and self._cached_vox_for_next_frame is vox_prev):
+                tree_prev = self._cached_tree_for_next_frame
+            else:
+                tree_prev = self._build_tree(self._scale_coords(vox_prev))
             tree_next = self._build_tree(self._scale_coords(vox_next))
 
             logger.debug(f'Forward voxel matching for t: {t}')
@@ -828,6 +846,11 @@ class VoxelReassigner:
             vox_prev_bw, vox_next_bw, dist_bw = self._match_backward(
                 self.flow_interpolator_bw, vox_next, vox_prev, t + 1, tree_prev=tree_prev
             )
+
+            # Cache tree_next for the next iteration's tree_prev (driver loop
+            # rotates vox_next → vox_prev, so this is byte-identical reuse).
+            self._cached_tree_for_next_frame = tree_next
+            self._cached_vox_for_next_frame = vox_next
 
         # combine forward and backward matches
         parts_prev = []
@@ -993,6 +1016,13 @@ class VoxelReassigner:
 
     def _run_reassignment(self):
         self._allocate_memory()
+
+        # Reset per-run state. The tree cache persists across match_voxels
+        # calls within one run; clear it here so a re-entry from `run()`'s
+        # mode_candidates cascade (e.g., GPU OOM → CPU retry) starts fresh
+        # rather than using a stale handle from the failed attempt.
+        self._cached_tree_for_next_frame = None
+        self._cached_vox_for_next_frame = None
 
         # initialize reassigned labels at t=0
         if self.branch_label_memmap is not None:

--- a/tests/test_voxel_reassignment.py
+++ b/tests/test_voxel_reassignment.py
@@ -1720,25 +1720,22 @@ def _count_build_tree_calls(
     return counter["n"], v
 
 
-def test_match_voxels_builds_two_trees_per_frame_pre_rewrite_high_mem(
+def test_match_voxels_builds_two_trees_per_frame_post_rewrite_high_mem(
     make_voxel_reassign_imageinfo_3d,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PRE-REWRITE contract: 2 cKDTree builds per frame in high-memory mode.
+    """POST-REWRITE contract (num_t=2): 2 cKDTree builds for the only frame transition.
 
-    The high-memory branch of `match_voxels` (lines 793-794) builds
-    `tree_prev` from `_scale_coords(vox_prev)` then `tree_next` from
-    `_scale_coords(vox_next)` — 2 builds per frame transition. With
-    num_t=2 there is exactly one frame transition, so total = 2.
+    The fixture has 2 frames, so the loop runs once (t=0). PRD #227
+    Slice 2's caching only fires at t >= 1 (where the previous
+    iteration cached its `tree_next`). At t=0 the cache is None and
+    both `tree_prev` and `tree_next` are built fresh — exactly the
+    pre-rewrite behavior for num_t=2.
 
-    Slice 2 of PRD #227 caches `tree_next` from frame t and reuses it
-    as `tree_prev` of frame t+1 in high-memory mode, dropping this to
-    1 build per frame after frame 0 (so for num_t=2, total = 2 still
-    but distributed differently — see the POST-rewrite test in Slice
-    2 which exercises num_t=3 to see the 1-after-first contract).
-
-    With num_t=2 we still expect 2 calls; the test pins the call shape
-    for the only frame transition.
+    The 1-build-per-frame-after-first contract is exercised directly
+    in `test_match_voxels_post_rewrite_caches_tree_next_for_next_iteration`
+    below (which calls `match_voxels` twice manually to simulate two
+    consecutive frame transitions without needing a 3-frame fixture).
     """
     n_calls, v = _count_build_tree_calls(
         make_voxel_reassign_imageinfo_3d,
@@ -1746,9 +1743,132 @@ def test_match_voxels_builds_two_trees_per_frame_pre_rewrite_high_mem(
         monkeypatch=monkeypatch,
     )
     assert n_calls == 2, (
-        f"PRE-REWRITE high-memory: _build_tree should be called 2× per "
-        f"frame transition (one for vox_prev, one for vox_next); for "
-        f"num_t=2 that's exactly 2. Got {n_calls}."
+        f"POST-REWRITE high-memory (num_t=2, 1 frame transition): "
+        f"_build_tree should be called 2× at t=0 (cold cache); got {n_calls}."
+    )
+    _release_voxel_reassigner(v)
+
+
+def test_match_voxels_post_rewrite_caches_tree_next_for_next_iteration(
+    make_voxel_reassign_imageinfo_3d,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST-REWRITE: second `match_voxels` call reuses cached `tree_next` as `tree_prev`.
+
+    Directly exercises the caching mechanism without relying on a
+    multi-frame fixture (the synthetic 3D fixture only has 2 frames).
+    Simulates two consecutive iterations of `_run_reassignment` by
+    calling `match_voxels(vox_a, vox_b, t=0)` then
+    `match_voxels(vox_b, vox_c, t=1)` with `vox_b` being the IDENTICAL
+    ndarray rotated forward (per PRD #217's `vox_prev = vox_next`
+    rotation).
+
+    Pre-rewrite: 2 builds per call → 4 builds total.
+    Post-rewrite: 2 builds at t=0 + 1 build at t=1 (vox_b cache hit) → 3 total.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(
+        info, VoxelReassignerConfig(device="cpu", low_memory=False), num_t=2
+    )
+    v._allocate_memory()
+    # Sanity: cache is empty at construction.
+    assert v._cached_tree_for_next_frame is None
+    assert v._cached_vox_for_next_frame is None
+
+    # Use a small slice of the fixture's labeled voxels so the test is fast.
+    branch_t0 = np.argwhere(v.branch_label_memmap[0] > 0)
+    branch_t1 = np.argwhere(v.branch_label_memmap[1] > 0)
+    # Trim to keep the test cheap; ensure we have at least a handful per side.
+    take = min(200, len(branch_t0), len(branch_t1))
+    assert take > 0, "fixture has no labeled branch voxels at t=0/t=1"
+    vox_a = branch_t0[:take]
+    vox_b = branch_t1[:take]
+    # vox_c is "next-next" — synthesize by adding a tiny offset to vox_b
+    # (clamped into bounds) so it's a different array but valid coords.
+    vox_c = np.clip(
+        vox_b + 1,
+        0,
+        np.array(v.spatial_shape, dtype=vox_b.dtype) - 1,
+    )
+
+    # Count `_build_tree` calls across both `match_voxels` invocations.
+    real_build_tree = VoxelReassigner._build_tree
+    counter = {"n": 0}
+
+    def counted_build_tree(self, coords_real_scaled):
+        counter["n"] += 1
+        return real_build_tree(self, coords_real_scaled)
+
+    monkeypatch.setattr(VoxelReassigner, "_build_tree", counted_build_tree)
+
+    # Iteration 1: cold cache → 2 builds (tree_prev + tree_next).
+    v.match_voxels(vox_a, vox_b, t=0)
+    assert counter["n"] == 2, (
+        f"Iter 1 (cold cache): expected 2 _build_tree calls, got {counter['n']}"
+    )
+    # After iter 1, cache should hold the tree built from vox_b.
+    assert v._cached_tree_for_next_frame is not None
+    assert v._cached_vox_for_next_frame is vox_b
+
+    # Iteration 2: vox_prev IS vox_b (the cached array) → tree_prev is reused;
+    # only tree_next (from vox_c) is built fresh.
+    v.match_voxels(vox_b, vox_c, t=1)
+    assert counter["n"] == 3, (
+        f"Iter 2 (warm cache, vox_b reused as tree_prev): expected 1 "
+        f"additional build (tree_next only), got {counter['n'] - 2} "
+        f"(total {counter['n']})"
+    )
+    # Cache now holds tree built from vox_c.
+    assert v._cached_vox_for_next_frame is vox_c
+    _release_voxel_reassigner(v)
+
+
+def test_match_voxels_post_rewrite_cache_miss_on_fresh_array_high_mem(
+    make_voxel_reassign_imageinfo_3d,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST-REWRITE: a direct caller passing a fresh `vox_prev` ndarray bypasses the cache.
+
+    The cache identity check is `self._cached_vox_for_next_frame is
+    vox_prev` (Python `is`). Direct callers of `match_voxels` (not
+    going through `_run_reassignment`'s rotation) typically pass a
+    fresh ndarray each call, so the identity check fails and tree_prev
+    is built normally. Pins the safe-by-default behavior.
+    """
+    info = make_voxel_reassign_imageinfo_3d()
+    v = VoxelReassigner(
+        info, VoxelReassignerConfig(device="cpu", low_memory=False), num_t=2
+    )
+    v._allocate_memory()
+
+    branch_t0 = np.argwhere(v.branch_label_memmap[0] > 0)
+    branch_t1 = np.argwhere(v.branch_label_memmap[1] > 0)
+    take = min(200, len(branch_t0), len(branch_t1))
+    vox_a = branch_t0[:take]
+    vox_b = branch_t1[:take]
+
+    real_build_tree = VoxelReassigner._build_tree
+    counter = {"n": 0}
+
+    def counted_build_tree(self, coords_real_scaled):
+        counter["n"] += 1
+        return real_build_tree(self, coords_real_scaled)
+
+    monkeypatch.setattr(VoxelReassigner, "_build_tree", counted_build_tree)
+
+    # Iter 1: cold cache → 2 builds.
+    v.match_voxels(vox_a, vox_b, t=0)
+    assert counter["n"] == 2
+
+    # Iter 2 with a FRESH vox_prev array (not the cached vox_b reference).
+    # Even if the values are identical, `is` fails, and tree_prev is rebuilt.
+    vox_b_fresh = vox_b.copy()
+    assert vox_b_fresh is not vox_b
+    np.testing.assert_array_equal(vox_b_fresh, vox_b)
+    v.match_voxels(vox_b_fresh, vox_a, t=1)
+    assert counter["n"] == 4, (
+        f"Iter 2 with fresh vox_prev (not cached array): expected 2 builds "
+        f"(no cache hit), got {counter['n'] - 2} (total {counter['n']})"
     )
     _release_voxel_reassigner(v)
 

--- a/wiki/tracking/voxel-reassignment.md
+++ b/wiki/tracking/voxel-reassignment.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-06
-modified: 2026-05-09
+modified: 2026-05-11
 ---
 
 # Voxel reassignment
@@ -46,6 +46,7 @@ OOM at any tier triggers `adaptive_run.free_gpu_memory(self.xp)` + a **local-onl
 - **Uses ravel-index tricks on `spatial_shape` for fast uniqueness** — `_allocate_memory()` must run first or `_select_best_pairs` / `_vote_targets` / `_assign_unique_matches` raise.
 - **`match_coord_dtype` is auto-selected** from `max(spatial_shape)` (`uint16` / `uint32` / `uint64`). Saved `running_matches` round-trip back to int coordinates correctly only if the dataset's spatial extent fits — bumping image size past 65 535 in any axis silently widens the saved dtype.
 - **Low-memory mode rebuilds the second tree only after freeing the first** (and frees the GPU pool between forward/backward passes), trading speed for headroom; it also caps `max_query_points` at 2e5 and `max_bruteforce_pairs` at 2e6.
+- **High-memory mode caches `tree_next` across frame transitions** (PR #227). The driver loop's `vox_prev = vox_next` rotation (PRD #217) makes the next iteration's `vox_prev` literally the same ndarray, so `match_voxels` identity-checks `vox_prev is self._cached_vox_for_next_frame` and reuses the cached tree as `tree_prev` instead of rebuilding. Saves one `cKDTree` build per frame after frame 0 (~tens of ms at N=1M). Direct callers of `match_voxels` (not going through `_run_reassignment`'s rotation) typically pass a fresh ndarray, so the identity check fails and tree_prev is built normally — safe by default. Cache is reset at the start of each `_run_reassignment` call; low-memory mode is intentionally skipped (persisting a tree across iterations would defeat the explicit serialized-build trade-off).
 - **`max_refine_iterations`** lets later iterations fill voxels left unassigned by earlier vote rounds. Stopping early can leave holes.
 - **Branch and object label types share one match computation per frame** for efficiency — splitting them would double the work.
 


### PR DESCRIPTION
Slice 2 of #227 — tree caching across frame transitions in `match_voxels`'s high-memory branch.

## Implementation

Adds two instance attributes (`_cached_tree_for_next_frame` + `_cached_vox_for_next_frame`) initialized in `__init__` and reset at the start of each `_run_reassignment` call. In `match_voxels`'s high-memory branch:
1. Identity-checks `vox_prev is _cached_vox_for_next_frame`; on hit, reuses the cached `_TreeHandle` as `tree_prev` (no rebuild).
2. After the matching work, stores the new `tree_next` for the next iteration.

The driver loop's `vox_prev = vox_next` rotation (PRD #217) makes the next iteration's `vox_prev` literally the same ndarray, so the identity check is correct by construction. Direct callers of `match_voxels` (not going through `_run_reassignment`) typically pass a fresh ndarray each call → identity check fails → tree_prev is built normally. **Safe by default.**

**Low-memory mode is intentionally skipped** — the explicit serialized-build trade-off (frees the first tree before building the second to halve peak memory) is preserved.

## Tests (3 new)
- `test_match_voxels_builds_two_trees_per_frame_post_rewrite_high_mem` (renamed from Slice 1's `_pre_rewrite_high_mem`) — pins that with `num_t=2` the cache never fires (only one frame transition; no rotation happens) so the build count is unchanged at 2.
- `test_match_voxels_post_rewrite_caches_tree_next_for_next_iteration` — directly exercises the cache by calling `match_voxels` twice with the IDENTICAL `vox_b` ndarray rotated forward; pins 2 builds at iter 1 (cold cache) + 1 build at iter 2 (warm cache, vox_b reused).
- `test_match_voxels_post_rewrite_cache_miss_on_fresh_array_high_mem` — pins safe-by-default behavior: fresh `vox_prev` ndarray (even if values match) bypasses the cache via `is` identity check.

`test_match_voxels_builds_two_trees_per_frame_low_mem` from Slice 1 still passes unchanged — low-memory mode is skipped by the cache.

## Wall-clock numbers (M2 Pro CPU, synthetic 3D fixture, num_t=2)
- Pre-rewrite: 197.1 ms
- Post-rewrite: 201.1 ms
- Δ ≈ +4 ms (within noise — the cache never fires at num_t=2 because there's only one frame transition)

The cache benefit scales with `num_t`. For `num_t=N`, the savings are `(N-1)` cKDTree builds per run. At N=1M coords that's ~tens of ms per build × (N-1) = hundreds of ms to seconds for typical multi-frame runs. The existing perf benchmark uses `num_t=2` only, so the savings don't show up — see the unit-test `_caches_tree_next_for_next_iteration` for direct verification at the `match_voxels` call level.

## Wiki
`wiki/tracking/voxel-reassignment.md` gotchas updated to document the new caching behavior alongside the existing low-memory serialized-build gotcha.

## Test plan
- [x] All 48 `tests/test_voxel_reassignment.py` tests pass locally
- [x] Cache hit / cache miss / low-mem unchanged paths all directly tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)