### PR TITLE
napari/processor: thread cleanup_drop_keys from SettingsConfig to ImInfo (Slice 4 of #245)

### DIFF
--- a/nellie_napari/nellie_processor.py
+++ b/nellie_napari/nellie_processor.py
@@ -552,7 +552,7 @@ class NellieProcessor(QWidget):
         self,
         im_info_list,
         config: HierarchyConfig,
-        remove_intermediates_checked: bool,
+        cleanup_drop_keys: frozenset[str],
     ):
         """
         Run the feature extraction step in a separate thread. Extracts various features from the processed image data for analysis.
@@ -563,8 +563,9 @@ class NellieProcessor(QWidget):
             List of ImInfo objects.
         config : HierarchyConfig
             Algorithm configuration for the Hierarchy stage.
-        remove_intermediates_checked : bool
-            Whether to remove intermediate files after each Hierarchy run.
+        cleanup_drop_keys : frozenset[str]
+            ``pipeline_paths`` keys to delete after each per-file
+            ``Hierarchy.run()`` succeeds. Empty frozenset = no cleanup.
         """
         for im_num, im_info in enumerate(im_info_list):
             self.current_im_info = im_info
@@ -578,9 +579,11 @@ class NellieProcessor(QWidget):
                 f"on {stage.device_type.upper()}"
             )
             stage.run()
-            if remove_intermediates_checked:
+            if cleanup_drop_keys:
                 try:
-                    self.current_im_info.remove_intermediates()
+                    self.current_im_info.remove_marked_intermediates(
+                        drop_keys=cleanup_drop_keys
+                    )
                 except Exception as e:
                     show_info(f"Error removing intermediates: {e}")
 
@@ -601,13 +604,17 @@ class NellieProcessor(QWidget):
         Start the feature extraction step and updates the UI to reflect that feature extraction is running.
         """
         self.status = "feature export"
-        remove_intermediates_checked = self.nellie.settings.remove_intermediates_checkbox.isChecked()
         settings = self._get_settings()
-        config = settings.get_feature_params() if settings else HierarchyConfig()
+        if settings is not None:
+            config = settings.get_feature_params()
+            cleanup_drop_keys = settings.to_config().cleanup_drop_keys
+        else:
+            config = HierarchyConfig()
+            cleanup_drop_keys = frozenset()
         worker = self._run_feature_export(
             self.im_info_list,
             config,
-            remove_intermediates_checked,
+            cleanup_drop_keys,
         )
         # This is the last step in the pipeline; always treat as final.
         self._start_worker(worker, final=True)


### PR DESCRIPTION
## Summary

- `nellie_processor.run_feature_export()` reads `cleanup_drop_keys` from `SettingsConfig` (delivered by Slice 3 / #252) instead of the now-removed `remove_intermediates_checkbox`.
- `_run_feature_export()` worker takes `cleanup_drop_keys: frozenset[str]` and calls `ImInfo.remove_marked_intermediates(drop_keys=...)` only when non-empty. Behaviorally identical to the legacy "checkbox unchecked = no cleanup" path when the default "Keep everything" preset is selected.
- Cleanup still fires after Hierarchy regardless of how Hierarchy was invoked (full pipeline chain via `run_nellie()` or solo button click), per PRD #245 User Story 8.

Closes #249. Completes the slice chain for #245. Builds on #246 (Slice 1) + #252 (Slice 3).

## Test plan

- [x] `uv run pytest -q --ignore=tests/test_*_perf.py` — 715 passed, 0 regressions
- [ ] Reviewer: open the napari plugin → select "CSVs only" preset → run full pipeline → verify droppable intermediates are gone after Hierarchy completes
- [ ] Reviewer: run "Run Feature Export" solo button with "CSVs only" → verify cleanup still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)