### PR TITLE
docs(frangi_math): correct frangi() polarity docstring — bright vessels on dark

### DIFF
--- a/nellie/segmentation/frangi_math.py
+++ b/nellie/segmentation/frangi_math.py
@@ -37,8 +37,14 @@ def frangi(
     -------
     response : (N,) float array, NaN/Inf-scrubbed.
 
-    Bright structures (positive λ₂, and positive λ₃ in 3D) are zeroed —
-    Frangi assumes vessels are darker than background.
+    Dark structures (positive λ₂, and positive λ₃ in 3D) are zeroed —
+    this implementation is tuned for **bright vessels on a dark
+    background** (λ₂ ≤ 0, and λ₃ ≤ 0 in 3D). The second derivative
+    perpendicular to a bright tubular structure is negative (image
+    curves downward outward from the bright center), so the Hessian
+    eigenvalues across the vessel are non-positive; positive λ₂/λ₃
+    correspond to dark structures on a bright background and are
+    rejected.
     """
     ndim = eigenvalues.shape[1]
     if ndim == 2:


### PR DESCRIPTION
## Summary

Docstring-only fix. The `frangi()` function in `nellie/segmentation/frangi_math.py` had the eigenvalue polarity reversed on both halves of its returns block:

- Claimed positive λ₂/λ₃ → "bright structures" (actually → dark structures)
- Claimed Frangi "assumes vessels are darker than background" (actually tuned for bright-on-dark — matches nellie's fluorescence-microscopy use case)

Code is correct. Only the docstring text changed; one-line reasoning added so a future reader doesn't have to re-derive the second-derivative convention.

## Test plan

- [x] No code changes — existing tests still pass.
- [ ] Reviewer: spot-check the corrected wording against the code at lines 70–71 (zeros where eigenvalues > 0, keeps where ≤ 0 → bright-on-dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)