### PR TITLE
run: cleanup_drop_keys kwarg threaded to remove_marked_intermediates (Slice 2 of #245)

### DIFF
--- a/nellie/run.py
+++ b/nellie/run.py
@@ -23,6 +23,7 @@ def run(
     timeit=False,
     device="auto",
     low_memory=False,
+    cleanup_drop_keys=None,
 ):
     """
     Main entry point for the Nellie pipeline.
@@ -43,6 +44,17 @@ def run(
         Backend selection for preprocessing, labeling, and feature extraction.
     low_memory : bool, optional
         Whether to prefer lower-memory (slower) implementations where available.
+    cleanup_drop_keys : frozenset[str] or None, optional
+        Per-output intermediate retention policy. If provided, the
+        specified ``pipeline_paths`` keys (validated against
+        ``DROPPABLE_KEYS``; the special key ``im_path`` resolves to the
+        canonical OME-TIFF) are deleted after ``Hierarchy.run()``
+        completes successfully. ``None`` (default) leaves all on-disk
+        state intact. The empty frozenset is also a no-op. Mid-pipeline
+        failures propagate without cleanup, so partial state remains
+        for inspection. Importable presets:
+        ``KEEP_EVERYTHING_PRESET``, ``MASKS_AND_CSVS_PRESET``,
+        ``CSVS_ONLY_PRESET`` from ``nellie.im_info``.
 
     Returns
     -------
@@ -133,6 +145,9 @@ def run(
         print(f"Nellie Pipeline: VoxelReassigner step took {vox_reassign_time:.4f} seconds")
         print(f"Nellie Pipeline: Hierarchy step took {hierarchy_time:.4f} seconds")
         print(f"Nellie Pipeline: Total time took {preprocessing_time + segmenting_time + networking_time + mocap_marking_time + hu_tracking_time + vox_reassign_time + hierarchy_time:.4f} seconds")
+
+    if cleanup_drop_keys:
+        im_info.remove_marked_intermediates(drop_keys=cleanup_drop_keys)
 
     return im_info
 

--- a/tests/test_run_cleanup.py
+++ b/tests/test_run_cleanup.py
@@ -1,0 +1,207 @@
+"""Tests for the ``cleanup_drop_keys`` kwarg on ``nellie.run.run()``.
+
+Slice 2 of #245 wires per-output retention through the standalone
+pipeline driver. The cleanup contract is:
+
+- ``cleanup_drop_keys=None`` (default) leaves all on-disk state intact.
+- An empty ``frozenset`` is also a no-op (truthiness check).
+- A non-empty ``frozenset`` calls ``ImInfo.remove_marked_intermediates``
+  after ``Hierarchy.run()`` succeeds.
+- A mid-pipeline failure propagates without running cleanup.
+
+The heavy pipeline stages are monkeypatched with cheap stubs that just
+``touch`` the expected output files for their stage. This keeps each
+test sub-second while still exercising the full ``run()`` orchestrator
+and the post-Hierarchy cleanup branch end-to-end.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+import nellie.run as run_mod
+from nellie.im_info.verifier import CSVS_ONLY_PRESET, FileInfo
+from nellie.run import run
+
+# ``conftest`` is on ``sys.path`` because pytest's rootdir-based collection
+# adds the test directory before importing test modules.
+from conftest import FIXTURE_2D_PATH  # type: ignore[import-not-found]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fresh_file_info(workdir: Path) -> FileInfo:
+    """Copy the 2D fixture into a fresh subdir and build a FileInfo."""
+    dst = workdir / FIXTURE_2D_PATH.name
+    shutil.copy(FIXTURE_2D_PATH, dst)
+    fi = FileInfo(str(dst))
+    fi.find_metadata()
+    fi.load_metadata()
+    return fi
+
+
+def _make_stage_stub(touch_keys: tuple[str, ...]):
+    """Build a stage stub class that touches the given pipeline_paths keys when run."""
+    class _StageStub:
+        def __init__(self, im_info, config=None, *args, **kwargs):
+            self.im_info = im_info
+
+        def run(self):
+            for key in touch_keys:
+                path = self.im_info.pipeline_paths[key]
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                if not os.path.exists(path):
+                    with open(path, 'wb') as f:
+                        f.write(b'x')
+    return _StageStub
+
+
+_STAGE_TO_OUTPUTS: dict[str, tuple[str, ...]] = {
+    'Filter': ('im_preprocessed',),
+    'Label': ('im_instance_label',),
+    'Network': ('im_skel', 'im_skel_relabelled', 'im_pixel_class'),
+    'Markers': ('im_marker', 'im_distance', 'im_border'),
+    'HuMomentTracking': ('flow_vector_array', 'voxel_matches'),
+    'VoxelReassigner': ('im_branch_label_reassigned', 'im_obj_label_reassigned'),
+    'Hierarchy': ('adjacency_maps',),
+}
+
+# Every droppable key in pipeline_paths that the stubs touch (excludes
+# the special ``im_path`` key, which is the canonical OME-TIFF and
+# always exists from FileInfo construction).
+_ALL_TOUCHED_KEYS: frozenset[str] = frozenset(
+    key for keys in _STAGE_TO_OUTPUTS.values() for key in keys
+)
+
+
+@pytest.fixture
+def stub_run_stages(monkeypatch):
+    """Replace heavy pipeline stages in ``nellie.run`` with cheap stubs.
+
+    Each stub touches the on-disk paths that the real stage would have
+    written. Cleanup logic in ``run()`` then has real files to delete.
+    """
+    for stage_name, outputs in _STAGE_TO_OUTPUTS.items():
+        monkeypatch.setattr(run_mod, stage_name, _make_stage_stub(outputs))
+    # Configs are passed as positional args to the stubs which ignore them.
+    for cfg_name in (
+        'FrangiConfig', 'LabelConfig', 'NetworkConfig', 'MarkersConfig',
+        'HuMomentTrackingConfig', 'VoxelReassignerConfig', 'HierarchyConfig',
+    ):
+        monkeypatch.setattr(run_mod, cfg_name, lambda *a, **kw: None)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_with_no_cleanup_drop_keys_leaves_all_intermediates(
+    stub_run_stages, tmp_path: Path,
+) -> None:
+    """Default ``cleanup_drop_keys=None`` → no files deleted."""
+    fi = _make_fresh_file_info(tmp_path)
+    info = run(fi)
+
+    for key in _ALL_TOUCHED_KEYS:
+        assert os.path.exists(info.pipeline_paths[key]), (
+            f"{key!r} should still exist (no cleanup configured)"
+        )
+    assert os.path.exists(info.im_path)
+
+
+def test_run_with_keep_everything_preset_is_noop(
+    stub_run_stages, tmp_path: Path,
+) -> None:
+    """Empty frozenset is a no-op (falsy → cleanup branch skipped)."""
+    fi = _make_fresh_file_info(tmp_path)
+    info = run(fi, cleanup_drop_keys=frozenset())
+
+    for key in _ALL_TOUCHED_KEYS:
+        assert os.path.exists(info.pipeline_paths[key])
+    assert os.path.exists(info.im_path)
+
+
+def test_run_with_csvs_only_preset_drops_all_droppable(
+    stub_run_stages, tmp_path: Path,
+) -> None:
+    """``CSVS_ONLY_PRESET`` deletes every droppable intermediate touched by the stubs.
+
+    CSV survival is pinned in the Slice 1 tests
+    (``test_remove_marked_intermediates_drops_only_marked_keys``); here
+    we only verify the wiring: passing ``CSVS_ONLY_PRESET`` to ``run()``
+    deletes the droppable intermediates AND the canonical OME-TIFF.
+    """
+    fi = _make_fresh_file_info(tmp_path)
+    info = run(fi, cleanup_drop_keys=CSVS_ONLY_PRESET)
+
+    for key in _ALL_TOUCHED_KEYS:
+        assert not os.path.exists(info.pipeline_paths[key]), (
+            f"{key!r} should have been deleted by CSVS_ONLY_PRESET"
+        )
+    assert not os.path.exists(info.im_path), (
+        "im_path should have been deleted by CSVS_ONLY_PRESET"
+    )
+
+
+def test_run_with_partial_drop_keys_drops_only_marked(
+    stub_run_stages, tmp_path: Path,
+) -> None:
+    """A subset drop set deletes only the marked file; others survive."""
+    fi = _make_fresh_file_info(tmp_path)
+    drop = frozenset({'im_preprocessed'})
+    info = run(fi, cleanup_drop_keys=drop)
+
+    assert not os.path.exists(info.pipeline_paths['im_preprocessed']), (
+        "im_preprocessed should have been deleted"
+    )
+    for key in (_ALL_TOUCHED_KEYS - drop):
+        assert os.path.exists(info.pipeline_paths[key]), (
+            f"{key!r} should still exist (not in drop set)"
+        )
+    assert os.path.exists(info.im_path)
+
+
+def test_run_propagates_stage_failure_without_cleanup(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Mid-pipeline failure → exception propagates, no cleanup runs.
+
+    Stub Filter to write its output (so we can detect whether cleanup
+    fired), then stub Label to raise. The failure must propagate and the
+    Filter output must survive (cleanup would have deleted it).
+    """
+    monkeypatch.setattr(run_mod, 'Filter', _make_stage_stub(('im_preprocessed',)))
+    monkeypatch.setattr(run_mod, 'FrangiConfig', lambda *a, **kw: None)
+
+    class _RaisingLabel:
+        def __init__(self, *a, **kw):
+            pass
+
+        def run(self):
+            raise RuntimeError("intentional mid-pipeline failure for test")
+
+    monkeypatch.setattr(run_mod, 'Label', _RaisingLabel)
+    monkeypatch.setattr(run_mod, 'LabelConfig', lambda *a, **kw: None)
+
+    fi = _make_fresh_file_info(tmp_path)
+    with pytest.raises(RuntimeError, match="intentional mid-pipeline failure"):
+        run(fi, cleanup_drop_keys=CSVS_ONLY_PRESET)
+
+    # Build an ImInfo to resolve pipeline_paths for the post-failure check.
+    from nellie.im_info.verifier import ImInfo
+    info = ImInfo.from_file_info(fi)
+    assert os.path.exists(info.pipeline_paths['im_preprocessed']), (
+        "im_preprocessed should survive — cleanup should NOT have run "
+        "after the Label failure"
+    )
+    assert os.path.exists(info.im_path), (
+        "im_path should survive — cleanup should NOT have run after failure"
+    )


### PR DESCRIPTION
## Summary

- Adds `cleanup_drop_keys: frozenset[str] | None = None` as the final kwarg on `nellie.run.run()`.
- After `Hierarchy.run()` succeeds, calls `im_info.remove_marked_intermediates(cleanup_drop_keys)` only when the set is non-empty. `None` and `frozenset()` are no-ops.
- No `try`/`except` around cleanup — mid-pipeline failures propagate and skip cleanup, matching the existing pipeline contract.
- 5 new tests in `tests/test_run_cleanup.py` use cheap stage stubs that touch the expected output files; tests run in <1s while exercising the full `run()` orchestrator end-to-end.

Closes #247. Foundation Slice 1 (#250) is merged.

## Test plan

- [x] `uv run pytest tests/test_run_cleanup.py tests/test_verifier_iminfo.py -q` — 73 passed (5 new in Slice 2 + 68 from Slice 1)
- [ ] Reviewer: spot-check `run.py` docstring + the two-line cleanup branch at end of `run()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)