### PR TITLE
perf(filtering): in-place multiplication in _mask_volume

### DIFF
--- a/nellie/segmentation/filtering.py
+++ b/nellie/segmentation/filtering.py
@@ -688,7 +688,10 @@ class Filter:
         thr = xp.percentile(positive, 1)
         frangi_mask = frangi_frame > thr
         frangi_mask = ndi.binary_opening(frangi_mask)
-        frangi_frame = frangi_frame * frangi_mask
+        # In-place to avoid a full-volume allocation on every frame —
+        # `_run_filter` already discards its caller-side reference and
+        # immediately overwrites with the masked result.
+        frangi_frame *= frangi_mask
         return frangi_frame
 
     def _remove_edges(self, frangi_frame):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -351,6 +351,31 @@ def test_backend_for_array_dispatches_numpy(make_imageinfo_2d) -> None:
     _release_filter(filt)
 
 
+def test_mask_volume_returns_input_object_in_place(make_imageinfo_2d) -> None:
+    """`_mask_volume` mutates and returns its input — pin against accidental revert.
+
+    Pre-rewrite computed `frangi_frame * frangi_mask` (allocating a new
+    full-volume array per frame); the in-place rewrite multiplies in
+    place and returns the same object. Bit-identical for downstream
+    callers — `_run_filter` discards its caller-side reference and
+    immediately overwrites with the masked result — but the
+    same-object identity is the cheapest pin against an accidental
+    revert in a future cleanup.
+    """
+    info = make_imageinfo_2d()
+    filt = Filter(info, _CPU, num_t=2)
+
+    frame = np.linspace(0.0, 1.0, num=64, dtype=np.float32).reshape(8, 8)
+    out = filt._mask_volume(frame)
+
+    assert out is frame, (
+        "_mask_volume must operate in place — switch back to `frangi_frame "
+        "*= frangi_mask` if a refactor reintroduced the allocating `*` form"
+    )
+
+    _release_filter(filt)
+
+
 # -------------------------------------------------------------------------
 # Dense vs sparse vesselness paths
 #


### PR DESCRIPTION
## What

`_mask_volume` (in `nellie/segmentation/filtering.py`) previously computed `frangi_frame = frangi_frame * frangi_mask`, allocating a new full-volume float32 array per frame. The result is immediately discarded by the caller (`_run_filter` overwrites its local `frangi_frame` reference and writes the masked output to the memmap), so the allocation served only the function-local rebind.

Switch to in-place `*=`. Bit-identical output, one full-volume allocation saved per frame.

## Why

Per the filtering audit (PRD #233 sibling). For a 1M-voxel float32 frame: 4 MB allocation per frame; for a 100M-voxel confocal stack: 400 MB allocation per frame. On a 10-frame run that's 40 MB → 4 GB of malloc/free pressure replaced with in-place writes.

## Test plan

`test_mask_volume_returns_input_object_in_place` pins same-object identity as the cheapest regression bar against an accidental revert to the allocating `*` form. All 41 filtering tests pass on `dechao` HEAD.

## Scope

Single PR (no slicing). The change is one operator swap (`*` → `*=`), bit-identical, and the same-object pin protects against future drift. No ADR needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)