### PR TITLE
perf(filtering): flat indexing in _compute_vesselness_sparse

### DIFF
--- a/nellie/segmentation/filtering.py
+++ b/nellie/segmentation/filtering.py
@@ -428,11 +428,19 @@ class Filter:
         Used when the Frobenius mask is partial — paying the indexing
         overhead is worth it to avoid evaluating frangi on voxels that
         will be zeroed anyway.
+
+        Indexes via a single 1D `flatnonzero` array rather than the
+        ndim-tuple `where` returns: 3D `where` produces 3 int64 coord
+        arrays (24 bytes per masked voxel for indices alone, vs 8 for
+        flat); per-chunk fancy indexing reads through 1 index array
+        instead of 3. Same voxels in the same C-order — bit-identical
+        to the prior `where`-based path.
         """
-        coords = self.xp.where(h_mask)
-        # Torch's ``.size`` is a method, not an attribute — reduce via shape.
-        total_voxels = int(np.prod(coords[0].shape))
         template = next(iter(h_components.values()))
+        # Torch's ``.size`` is a method, not an attribute — reduce via shape.
+        shape = template.shape
+        flat_indices = self.xp.flatnonzero(h_mask.ravel())
+        total_voxels = int(np.prod(flat_indices.shape))
         if total_voxels == 0:
             return self.xp.zeros_like(template, dtype=self.work_dtype)
 
@@ -440,21 +448,22 @@ class Filter:
         if chunk_size is None or chunk_size <= 0:
             chunk_size = total_voxels
 
+        flat_components = {k: v.ravel() for k, v in h_components.items()}
         vessel_masked = self.xp.zeros(total_voxels, dtype=self.work_dtype)
 
         for start in range(0, total_voxels, chunk_size):
             end = min(start + chunk_size, total_voxels)
-            idx_chunk = tuple(c[start:end] for c in coords)
-            h_chunks = {k: h_components[k][idx_chunk] for k in h_components}
+            idx_chunk = flat_indices[start:end]
+            h_chunks = {k: flat_components[k][idx_chunk] for k in flat_components}
             eigenvalues = self._eigenvalues_from_chunk(h_chunks)
             v_chunk = frangi_math.frangi(
                 eigenvalues, self.alpha_sq, self.beta_sq, gamma_sq, self.xp
             )
             vessel_masked[start:end] = v_chunk.astype(self.work_dtype, copy=False)
 
-        vesselness = self.xp.zeros_like(template, dtype=self.work_dtype)
-        vesselness[coords] = vessel_masked
-        return vesselness
+        flat_vesselness = self.xp.zeros(int(np.prod(shape)), dtype=self.work_dtype)
+        flat_vesselness[flat_indices] = vessel_masked
+        return flat_vesselness.reshape(shape)
 
     def _compute_vesselness_dense(self, h_components, gamma_sq):
         """Vesselness over the full volume via flat slicing — no `xp.where` indirection.


### PR DESCRIPTION
## What

`_compute_vesselness_sparse` (in `nellie/segmentation/filtering.py`) previously used `xp.where(h_mask)`, which returns one int64 coord array per dimension (3 arrays in 3D). Per-chunk fancy indexing into 6 Hessian components reads through 3 coord arrays per access; the final scatter writes through 3 too.

Switch to a single 1D `xp.flatnonzero(h_mask.ravel())`. Per-chunk fancy indexing is now 1D into the raveled components; final scatter writes 1D into a flat output, then reshapes back.

## Why

Memory savings scale with mask coverage:

| Volume × coverage | Old indices | New indices |
|---|---|---|
| 1M voxels × 50% | 12 MB | 4 MB |
| 100M × 50% | 1.2 GB | 400 MB |

Plus 1D fancy-indexing is generally faster than multi-dim on most backends (single coalesced gather vs three uncoalesced gathers).

## Bit-identical equivalence

`xp.where(arr)` and `xp.flatnonzero(arr.ravel())` both iterate in C order — the same voxels appear in the same order. Verified locally on yeast fixtures (macOS):

| Fixture | Pre-rewrite SHA | Post-rewrite SHA |
|---|---|---|
| 3D | `5a86...c77` | `5a86...c77` |
| 2D | `bc62...57d` | `bc62...57d` |

## Test plan

- [x] Existing `test_dense_and_sparse_vesselness_paths_agree[2d|3d]` exercises the rewritten sparse path against the dense path with `assert_allclose(atol=1e-6)` — passes.
- [x] All 41 filtering tests pass on `dechao` HEAD.
- [x] Pre/post `Filter.run()` SHAs match locally (bit-identical).
- [x] `test_dense_path_at_least_as_fast_as_sparse` (perf gate) passes — sparse path on a fully-true mask still doesn't regress past 1.2× of dense.

## Scope

Single PR (no slicing). Bit-identical, covered by existing equivalence test, no new ADR — pure mechanical refactor of the indexing form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)