### PR TITLE
im_info: add DROPPABLE_KEYS + presets + remove_marked_intermediates (Slice 1 of #245)

### DIFF
--- a/nellie/im_info/__init__.py
+++ b/nellie/im_info/__init__.py
@@ -1,7 +1,14 @@
 from pathlib import Path
 
 from .types import DimRes
-from .verifier import FileInfo, ImInfo
+from .verifier import (
+    CSVS_ONLY_PRESET,
+    DROPPABLE_KEYS,
+    FileInfo,
+    ImInfo,
+    KEEP_EVERYTHING_PRESET,
+    MASKS_AND_CSVS_PRESET,
+)
 
 
 def load_image(
@@ -53,4 +60,13 @@ def load_image(
     return ImInfo.from_file_info(file_info)
 
 
-__all__ = ["FileInfo", "ImInfo", "DimRes", "load_image"]
+__all__ = [
+    "FileInfo",
+    "ImInfo",
+    "DimRes",
+    "load_image",
+    "DROPPABLE_KEYS",
+    "KEEP_EVERYTHING_PRESET",
+    "MASKS_AND_CSVS_PRESET",
+    "CSVS_ONLY_PRESET",
+]

--- a/nellie/im_info/verifier.py
+++ b/nellie/im_info/verifier.py
@@ -20,7 +20,46 @@ from nellie.utils.base_logger import logger
 # ``nellie.im_info.types`` in Slice 6 to break the verifier ↔ extractors
 # circular import. Existing ``from nellie.im_info.verifier import DimRes``
 # (or ``infer_t_axis``) imports keep working via the re-exports above.
-__all__ = ['FileInfo', 'ImInfo', 'DimRes', 'infer_t_axis', 'transform_to_axes']
+__all__ = [
+    'FileInfo', 'ImInfo', 'DimRes', 'infer_t_axis', 'transform_to_axes',
+    'DROPPABLE_KEYS', 'KEEP_EVERYTHING_PRESET', 'MASKS_AND_CSVS_PRESET',
+    'CSVS_ONLY_PRESET',
+]
+
+
+# The universe of pipeline outputs that ``ImInfo.remove_marked_intermediates``
+# is allowed to delete. Membership must be kept in sync with
+# ``ImInfo._create_output_paths``: every non-CSV key created there should
+# appear here, plus the special ``im_path`` key that resolves to the
+# canonical OME-TIFF (which lives outside ``pipeline_paths`` but is part
+# of the cleanup contract). The 5 ``features_*`` CSVs are intentionally
+# excluded — they are the user-facing analytical product and the napari
+# analyzer reads them back. See [[wiki/decisions/0014-intermediates-policy-frozenset]].
+DROPPABLE_KEYS: frozenset[str] = frozenset({
+    'im_preprocessed',
+    'im_instance_label',
+    'im_skel',
+    'im_skel_relabelled',
+    'im_pixel_class',
+    'im_marker',
+    'im_distance',
+    'im_border',
+    'flow_vector_array',
+    'voxel_matches',
+    'im_branch_label_reassigned',
+    'im_obj_label_reassigned',
+    'adjacency_maps',
+    'im_path',
+})
+
+KEEP_EVERYTHING_PRESET: frozenset[str] = frozenset()
+MASKS_AND_CSVS_PRESET: frozenset[str] = DROPPABLE_KEYS - {
+    'im_instance_label',
+    'im_branch_label_reassigned',
+    'im_obj_label_reassigned',
+    'im_path',
+}
+CSVS_ONLY_PRESET: frozenset[str] = DROPPABLE_KEYS
 
 
 def transform_to_axes(
@@ -815,8 +854,10 @@ class ImInfo:
         Creates a file path for a specific stage of the image processing pipeline.
     _create_output_paths()
         Creates all necessary output paths for various stages in the image processing pipeline.
+    remove_marked_intermediates(drop_keys)
+        Deletes the files for the specified `pipeline_paths` keys (plus `im_path` if included). Validates against `DROPPABLE_KEYS`.
     remove_intermediates()
-        Removes intermediate files created during the image processing pipeline, except for .csv files.
+        Legacy shim: deletes all entries in `DROPPABLE_KEYS` (= every non-CSV intermediate plus `im_path`). Equivalent to `remove_marked_intermediates(drop_keys=DROPPABLE_KEYS)`.
     _get_ome_metadata()
         Extracts OME metadata from the image and updates resolution, axes, and shape information.
     get_memmap(file_path: str, read_mode: str = 'r+')
@@ -969,19 +1010,52 @@ class ImInfo:
         self.create_output_path('features_image', ext='.csv', for_nellie=False)
         self.create_output_path('adjacency_maps', ext='.pkl')
 
+    def remove_marked_intermediates(self, drop_keys):
+        """
+        Delete the on-disk files for the specified ``pipeline_paths`` keys.
+
+        The droppable universe is ``DROPPABLE_KEYS`` (the 12 image-like
+        intermediates + ``adjacency_maps`` + the special ``im_path`` key
+        that resolves to the canonical OME-TIFF). The 5 ``features_*``
+        CSV keys are not in ``DROPPABLE_KEYS`` and are therefore
+        rejected; they are the user-facing analytical product and the
+        napari analyzer reads them back.
+
+        Missing files (e.g., ``adjacency_maps`` when ``skip_nodes=True``)
+        are silently skipped so callers can pass a uniform drop set
+        without inspecting which files were actually produced.
+
+        Parameters
+        ----------
+        drop_keys : frozenset[str]
+            Keys to delete. Must be a subset of ``DROPPABLE_KEYS``.
+
+        Raises
+        ------
+        AssertionError
+            If ``drop_keys`` contains any key not in ``DROPPABLE_KEYS``.
+        """
+        unknown = set(drop_keys) - DROPPABLE_KEYS
+        assert not unknown, (
+            f"remove_marked_intermediates: unknown keys {sorted(unknown)} "
+            f"(must be subset of DROPPABLE_KEYS)"
+        )
+        for key in drop_keys:
+            path = self.im_path if key == 'im_path' else self.pipeline_paths[key]
+            if os.path.exists(path):
+                os.remove(path)
+
     def remove_intermediates(self):
         """
-        Removes intermediate files created during the image processing pipeline, except for CSV files.
+        Legacy shim: drop every entry in :data:`DROPPABLE_KEYS`.
 
-        This method loops through all pipeline paths and deletes files (except .csv files) that were created during
-        processing. It also deletes the main image file if it exists.
+        Equivalent to ``self.remove_marked_intermediates(drop_keys=DROPPABLE_KEYS)``.
+        Preserved so that callers / tests pinning the prior contract
+        (CSVs survive; ``im_path`` is deleted alongside the other
+        intermediates) continue to work unchanged. New code should call
+        ``remove_marked_intermediates`` with an explicit drop set.
         """
-        all_pipeline_paths = [self.pipeline_paths[pipeline_path] for pipeline_path in self.pipeline_paths]
-        for pipeline_path in all_pipeline_paths + [self.im_path]:
-            if 'csv' in pipeline_path:
-                continue
-            elif os.path.exists(pipeline_path):
-                os.remove(pipeline_path)
+        self.remove_marked_intermediates(drop_keys=DROPPABLE_KEYS)
 
     def _get_ome_metadata(self, ):
         """

--- a/tests/test_verifier_iminfo.py
+++ b/tests/test_verifier_iminfo.py
@@ -39,7 +39,15 @@ import ome_types
 import pytest
 import tifffile
 
-from nellie.im_info.verifier import FileInfo, ImInfo, transform_to_axes
+from nellie.im_info.verifier import (
+    CSVS_ONLY_PRESET,
+    DROPPABLE_KEYS,
+    FileInfo,
+    ImInfo,
+    KEEP_EVERYTHING_PRESET,
+    MASKS_AND_CSVS_PRESET,
+    transform_to_axes,
+)
 
 
 def _release_iminfo_memmap(info: ImInfo) -> None:
@@ -834,6 +842,172 @@ def test_remove_intermediates_deletes_canonical_im_path(make_imageinfo_3d) -> No
     _release_iminfo_memmap(info)  # Windows: release im_path mmap before delete
     info.remove_intermediates()
     assert not os.path.exists(info.im_path)
+
+
+# ----------------------------------------------------------------------------
+# H.1 ``DROPPABLE_KEYS`` + presets + ``remove_marked_intermediates``
+# ----------------------------------------------------------------------------
+
+
+_EXPECTED_DROPPABLE_KEYS = frozenset({
+    'im_preprocessed',
+    'im_instance_label',
+    'im_skel',
+    'im_skel_relabelled',
+    'im_pixel_class',
+    'im_marker',
+    'im_distance',
+    'im_border',
+    'flow_vector_array',
+    'voxel_matches',
+    'im_branch_label_reassigned',
+    'im_obj_label_reassigned',
+    'adjacency_maps',
+    'im_path',
+})
+
+
+def test_droppable_keys_membership_exact() -> None:
+    """``DROPPABLE_KEYS`` is the 14-key universe, no CSVs."""
+    assert DROPPABLE_KEYS == _EXPECTED_DROPPABLE_KEYS
+    csv_keys = {
+        'features_voxels', 'features_nodes', 'features_branches',
+        'features_organelles', 'features_image',
+    }
+    assert DROPPABLE_KEYS.isdisjoint(csv_keys)
+
+
+def test_keep_everything_preset_is_empty() -> None:
+    assert KEEP_EVERYTHING_PRESET == frozenset()
+
+
+def test_csvs_only_preset_equals_droppable_keys() -> None:
+    assert CSVS_ONLY_PRESET == DROPPABLE_KEYS
+
+
+def test_masks_and_csvs_preset_keeps_three_labels_plus_im_path() -> None:
+    """Preset drops everything except the three label maps and ``im_path``."""
+    kept = DROPPABLE_KEYS - MASKS_AND_CSVS_PRESET
+    assert kept == frozenset({
+        'im_instance_label',
+        'im_branch_label_reassigned',
+        'im_obj_label_reassigned',
+        'im_path',
+    })
+
+
+def _plant_dummy_files(info: ImInfo, keys) -> None:
+    """Create a small placeholder file at each pipeline_paths key."""
+    for key in keys:
+        if key == 'im_path':
+            continue  # already exists from ImInfo construction
+        path = info.pipeline_paths[key]
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'wb') as f:
+            f.write(b'x')
+
+
+def test_remove_marked_intermediates_drops_only_marked_keys(make_imageinfo_3d) -> None:
+    """Only the keys passed in are deleted; CSVs always survive."""
+    info = make_imageinfo_3d()
+    droppable_non_im_path = DROPPABLE_KEYS - {'im_path'}
+    csv_keys = {
+        'features_voxels', 'features_nodes', 'features_branches',
+        'features_organelles', 'features_image',
+    }
+    _plant_dummy_files(info, droppable_non_im_path | csv_keys)
+
+    drop = frozenset({'im_preprocessed', 'im_skel', 'flow_vector_array'})
+    info.remove_marked_intermediates(drop_keys=drop)
+
+    for key in drop:
+        assert not os.path.exists(info.pipeline_paths[key]), (
+            f"{key!r} should have been deleted"
+        )
+    for key in (droppable_non_im_path - drop):
+        assert os.path.exists(info.pipeline_paths[key]), (
+            f"{key!r} should have survived (not in drop set)"
+        )
+    for key in csv_keys:
+        assert os.path.exists(info.pipeline_paths[key]), (
+            f"{key!r} (CSV) should always survive"
+        )
+    # im_path was not in the drop set, should still exist.
+    assert os.path.exists(info.im_path)
+
+
+def test_remove_marked_intermediates_empty_set_is_noop(make_imageinfo_3d) -> None:
+    """Empty drop set deletes nothing."""
+    info = make_imageinfo_3d()
+    droppable_non_im_path = DROPPABLE_KEYS - {'im_path'}
+    _plant_dummy_files(info, droppable_non_im_path)
+
+    info.remove_marked_intermediates(drop_keys=frozenset())
+
+    for key in droppable_non_im_path:
+        assert os.path.exists(info.pipeline_paths[key])
+    assert os.path.exists(info.im_path)
+
+
+@pytest.mark.parametrize('bad_key', ['not_a_real_key', 'features_voxels'])
+def test_remove_marked_intermediates_rejects_unknown_keys(
+    make_imageinfo_3d, bad_key: str,
+) -> None:
+    """Keys outside ``DROPPABLE_KEYS`` (including CSV keys) raise."""
+    info = make_imageinfo_3d()
+    with pytest.raises(AssertionError, match=bad_key):
+        info.remove_marked_intermediates(drop_keys=frozenset({bad_key}))
+
+
+def test_remove_marked_intermediates_silently_skips_missing_files(
+    make_imageinfo_3d,
+) -> None:
+    """Drop set includes a key whose file was never created — no error."""
+    info = make_imageinfo_3d()
+    # Don't plant adjacency_maps; it's only created when skip_nodes=False
+    # at Hierarchy time, which the fixture doesn't run.
+    assert not os.path.exists(info.pipeline_paths['adjacency_maps'])
+    info.remove_marked_intermediates(drop_keys=frozenset({'adjacency_maps'}))
+    # No exception raised; nothing changed.
+    assert not os.path.exists(info.pipeline_paths['adjacency_maps'])
+
+
+def test_remove_marked_intermediates_handles_im_path(make_imageinfo_3d) -> None:
+    """``im_path`` resolves to ``self.im_path`` and gets deleted."""
+    info = make_imageinfo_3d()
+    assert os.path.exists(info.im_path)
+    _release_iminfo_memmap(info)  # Windows: release mmap before delete
+    info.remove_marked_intermediates(drop_keys=frozenset({'im_path'}))
+    assert not os.path.exists(info.im_path)
+
+
+def test_remove_intermediates_legacy_shim_matches_new_method(make_imageinfo_3d) -> None:
+    """Legacy ``remove_intermediates()`` is equivalent to dropping all of ``DROPPABLE_KEYS``.
+
+    Re-asserts the contract pinned by the two pre-existing legacy tests
+    (CSVs survive, im_path deleted, all 12 image intermediates +
+    adjacency_maps deleted if present) via the new shim path.
+    """
+    info = make_imageinfo_3d()
+    droppable_non_im_path = DROPPABLE_KEYS - {'im_path'}
+    csv_keys = {
+        'features_voxels', 'features_nodes', 'features_branches',
+        'features_organelles', 'features_image',
+    }
+    _plant_dummy_files(info, droppable_non_im_path | csv_keys)
+
+    _release_iminfo_memmap(info)
+    info.remove_intermediates()
+
+    for key in droppable_non_im_path:
+        assert not os.path.exists(info.pipeline_paths[key]), (
+            f"{key!r} should have been deleted by legacy shim"
+        )
+    assert not os.path.exists(info.im_path)
+    for key in csv_keys:
+        assert os.path.exists(info.pipeline_paths[key]), (
+            f"{key!r} (CSV) should have survived legacy shim"
+        )
 
 
 # ============================================================================

--- a/wiki/decisions/0014-intermediates-policy-frozenset.md
+++ b/wiki/decisions/0014-intermediates-policy-frozenset.md
@@ -1,0 +1,86 @@
+---
+created: 2026-05-12
+modified: 2026-05-12
+---
+
+# Per-output intermediate retention policy is a `frozenset[str]` of `pipeline_paths` keys, not a structured dataclass
+
+The legacy `ImInfo.remove_intermediates()` is all-or-nothing: every non-CSV
+entry in `pipeline_paths` plus `im_path` is deleted, gated by the napari
+Settings widget's single `remove_intermediates_checkbox`. The new
+per-output retention design (see [[pipeline]] for stage→output mapping)
+introduces a policy parameter that travels through both `nellie.run.run()`
+and `nellie_napari.processor` so the napari widget and scripted callers
+share one mechanism.
+
+The decision is **the policy is a `frozenset[str]` of `pipeline_paths` keys
+to drop**, validated against a module-level `DROPPABLE_KEYS: frozenset[str]`
+constant (the universe of toggleable outputs: the 12 image-like
+intermediates + `adjacency_maps` + `im_path`). Presets are module-level
+`frozenset[str]` constants derived from `DROPPABLE_KEYS` (`KEEP_EVERYTHING_PRESET = frozenset()`,
+`CSVS_ONLY_PRESET = DROPPABLE_KEYS`,
+`MASKS_AND_CSVS_PRESET = DROPPABLE_KEYS - {<the three label maps> + im_path}`).
+The cleanup method is `ImInfo.remove_marked_intermediates(drop_keys: frozenset[str])`,
+which validates `drop_keys <= DROPPABLE_KEYS` and deletes each existing path.
+The legacy `remove_intermediates()` becomes a one-line shim:
+`self.remove_marked_intermediates(drop_keys=DROPPABLE_KEYS)` — preserving the
+existing test contract (CSVs survive; `im_path` deleted).
+
+Status: **Accepted** — to be implemented per the PRD this ADR was written
+during.
+
+## Considered Options
+
+- **`frozenset[str]` of drop keys (chosen).** Minimal API surface; presets
+  are derivable arithmetic on `DROPPABLE_KEYS`; new pipeline outputs only
+  need a single `DROPPABLE_KEYS` addition and the presets re-derive
+  automatically; legacy backward-compat shim is one line; immutable so it
+  can be a default-arg or module constant safely; validation at the
+  `ImInfo.remove_marked_intermediates` boundary catches typos with one
+  `assert drop_keys <= DROPPABLE_KEYS` line.
+- **`@dataclass IntermediatesPolicy` with one bool field per intermediate
+  (rejected).** Type-safe and IDE-discoverable for scripted callers, but
+  carries 14+ boolean fields that all need to be threaded through every
+  preset constructor and updated whenever a new pipeline output is added.
+  The discoverability advantage is real but the napari Settings widget is
+  the actual discovery surface for end users; scripted callers reach for
+  named preset constants 90% of the time, where the type doesn't matter.
+- **`dict[str, bool]` mapping key → keep (rejected).** Redundant: each
+  entry carries a boolean but only the "drop" answers matter. Forces a
+  policy decision on missing-key semantics (keep, drop, or raise?) that
+  `frozenset` sidesteps by construction. Mutable, so it can't safely be a
+  module constant for presets without `MappingProxyType` ceremony.
+- **Preset enum + override sets (rejected).** Two-layer state (named
+  preset + diff sets) is more to think about than the final drop set
+  itself; the napari widget would need to track which preset was last
+  selected separately from the actual checkbox state. The `frozenset`
+  collapses this — selecting a preset just sets the drop set; tweaking a
+  checkbox updates the drop set; the widget reverse-derives "is this a
+  named preset?" by membership comparison.
+
+## Consequences
+
+- **Public API contract is `frozenset[str]`** for `nellie.run.run(file_info, ..., cleanup_drop_keys: frozenset[str] | None = None)`
+  and `SettingsConfig.cleanup_drop_keys: frozenset[str]`. Hard to reverse
+  after release: scripted callers will pin the type; the napari widget's
+  saved-settings JSON will serialize as a list and round-trip via
+  `frozenset(...)`.
+- **`DROPPABLE_KEYS` is the source of truth.** Adding a new output to
+  `_create_output_paths` that should be droppable also requires adding
+  the key to `DROPPABLE_KEYS`; forgetting this is a one-line mistake
+  caught by the validation assert (the new key won't accept toggle
+  attempts) but won't auto-show up in the napari widget either. Document
+  alongside `_create_output_paths`.
+- **CSV keys (`features_voxels`, `features_nodes`, `features_branches`,
+  `features_organelles`, `features_image`) are NOT in `DROPPABLE_KEYS`.**
+  Hard-protected because the napari analyzer reads them back; any user
+  intent to delete CSVs is out-of-scope per Q2 of the design grilling.
+- **Legacy `remove_intermediates()` is preserved** as a thin wrapper
+  calling `remove_marked_intermediates(drop_keys=DROPPABLE_KEYS)`. The
+  two existing tests (`test_remove_intermediates_preserves_csv_files`,
+  `test_remove_intermediates_deletes_canonical_im_path`) stay green
+  unchanged; they characterize the legacy semantic the wrapper preserves.
+- **Cleanup fires once, after `Hierarchy.run()` succeeds** — same trigger
+  point as today, no `try/finally`. Inherits the existing pipeline
+  "no try/except around stages" gotcha (per [[pipeline]]); a mid-pipeline
+  failure leaves all on-disk state for inspection.

--- a/wiki/decisions/index.md
+++ b/wiki/decisions/index.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-05-09
-modified: 2026-05-11
+modified: 2026-05-12
 ---
 
 
@@ -25,3 +25,4 @@ Decisions worth recording per [[CLAUDE|wiki conventions]] — hard to reverse, s
 - [[decisions/0011-voxel-assign-unique-matches-round-based]] — `VoxelReassigner._assign_unique_matches` switches from Python greedy loop to round-based per-prev/per-next argmin intersection; rejected first-occurrence-of-both heuristic as not equivalent to greedy; set-equality (not ordered-equality) test bar (preventive, ahead of PRD #222 Slice 2 rewrite)
 - [[decisions/0012-filter-frob-mask-subsample-side-inf-filter]] — `Filter._get_frob_mask` switches inf-filtering from full volume to subsample; bit-identical for finite-only data, approx-equivalent for inf-containing data (sampling-noise on threshold) — same equivalence bar as ADRs 0008 / 0009. Bonus: per-sigma `xp.any(h_mask)` + `bool(h_mask.all())` fused into single `xp.sum(h_mask)` (pure refactor, no ADR)
 - [[decisions/0013-hierarchy-branch-stats-vectorized-rewrite]] — `Branches._get_branch_stats` per-label loops (base-length gather, tip-radius adjustment ×2, median thickness, tortuosity) replaced with `np.add.at` / `scipy.ndimage.median` / stable-argsort vectorized variants; float64 accumulation + single end-cast for tip-radius adjustment shifts the float32 cast point — drift bounded at 1 ULP on multi-tip labels (`rtol=1e-5, atol=1e-5`) — bit-identical for `branch_thickness` and for the 2D fixture; test bar pinned in `test_hierarchical.py`
+- [[decisions/0014-intermediates-policy-frozenset]] — per-output intermediate retention policy is a `frozenset[str]` of `pipeline_paths` keys to drop (validated against module-level `DROPPABLE_KEYS`), threaded through both `nellie.run.run()` and the napari Settings widget; presets are `frozenset` constants derived from `DROPPABLE_KEYS`; legacy `remove_intermediates()` becomes a one-line shim preserving today's "drop all non-CSV + im_path" semantic


### PR DESCRIPTION
## Summary

- Adds module-level constants in `nellie.im_info`: `DROPPABLE_KEYS` (the 14-key universe), `KEEP_EVERYTHING_PRESET`, `MASKS_AND_CSVS_PRESET`, `CSVS_ONLY_PRESET`.
- Adds `ImInfo.remove_marked_intermediates(drop_keys: frozenset[str])` — validates against `DROPPABLE_KEYS`, deletes only the marked files, silently skips missing ones.
- Refactors legacy `ImInfo.remove_intermediates()` into a one-line shim calling the new method with `DROPPABLE_KEYS`. Both pre-existing pinned tests pass unchanged.
- 11 new tests in `tests/test_verifier_iminfo.py` (section H.1) pin the contract.
- ADR 0014 written and indexed: `wiki/decisions/0014-intermediates-policy-frozenset.md`.

Closes #246. Foundation for Slices 2/3 of #245.

## Test plan

- [x] `uv run pytest tests/test_verifier_iminfo.py -q` — 68 passed (was 57, 11 new)
- [ ] Reviewer: confirm `DROPPABLE_KEYS` membership matches `_create_output_paths` (every non-CSV key plus `im_path`)
- [ ] Reviewer: confirm legacy `remove_intermediates()` semantics preserved end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)